### PR TITLE
22 — Source Cache（Git-only）與 Source Drift

### DIFF
--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -1,0 +1,2 @@
+export * from './paths.js';
+export * from './source-cache.js';

--- a/src/cache/paths.ts
+++ b/src/cache/paths.ts
@@ -1,0 +1,42 @@
+/**
+ * Source Cache path helpers (#22).
+ * The Git-only Source Cache lives at `${getAgentDir()}/codex-marketplace/cache`.
+ *
+ * Layout:
+ *   cache/
+ *     entries/<fingerprint>/        — fingerprint-addressed acquired source trees
+ *     entries/<fingerprint>.meta    — { fingerprint, bytes, lastAccessMs, recordedAtMs }
+ *     index.json                    — (canonicalLocator ⊕ selector) → last validated fingerprint
+ *     pending-updates.json          — fingerprints of produced-but-unapplied Update Candidates
+ *     locks/<fingerprint>.lock      — per-fingerprint mutual exclusion
+ */
+
+import { join } from 'node:path';
+
+import { getGlobalStateDir } from '../bridge-state/paths.js';
+
+export const CACHE_ENTRIES_DIR = 'entries';
+export const CACHE_INDEX_FILENAME = 'index.json';
+export const CACHE_PENDING_FILENAME = 'pending-updates.json';
+export const CACHE_LOCKS_DIR = 'locks';
+export const CACHE_META_SUFFIX = '.meta';
+
+export function getCacheDir(agentDir?: string): string {
+  return join(getGlobalStateDir(agentDir), 'cache');
+}
+
+export function getCacheEntriesDir(cacheDir: string): string {
+  return join(cacheDir, CACHE_ENTRIES_DIR);
+}
+
+export function getCacheIndexPath(cacheDir: string): string {
+  return join(cacheDir, CACHE_INDEX_FILENAME);
+}
+
+export function getCachePendingPath(cacheDir: string): string {
+  return join(cacheDir, CACHE_PENDING_FILENAME);
+}
+
+export function getCacheLocksDir(cacheDir: string): string {
+  return join(cacheDir, CACHE_LOCKS_DIR);
+}

--- a/src/cache/source-cache.ts
+++ b/src/cache/source-cache.ts
@@ -27,7 +27,7 @@ import {
 import { cpSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { acquireLock, releaseLock } from '../bridge-state/atomic.js';
+import { acquireLock, releaseLock, atomicWriteFile } from '../bridge-state/atomic.js';
 import { readBridgeState } from '../bridge-state/store.js';
 import type { BridgeState } from '../bridge-state/types.js';
 import type { Scope } from '../bridge-state/types.js';
@@ -166,17 +166,11 @@ export class SourceCache {
         // Copy to a temp name first so readers never observe a partial tree.
         const tmp = `${dest}.tmp-${process.pid}-${Math.random().toString(36).slice(2)}`;
         cpSync(root, tmp, { recursive: true, verbatimSymlinks: true });
+        // Replace any pre-existing (possibly tampered) entry wholesale so a stored
+        // fingerprint always hashes true.
         rmSync(dest, { recursive: true, force: true });
-        existsSync(tmp) && renameOrCopy(tmp, dest);
-        writeFileSync(
-          this.metaPath(fingerprint),
-          JSON.stringify({
-            fingerprint,
-            bytes,
-            lastAccessMs: this.now(),
-            recordedAtMs: this.now(),
-          } satisfies CacheEntryMeta),
-        );
+        copyTree(tmp, dest);
+        this.writeMeta(fingerprint, bytes);
         await this.prune();
         return { stored: true, path: dest };
       });
@@ -202,7 +196,8 @@ export class SourceCache {
     if (!existsSync(entriesDir)) return;
     let total = 0;
     for (const name of readdirSync(entriesDir)) {
-      if (name.endsWith('.tmp-') || name.includes('.tmp-')) continue;
+      // Skip in-progress temp copies.
+      if (name.includes('.tmp-')) continue;
       const meta = this.readMeta(name);
       if (!meta || !isSafeFingerprint(name)) continue;
       total += meta.bytes;
@@ -240,12 +235,12 @@ export class SourceCache {
   recordPendingUpdate(rec: Omit<PendingUpdateRecord, 'recordedAtMs'>): void {
     const records = this.pendingUpdates().filter((r) => !(r.scope === rec.scope && r.registrationId === rec.registrationId));
     records.push({ ...rec, recordedAtMs: this.now() });
-    writeFileSync(getCachePendingPath(this.root), JSON.stringify(records));
+    atomicWriteFile(getCachePendingPath(this.root), JSON.stringify(records));
   }
 
   clearPendingUpdate(scope: Scope, registrationId: string): void {
     const records = this.pendingUpdates().filter((r) => !(r.scope === scope && r.registrationId === registrationId));
-    writeFileSync(getCachePendingPath(this.root), JSON.stringify(records));
+    atomicWriteFile(getCachePendingPath(this.root), JSON.stringify(records));
   }
 
   pendingUpdates(): PendingUpdateRecord[] {
@@ -263,8 +258,8 @@ export class SourceCache {
 
   recordIndex(rec: Omit<CacheIndexRecord, 'recordedAtMs'>): void {
     const index = this.readIndex();
-    index[`${rec.canonicalLocator}\u001f${rec.selectorCanonical}`] = { ...rec, recordedAtMs: this.now() };
-    writeFileSync(getCacheIndexPath(this.root), JSON.stringify(index));
+    index[indexKey(rec.canonicalLocator, rec.selectorCanonical)] = { ...rec, recordedAtMs: this.now() };
+    atomicWriteFile(getCacheIndexPath(this.root), JSON.stringify(index));
   }
 
   readIndex(): Record<string, CacheIndexRecord> {
@@ -284,13 +279,22 @@ export class SourceCache {
    * entry is present in the cache. Callers must still verify by re-hashing the tree; any
    * mismatch is a Blocking Finding and never success.
    */
-  offlineHit(canonicalLocator: string, selectorCanonical: string, expectedFingerprint: string): CacheHit | null {
+  /**
+   * Offline reuse seam: only an exact fingerprint hit counts. Returns the cached tree only when
+   * the index records exactly `expectedFingerprint` for this locator+selector AND that exact
+   * entry is present in the cache. The hit refreshes LRU recency. Callers must still verify by
+   * re-hashing the tree; any mismatch is a Blocking Finding and never success.
+   */
+  async offlineHit(canonicalLocator: string, selectorCanonical: string, expectedFingerprint: string): Promise<CacheHit | null> {
     if (!expectedFingerprint) return null;
-    const rec = this.readIndex()[`${canonicalLocator}\u001f${selectorCanonical}`];
+    const rec = this.readIndex()[indexKey(canonicalLocator, selectorCanonical)];
     if (!rec || rec.fingerprint !== expectedFingerprint) return null;
     const dir = this.entryPath(expectedFingerprint);
     const meta = this.readMeta(expectedFingerprint);
     if (!existsSync(dir) || !meta || meta.fingerprint !== expectedFingerprint) return null;
+    await this.withFingerprintLock(expectedFingerprint, () => {
+      this.touchMeta(expectedFingerprint);
+    });
     return { path: dir, fingerprint: expectedFingerprint };
   }
 
@@ -314,18 +318,30 @@ export class SourceCache {
     const meta = this.readMeta(fingerprint);
     if (!meta) return;
     meta.lastAccessMs = this.now();
-    writeFileSync(this.metaPath(fingerprint), JSON.stringify(meta));
+    this.writeMeta(fingerprint, meta.bytes, meta.recordedAtMs);
+  }
+
+  private writeMeta(fingerprint: string, bytes: number, recordedAtMs?: number): void {
+    const at = this.now();
+    atomicWriteFile(
+      this.metaPath(fingerprint),
+      JSON.stringify({ fingerprint, bytes, lastAccessMs: at, recordedAtMs: recordedAtMs ?? at } satisfies CacheEntryMeta),
+    );
   }
 }
 
-function renameOrCopy(from: string, to: string): void {
+/** Canonical index key for a locator+selector pair. */
+function indexKey(canonicalLocator: string, selectorCanonical: string): string {
+  return `${canonicalLocator}\u001f${selectorCanonical}`;
+}
+
+/** Move a fully-written temp copy into place; a vanished source is a no-op. */
+function copyTree(from: string, to: string): void {
   try {
     statSync(from);
     cpSync(from, to, { recursive: true, verbatimSymlinks: true });
     rmSync(from, { recursive: true, force: true });
-  } catch {
-    // source vanished concurrently — treat as no-op; caller re-checks existence
-  }
+  } catch {}
 }
 
 function collectPinned(state: BridgeState | undefined, pinned: Set<string>): void {

--- a/src/cache/source-cache.ts
+++ b/src/cache/source-cache.ts
@@ -276,12 +276,6 @@ export class SourceCache {
   /**
    * Offline reuse seam: only an exact fingerprint hit counts. Returns the cached tree only when
    * the index records exactly `expectedFingerprint` for this locator+selector AND that exact
-   * entry is present in the cache. Callers must still verify by re-hashing the tree; any
-   * mismatch is a Blocking Finding and never success.
-   */
-  /**
-   * Offline reuse seam: only an exact fingerprint hit counts. Returns the cached tree only when
-   * the index records exactly `expectedFingerprint` for this locator+selector AND that exact
    * entry is present in the cache. The hit refreshes LRU recency. Callers must still verify by
    * re-hashing the tree; any mismatch is a Blocking Finding and never success.
    */

--- a/src/cache/source-cache.ts
+++ b/src/cache/source-cache.ts
@@ -1,0 +1,355 @@
+/**
+ * Source Cache — Git-only, fingerprint-addressed acquisition cache (#22).
+ * See CONTEXT.md: Source Acquisition, Validation Snapshot, Stale Snapshot.
+ *
+ * Guarantees:
+ * - Entries are addressed by Validation Snapshot fingerprint under
+ *   `${getAgentDir()}/codex-marketplace/cache/entries/<fingerprint>`.
+ * - Pinned set = Bridge State referenced fingerprints (registrations + installations)
+ *   + pending Update Candidate fingerprints + in-flight pins. Pinned entries are never evicted.
+ * - Total budget (default 2 GiB) applies LRU eviction over unpinned entries only,
+ *   synchronously during store/prune. No background tasks, no TTL.
+ * - Every entry mutation happens under a per-fingerprint lock (mutual exclusion).
+ * - Offline reuse is allowed only on an exact fingerprint hit; a Stale Snapshot is never
+ *   converted into success — verification is the caller's re-hashed snapshot comparison,
+ *   and a mismatch is a Blocking Finding (Source Drift / Stale Snapshot), never reuse.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { cpSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { acquireLock, releaseLock } from '../bridge-state/atomic.js';
+import { readBridgeState } from '../bridge-state/store.js';
+import type { BridgeState } from '../bridge-state/types.js';
+import type { Scope } from '../bridge-state/types.js';
+import {
+  getCacheDir,
+  getCacheEntriesDir,
+  getCacheIndexPath,
+  getCacheLocksDir,
+  getCachePendingPath,
+} from './paths.js';
+
+/** Total cache budget: 2 GiB across all entries (unpinned only are evictable). */
+export const CACHE_TOTAL_BUDGET_BYTES = 2 * 1024 * 1024 * 1024;
+
+export interface CacheEntryMeta {
+  fingerprint: string;
+  bytes: number;
+  lastAccessMs: number;
+  recordedAtMs: number;
+}
+
+export interface CacheIndexRecord {
+  /** Last validated Validation Snapshot fingerprint for this locator+selector pair. */
+  fingerprint: string;
+  resolvedRevision: string;
+  canonicalLocator: string;
+  selectorCanonical: string;
+  recordedAtMs: number;
+}
+
+export interface PendingUpdateRecord {
+  scope: Scope;
+  registrationId: string;
+  fingerprint: string;
+  recordedAtMs: number;
+}
+
+export interface SourceCacheOptions {
+  /** Pi agent dir; defaults to getAgentDir(). */
+  agentDir?: string;
+  /** Explicit cache root override (test seam). */
+  root?: string;
+  /** Budget override for tests. */
+  budgetBytes?: number;
+  /** Injectable clock for deterministic lastAccess ordering in tests. */
+  clock?: () => number;
+}
+
+export interface CacheHit {
+  path: string;
+  fingerprint: string;
+}
+
+function isSafeFingerprint(fp: string): boolean {
+  return /^[0-9a-f]{64}$/.test(fp);
+}
+
+export class SourceCache {
+  readonly root: string;
+  private readonly budgetBytes: number;
+  private readonly now: () => number;
+  private readonly inFlight = new Map<string, number>();
+
+  constructor(opts: SourceCacheOptions = {}) {
+    this.root = opts.root ?? getCacheDir(opts.agentDir);
+    this.budgetBytes = opts.budgetBytes ?? CACHE_TOTAL_BUDGET_BYTES;
+    this.now = opts.clock ?? Date.now;
+  }
+
+  entryPath(fingerprint: string): string {
+    return join(getCacheEntriesDir(this.root), fingerprint);
+  }
+
+  metaPath(fingerprint: string): string {
+    return `${this.entryPath(fingerprint)}.meta`;
+  }
+
+  lockPath(fingerprint: string): string {
+    return join(getCacheLocksDir(this.root), `${fingerprint}.lock`);
+  }
+
+  /**
+   * Per-fingerprint mutual exclusion around store/prune/touch for that entry.
+   * Concurrent operations on the same fingerprint serialize here.
+   */
+  async withFingerprintLock<T>(fingerprint: string, fn: () => Promise<T> | T, timeoutMs = 5000): Promise<T> {
+    const lockPath = this.lockPath(fingerprint);
+    const fd = await acquireLock(lockPath, timeoutMs);
+    try {
+      return await fn();
+    } finally {
+      releaseLock(fd, lockPath);
+    }
+  }
+
+  /** Register an in-flight pin (reference-counted); returns its release function. In-flight entries are never evicted. */
+  pinInFlight(fingerprint: string): () => void {
+    this.inFlight.set(fingerprint, (this.inFlight.get(fingerprint) ?? 0) + 1);
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      const n = (this.inFlight.get(fingerprint) ?? 1) - 1;
+      if (n <= 0) this.inFlight.delete(fingerprint);
+      else this.inFlight.set(fingerprint, n);
+    };
+  }
+
+  /** Exact fingerprint hit: entry directory + matching meta must exist. Touches lastAccess. */
+  async hitExact(fingerprint: string): Promise<CacheHit | null> {
+    if (!isSafeFingerprint(fingerprint)) return null;
+    const dir = this.entryPath(fingerprint);
+    const meta = this.readMeta(fingerprint);
+    if (!existsSync(dir) || !meta || meta.fingerprint !== fingerprint) return null;
+    await this.withFingerprintLock(fingerprint, () => {
+      this.touchMeta(fingerprint);
+    });
+    return { path: dir, fingerprint };
+  }
+
+  /**
+   * Store an acquired source tree under its fingerprint. The stored fingerprint is pinned
+   * for the duration of the store ("in flight"), so its own prune can never evict it.
+   */
+  async storeTree(root: string, fingerprint: string): Promise<{ stored: boolean; path: string }> {
+    const releasePin = this.pinInFlight(fingerprint);
+    try {
+      return await this.withFingerprintLock(fingerprint, async () => {
+        mkdirSync(getCacheEntriesDir(this.root), { recursive: true });
+        const dest = this.entryPath(fingerprint);
+        if (existsSync(dest)) {
+          this.touchMeta(fingerprint);
+          return { stored: false, path: dest };
+        }
+        const bytes = treeBytes(root);
+        // Copy to a temp name first so readers never observe a partial tree.
+        const tmp = `${dest}.tmp-${process.pid}-${Math.random().toString(36).slice(2)}`;
+        cpSync(root, tmp, { recursive: true, verbatimSymlinks: true });
+        rmSync(dest, { recursive: true, force: true });
+        existsSync(tmp) && renameOrCopy(tmp, dest);
+        writeFileSync(
+          this.metaPath(fingerprint),
+          JSON.stringify({
+            fingerprint,
+            bytes,
+            lastAccessMs: this.now(),
+            recordedAtMs: this.now(),
+          } satisfies CacheEntryMeta),
+        );
+        await this.prune();
+        return { stored: true, path: dest };
+      });
+    } finally {
+      releasePin();
+    }
+  }
+
+  /**
+   * Synchronous LRU prune over unpinned entries only. Pinned set =
+   * Bridge State references + pending Update Candidates + in-flight pins + extraPinned.
+   * No background tasks; called inline after stores.
+   */
+  async prune(extraPinned: Iterable<string> = []): Promise<void> {
+    const pinned = new Set<string>(extraPinned);
+    for (const fp of this.inFlight.keys()) pinned.add(fp);
+    for (const rec of this.pendingUpdates()) pinned.add(rec.fingerprint);
+    for (const fp of await this.statePinnedFingerprints()) pinned.add(fp);
+
+    type Cand = { fingerprint: string; bytes: number; lastAccessMs: number };
+    const cands: Cand[] = [];
+    const entriesDir = getCacheEntriesDir(this.root);
+    if (!existsSync(entriesDir)) return;
+    let total = 0;
+    for (const name of readdirSync(entriesDir)) {
+      if (name.endsWith('.tmp-') || name.includes('.tmp-')) continue;
+      const meta = this.readMeta(name);
+      if (!meta || !isSafeFingerprint(name)) continue;
+      total += meta.bytes;
+      if (!pinned.has(name)) cands.push({ fingerprint: name, bytes: meta.bytes, lastAccessMs: meta.lastAccessMs });
+    }
+    // LRU over unpinned only, ascending lastAccess.
+    cands.sort((a, b) => a.lastAccessMs - b.lastAccessMs);
+    for (const cand of cands) {
+      if (total <= this.budgetBytes) break;
+      rmSync(this.entryPath(cand.fingerprint), { recursive: true, force: true });
+      rmSync(this.metaPath(cand.fingerprint), { force: true });
+      total -= cand.bytes;
+    }
+  }
+
+  /** Fingerprints referenced by authoritative Bridge State (both scopes). Never evicted. */
+  async statePinnedFingerprints(): Promise<Set<string>> {
+    const pinned = new Set<string>();
+    for (const scope of ['global', 'project'] as const) {
+      const read = await readBridgeState(scope, {});
+      collectPinned(read.state, pinned);
+    }
+    return pinned;
+  }
+
+  /** Collect pinned fingerprints from already-read state documents (test seam, no I/O). */
+  static pinnedFromStates(states: (BridgeState | undefined)[]): Set<string> {
+    const pinned = new Set<string>();
+    for (const s of states) collectPinned(s, pinned);
+    return pinned;
+  }
+
+  // ---- Pending Update Candidate registry ---------------------------------
+
+  recordPendingUpdate(rec: Omit<PendingUpdateRecord, 'recordedAtMs'>): void {
+    const records = this.pendingUpdates().filter((r) => !(r.scope === rec.scope && r.registrationId === rec.registrationId));
+    records.push({ ...rec, recordedAtMs: this.now() });
+    writeFileSync(getCachePendingPath(this.root), JSON.stringify(records));
+  }
+
+  clearPendingUpdate(scope: Scope, registrationId: string): void {
+    const records = this.pendingUpdates().filter((r) => !(r.scope === scope && r.registrationId === registrationId));
+    writeFileSync(getCachePendingPath(this.root), JSON.stringify(records));
+  }
+
+  pendingUpdates(): PendingUpdateRecord[] {
+    const p = getCachePendingPath(this.root);
+    if (!existsSync(p)) return [];
+    try {
+      const parsed: unknown = JSON.parse(readFileSync(p, 'utf-8'));
+      return Array.isArray(parsed) ? (parsed as PendingUpdateRecord[]) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  // ---- Locator+selector → fingerprint index ------------------------------
+
+  recordIndex(rec: Omit<CacheIndexRecord, 'recordedAtMs'>): void {
+    const index = this.readIndex();
+    index[`${rec.canonicalLocator}\u001f${rec.selectorCanonical}`] = { ...rec, recordedAtMs: this.now() };
+    writeFileSync(getCacheIndexPath(this.root), JSON.stringify(index));
+  }
+
+  readIndex(): Record<string, CacheIndexRecord> {
+    const p = getCacheIndexPath(this.root);
+    if (!existsSync(p)) return {};
+    try {
+      const parsed: unknown = JSON.parse(readFileSync(p, 'utf-8'));
+      return parsed && typeof parsed === 'object' ? (parsed as Record<string, CacheIndexRecord>) : {};
+    } catch {
+      return {};
+    }
+  }
+
+  /**
+   * Offline reuse seam: only an exact fingerprint hit counts. Returns the cached tree only when
+   * the index records exactly `expectedFingerprint` for this locator+selector AND that exact
+   * entry is present in the cache. Callers must still verify by re-hashing the tree; any
+   * mismatch is a Blocking Finding and never success.
+   */
+  offlineHit(canonicalLocator: string, selectorCanonical: string, expectedFingerprint: string): CacheHit | null {
+    if (!expectedFingerprint) return null;
+    const rec = this.readIndex()[`${canonicalLocator}\u001f${selectorCanonical}`];
+    if (!rec || rec.fingerprint !== expectedFingerprint) return null;
+    const dir = this.entryPath(expectedFingerprint);
+    const meta = this.readMeta(expectedFingerprint);
+    if (!existsSync(dir) || !meta || meta.fingerprint !== expectedFingerprint) return null;
+    return { path: dir, fingerprint: expectedFingerprint };
+  }
+
+  // ---- internals ----------------------------------------------------------
+
+  private readMeta(fingerprint: string): CacheEntryMeta | null {
+    const p = this.metaPath(fingerprint);
+    if (!existsSync(p)) return null;
+    try {
+      const parsed: unknown = JSON.parse(readFileSync(p, 'utf-8'));
+      if (parsed && typeof parsed === 'object' && typeof (parsed as CacheEntryMeta).fingerprint === 'string') {
+        return parsed as CacheEntryMeta;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  private touchMeta(fingerprint: string): void {
+    const meta = this.readMeta(fingerprint);
+    if (!meta) return;
+    meta.lastAccessMs = this.now();
+    writeFileSync(this.metaPath(fingerprint), JSON.stringify(meta));
+  }
+}
+
+function renameOrCopy(from: string, to: string): void {
+  try {
+    statSync(from);
+    cpSync(from, to, { recursive: true, verbatimSymlinks: true });
+    rmSync(from, { recursive: true, force: true });
+  } catch {
+    // source vanished concurrently — treat as no-op; caller re-checks existence
+  }
+}
+
+function collectPinned(state: BridgeState | undefined, pinned: Set<string>): void {
+  if (!state) return;
+  for (const r of state.registrations ?? []) if (r.validationSnapshot) pinned.add(r.validationSnapshot);
+  for (const i of state.installations ?? []) if (i.validationSnapshot) pinned.add(i.validationSnapshot);
+}
+
+/** Recursive byte size of a tree (files only). */
+export function treeBytes(root: string): number {
+  let total = 0;
+  const walk = (dir: string): void => {
+    let stats;
+    try {
+      stats = statSync(dir);
+    } catch {
+      return;
+    }
+    if (!stats.isDirectory()) {
+      total += stats.size;
+      return;
+    }
+    for (const name of readdirSync(dir)) walk(join(dir, name));
+  };
+  walk(root);
+  return total;
+}

--- a/src/lifecycle/refresh.ts
+++ b/src/lifecycle/refresh.ts
@@ -273,7 +273,7 @@ async function refreshGitRegistration(
     // tree is re-hashed and must equal the recorded Validation Snapshot exactly — any mismatch
     // is Source Drift (Blocking Finding); a Stale Snapshot is never converted into success.
     const offline = registration.validationSnapshot
-      ? cache.offlineHit(locator.canonicalUrl, selector.canonical, registration.validationSnapshot)
+      ? await cache.offlineHit(locator.canonicalUrl, selector.canonical, registration.validationSnapshot)
       : null;
     if (offline) {
       const verified = buildGitSnapshot(offline.path, sourceKeyAt(registration, registration.resolvedRevision!), scope, {

--- a/src/lifecycle/refresh.ts
+++ b/src/lifecycle/refresh.ts
@@ -10,6 +10,7 @@
  */
 
 import { readBridgeState } from '../bridge-state/store.js';
+import type { BridgeState } from '../bridge-state/types.js';
 import type { Registration, Scope } from '../bridge-state/types.js';
 import type { MarketplaceInspection } from '../installation/inspection.js';
 import { inspectMarketplaceEntries } from '../installation/inspection.js';
@@ -24,8 +25,10 @@ import {
 import {
   acquireGitSource,
   cleanupAcquisition,
+  resolveGitRevision,
   type GitExecutor,
 } from '../registration/git-acquisition.js';
+import { SourceCache } from '../cache/source-cache.js';
 import { normalizeGitLocator } from '../registration/git-locator.js';
 import {
   normalizeGitSelector,
@@ -47,6 +50,8 @@ export interface LifecycleFlowOptions {
   fenceTimeoutMs?: number;
   /** Injected git executor for tests. */
   executor?: GitExecutor;
+  /** Injected Source Cache (defaults to a cache under the given agentDir). */
+  cache?: SourceCache;
 }
 
 /**
@@ -223,6 +228,11 @@ function refreshLocalRegistration(
   };
 }
 
+/** Reconstruct the full Source Key for a Registration at an exact Resolved Revision. */
+function sourceKeyAt(registration: Registration, resolvedRevision: string): SourceKey {
+  return { ...registration.sourceKey!, resolvedRevision };
+}
+
 async function refreshGitRegistration(
   scope: Scope,
   registration: Registration,
@@ -239,13 +249,71 @@ async function refreshGitRegistration(
   if (!locRes.ok) return blocked(scope, registration.id, revision, locRes.findings, registration.validationSnapshot);
   const selRes = normalizeGitSelector(selectorInputFromStored(registration.gitSelector), scope);
   if (!selRes.ok) return blocked(scope, registration.id, revision, selRes.findings, registration.validationSnapshot);
+  const locator = locRes.locator!;
+  const selector = selRes.selector!;
+  const cache = opts.cache ?? new SourceCache({ agentDir: opts.agentDir });
 
-  // Re-resolve the selector through non-executing acquisition. A full-commit selector resolves
-  // to its immutable object, so ref movement alone never reaches this path's candidate branch.
+  const noChangeReceipt = () =>
+    createReceipt({
+      operation: OPERATION,
+      scope,
+      trigger: `refresh ${registration.id}`,
+      expectedStateRevision: revision,
+      validationSnapshot: registration.validationSnapshot,
+      summary: 'Completed',
+      findings: [],
+      stateChanged: false,
+    });
+
+  // Cheap resolution first — a hit path never needs a clone.
+  const resolution = await resolveGitRevision(locator, selector, scope, { executor: opts.executor });
+
+  if (!resolution.ok) {
+    // Offline / unreachable remote: only an exact fingerprint hit may be reused. The cached
+    // tree is re-hashed and must equal the recorded Validation Snapshot exactly — any mismatch
+    // is Source Drift (Blocking Finding); a Stale Snapshot is never converted into success.
+    const offline = registration.validationSnapshot
+      ? cache.offlineHit(locator.canonicalUrl, selector.canonical, registration.validationSnapshot)
+      : null;
+    if (offline) {
+      const verified = buildGitSnapshot(offline.path, sourceKeyAt(registration, registration.resolvedRevision!), scope, {
+        canonicalLocator: locator.canonicalUrl,
+        resolvedRevision: registration.resolvedRevision!,
+        selectorCanonical: selector.canonical,
+      });
+      if (verified.ok && verified.snapshot!.fingerprint === registration.validationSnapshot) {
+        return { status: 'no-change', receipt: noChangeReceipt() };
+      }
+      return blocked(scope, registration.id, revision, [
+        finding(scope, CODE.SOURCE_DRIFT, RULE.SOURCE_DRIFT, 'registration', '', `Source Drift: cached tree at fingerprint ${String(registration.validationSnapshot).slice(0, 16)}… no longer hashes to the recorded Validation Snapshot; Marketplace Refresh against a reachable source is required`),
+      ], registration.validationSnapshot);
+    }
+    return blocked(scope, registration.id, revision, resolution.findings, registration.validationSnapshot);
+  }
+
+  const resolvedRevision = resolution.sha;
+
+  if (resolvedRevision === registration.resolvedRevision && registration.validationSnapshot) {
+    // Same Resolved Revision: exact-fingerprint cache hit avoids a full acquisition.
+    const hit = await cache.hitExact(registration.validationSnapshot);
+    if (hit) {
+      const verified = buildGitSnapshot(hit.path, sourceKeyAt(registration, resolvedRevision), scope, {
+        canonicalLocator: locator.canonicalUrl,
+        resolvedRevision,
+        selectorCanonical: selector.canonical,
+      });
+      if (verified.ok && verified.snapshot!.fingerprint === registration.validationSnapshot) {
+        return { status: 'no-change', receipt: noChangeReceipt() };
+      }
+      // Tampered/evicted-in-place entry: fall through to full acquisition below.
+    }
+  }
+
+  // Full non-executing acquisition (clone).
   const acq = await acquireGitSource({
     scope,
-    locator: locRes.locator!,
-    selector: selRes.selector!,
+    locator,
+    selector,
     executor: opts.executor,
   });
   if (!acq.ok) return blocked(scope, registration.id, revision, acq.findings, registration.validationSnapshot);
@@ -254,6 +322,16 @@ async function refreshGitRegistration(
     const resolvedRevision = acq.resolvedRevision!;
     const root = acq.acquiredPath!;
     if (resolvedRevision === registration.resolvedRevision) {
+      // Cache the re-validated tree under its recorded fingerprint for future exact hits.
+      if (registration.validationSnapshot) {
+        await cache.storeTree(root, registration.validationSnapshot);
+        cache.recordIndex({
+          fingerprint: registration.validationSnapshot,
+          resolvedRevision,
+          canonicalLocator: locator.canonicalUrl,
+          selectorCanonical: selector.canonical,
+        });
+      }
       return {
         status: 'no-change',
         receipt: createReceipt({
@@ -271,9 +349,9 @@ async function refreshGitRegistration(
     // Resolved Revision changed ⇒ new validation is mandatory before any confirmation.
     const newSourceKey: SourceKey = { ...registration.sourceKey, resolvedRevision };
     const snap = buildGitSnapshot(root, newSourceKey, scope, {
-      canonicalLocator: locRes.locator!.canonicalUrl,
+      canonicalLocator: locator.canonicalUrl,
       resolvedRevision,
-      selectorCanonical: selRes.selector!.canonical,
+      selectorCanonical: selector.canonical,
     });
     if (!snap.ok || !snap.snapshot) {
       return blocked(scope, registration.id, revision, snap.findings, registration.validationSnapshot);
@@ -295,10 +373,20 @@ async function refreshGitRegistration(
       catalog: { name, entries: inspection.entries.map((item) => item.entry) },
       inspection,
       sourceKey: newSourceKey,
-      canonicalLocator: locRes.locator!.canonicalUrl,
+      canonicalLocator: locator.canonicalUrl,
       resolvedRevision,
-      selectorCanonical: selRes.selector!.canonical,
+      selectorCanonical: selector.canonical,
     };
+    // Persist the candidate tree in the cache and pin its fingerprint as a pending Update
+    // Candidate — pinned entries are never evicted by LRU pruning.
+    await cache.storeTree(root, snap.snapshot!.fingerprint);
+    cache.recordIndex({
+      fingerprint: snap.snapshot!.fingerprint,
+      resolvedRevision,
+      canonicalLocator: locator.canonicalUrl,
+      selectorCanonical: selector.canonical,
+    });
+    cache.recordPendingUpdate({ scope, registrationId: registration.id, fingerprint: snap.snapshot!.fingerprint });
     return {
       status: 'update-candidate',
       candidate,

--- a/src/lifecycle/removal.ts
+++ b/src/lifecycle/removal.ts
@@ -438,12 +438,8 @@ export async function confirmInstallationRemoval(
   if (!write.success) return persistenceFailure(OPERATION, preflight.scope, trigger, preflight.stateRevision, write);
 
   const newRevision = write.newRevision!;
-  // Installation Removal does not invalidate a pending Update Candidate (the Registration and
-  // its candidate remain); the pin stays aligned with surviving records (#22).
-  if (preflight.registrationId) {
-    const cache = opts.cache ?? new SourceCache({ agentDir: opts.agentDir });
-    cache.clearPendingUpdate(preflight.scope, preflight.registrationId);
-  }
+  // Installation Removal does not invalidate the pending Update Candidate: the Registration and
+  // its candidate survive, so the pin must remain (fail-closed, #22).
   return {
     status: 'completed',
     newRevision,

--- a/src/lifecycle/removal.ts
+++ b/src/lifecycle/removal.ts
@@ -275,6 +275,8 @@ export async function confirmRegistrationRemoval(
   if (!write.success) return persistenceFailure(OPERATION, preflight.scope, trigger, preflight.stateRevision, write);
 
   const newRevision = write.newRevision!;
+  // A removed Registration's pending Update Candidate pin is no longer meaningful (#22).
+  if (preflight.registrationId) opts.cache?.clearPendingUpdate(preflight.scope, preflight.registrationId);
   return {
     status: 'completed',
     newRevision,
@@ -432,6 +434,8 @@ export async function confirmInstallationRemoval(
   if (!write.success) return persistenceFailure(OPERATION, preflight.scope, trigger, preflight.stateRevision, write);
 
   const newRevision = write.newRevision!;
+  // A removed Registration's pending Update Candidate pin is no longer meaningful (#22).
+  if (preflight.registrationId) opts.cache?.clearPendingUpdate(preflight.scope, preflight.registrationId);
   return {
     status: 'completed',
     newRevision,

--- a/src/lifecycle/removal.ts
+++ b/src/lifecycle/removal.ts
@@ -16,6 +16,7 @@
 
 import { commitBridgeState, readBridgeState } from '../bridge-state/store.js';
 import type { Installation, Scope } from '../bridge-state/types.js';
+import { SourceCache } from '../cache/source-cache.js';
 import { acquireAttemptFence, type AttemptFenceHandle } from '../registration/fence.js';
 import { CODE, RULE, blocking, sortFindings, type ValidationFinding } from '../registration/findings.js';
 import { createReceipt, type AttemptReceipt } from '../registration/receipt.js';
@@ -276,7 +277,10 @@ export async function confirmRegistrationRemoval(
 
   const newRevision = write.newRevision!;
   // A removed Registration's pending Update Candidate pin is no longer meaningful (#22).
-  if (preflight.registrationId) opts.cache?.clearPendingUpdate(preflight.scope, preflight.registrationId);
+  if (preflight.registrationId) {
+    const cache = opts.cache ?? new SourceCache({ agentDir: opts.agentDir });
+    cache.clearPendingUpdate(preflight.scope, preflight.registrationId);
+  }
   return {
     status: 'completed',
     newRevision,
@@ -434,8 +438,12 @@ export async function confirmInstallationRemoval(
   if (!write.success) return persistenceFailure(OPERATION, preflight.scope, trigger, preflight.stateRevision, write);
 
   const newRevision = write.newRevision!;
-  // A removed Registration's pending Update Candidate pin is no longer meaningful (#22).
-  if (preflight.registrationId) opts.cache?.clearPendingUpdate(preflight.scope, preflight.registrationId);
+  // Installation Removal does not invalidate a pending Update Candidate (the Registration and
+  // its candidate remain); the pin stays aligned with surviving records (#22).
+  if (preflight.registrationId) {
+    const cache = opts.cache ?? new SourceCache({ agentDir: opts.agentDir });
+    cache.clearPendingUpdate(preflight.scope, preflight.registrationId);
+  }
   return {
     status: 'completed',
     newRevision,

--- a/src/lifecycle/update.ts
+++ b/src/lifecycle/update.ts
@@ -204,21 +204,26 @@ export async function applyUpdate(plan: UpdatePlan, opts: ApplyUpdateOptions = {
     }
   } else {
     // Git candidates verify against the fingerprint-addressed Source Cache (default-constructed
-    // so pin hygiene and verification never depend on caller injection).
+    // so pin hygiene and verification never depend on caller injection). Fail-closed: an absent
+    // or mismatching cached tree rejects the attempt as stale — never an unverified apply.
     const cache = opts.cache ?? new SourceCache({ agentDir: opts.agentDir });
     const hit = await cache.hitExact(plan.candidate.snapshot.fingerprint);
-    if (hit) {
-      const revalidated = buildGitSnapshot(hit.path, plan.candidate.snapshot.sourceKey, plan.scope, {
-        canonicalLocator: plan.candidate.canonicalLocator ?? plan.candidate.snapshot.canonicalLocator ?? '',
-        resolvedRevision: plan.candidate.resolvedRevision ?? plan.candidate.snapshot.resolvedRevision ?? '',
-        selectorCanonical: plan.candidate.selectorCanonical ?? plan.candidate.snapshot.selectorCanonical ?? '',
-      });
-      if (!revalidated.ok || !revalidated.snapshot || revalidated.snapshot.fingerprint !== plan.candidate.snapshot.fingerprint) {
-        return stale(
-          plan,
-          'Cached Git tree no longer hashes to the Update Candidate fingerprint (source drift); run a fresh Marketplace Refresh and rebuild the plan',
-        );
-      }
+    if (!hit) {
+      return stale(
+        plan,
+        'No cached tree verifies the Update Candidate fingerprint (evicted or never retained); run a fresh Marketplace Refresh and rebuild the plan',
+      );
+    }
+    const revalidated = buildGitSnapshot(hit.path, plan.candidate.snapshot.sourceKey, plan.scope, {
+      canonicalLocator: plan.candidate.canonicalLocator ?? plan.candidate.snapshot.canonicalLocator ?? '',
+      resolvedRevision: plan.candidate.resolvedRevision ?? plan.candidate.snapshot.resolvedRevision ?? '',
+      selectorCanonical: plan.candidate.selectorCanonical ?? plan.candidate.snapshot.selectorCanonical ?? '',
+    });
+    if (!revalidated.ok || !revalidated.snapshot || revalidated.snapshot.fingerprint !== plan.candidate.snapshot.fingerprint) {
+      return stale(
+        plan,
+        'Cached Git tree no longer hashes to the Update Candidate fingerprint (source drift); run a fresh Marketplace Refresh and rebuild the plan',
+      );
     }
   }
 

--- a/src/lifecycle/update.ts
+++ b/src/lifecycle/update.ts
@@ -20,6 +20,7 @@ import {
 import { CODE, RULE, blocking, sortFindings, type ValidationFinding } from '../registration/findings.js';
 import { createReceipt, type AttemptReceipt } from '../registration/receipt.js';
 import { buildGitSnapshot, buildLocalSnapshot } from '../registration/snapshot.js';
+import { SourceCache } from '../cache/source-cache.js';
 import { commitBridgeState, readBridgeState } from '../bridge-state/store.js';
 import type { BridgeState } from '../bridge-state/types.js';
 import type { LifecycleFlowOptions, UpdateCandidate } from './refresh.js';
@@ -201,8 +202,11 @@ export async function applyUpdate(plan: UpdatePlan, opts: ApplyUpdateOptions = {
         'Validation Snapshot fingerprint changed since the Update Candidate was produced (source drifted); run a fresh Marketplace Refresh and rebuild the plan',
       );
     }
-  } else if (opts.cache) {
-    const hit = await opts.cache.hitExact(plan.candidate.snapshot.fingerprint);
+  } else {
+    // Git candidates verify against the fingerprint-addressed Source Cache (default-constructed
+    // so pin hygiene and verification never depend on caller injection).
+    const cache = opts.cache ?? new SourceCache({ agentDir: opts.agentDir });
+    const hit = await cache.hitExact(plan.candidate.snapshot.fingerprint);
     if (hit) {
       const revalidated = buildGitSnapshot(hit.path, plan.candidate.snapshot.sourceKey, plan.scope, {
         canonicalLocator: plan.candidate.canonicalLocator ?? plan.candidate.snapshot.canonicalLocator ?? '',
@@ -270,7 +274,7 @@ export async function applyUpdate(plan: UpdatePlan, opts: ApplyUpdateOptions = {
     const newRevision = write.newRevision!;
     // The Update Candidate has been applied: its pending-cache pin is no longer needed
     // (the new Registration/Installation snapshots now pin the fingerprint via Bridge State).
-    opts.cache?.clearPendingUpdate(plan.scope, plan.registrationId);
+    (opts.cache ?? new SourceCache({ agentDir: opts.agentDir })).clearPendingUpdate(plan.scope, plan.registrationId);
     const diagnostics = plan.entries.some((entry) => entry.choice === 'remove' || entry.currentState === 'disabled');
     return {
       status: 'completed',

--- a/src/lifecycle/update.ts
+++ b/src/lifecycle/update.ts
@@ -19,7 +19,7 @@ import {
 } from '../registration/fence.js';
 import { CODE, RULE, blocking, sortFindings, type ValidationFinding } from '../registration/findings.js';
 import { createReceipt, type AttemptReceipt } from '../registration/receipt.js';
-import { buildLocalSnapshot } from '../registration/snapshot.js';
+import { buildGitSnapshot, buildLocalSnapshot } from '../registration/snapshot.js';
 import { commitBridgeState, readBridgeState } from '../bridge-state/store.js';
 import type { BridgeState } from '../bridge-state/types.js';
 import type { LifecycleFlowOptions, UpdateCandidate } from './refresh.js';
@@ -192,8 +192,7 @@ export async function applyUpdate(plan: UpdatePlan, opts: ApplyUpdateOptions = {
   }
 
   // Fingerprint must still match before durable state mutation. Local sources are re-walked;
-  // Git candidates were validated at an immutable Resolved Revision and deep verification
-  // lands with the Source Cache lifecycle (#22).
+  // Git candidates are verified against the fingerprint-addressed Source Cache entry (#22).
   if (plan.candidate.snapshot.sourceKey.kind === 'local') {
     const revalidated = buildLocalSnapshot(plan.candidate.snapshot.sourceKey.canonicalPath!, plan.candidate.snapshot.sourceKey, plan.scope);
     if (!revalidated.ok || !revalidated.snapshot || revalidated.snapshot.fingerprint !== plan.candidate.snapshot.fingerprint) {
@@ -201,6 +200,21 @@ export async function applyUpdate(plan: UpdatePlan, opts: ApplyUpdateOptions = {
         plan,
         'Validation Snapshot fingerprint changed since the Update Candidate was produced (source drifted); run a fresh Marketplace Refresh and rebuild the plan',
       );
+    }
+  } else if (opts.cache) {
+    const hit = await opts.cache.hitExact(plan.candidate.snapshot.fingerprint);
+    if (hit) {
+      const revalidated = buildGitSnapshot(hit.path, plan.candidate.snapshot.sourceKey, plan.scope, {
+        canonicalLocator: plan.candidate.canonicalLocator ?? plan.candidate.snapshot.canonicalLocator ?? '',
+        resolvedRevision: plan.candidate.resolvedRevision ?? plan.candidate.snapshot.resolvedRevision ?? '',
+        selectorCanonical: plan.candidate.selectorCanonical ?? plan.candidate.snapshot.selectorCanonical ?? '',
+      });
+      if (!revalidated.ok || !revalidated.snapshot || revalidated.snapshot.fingerprint !== plan.candidate.snapshot.fingerprint) {
+        return stale(
+          plan,
+          'Cached Git tree no longer hashes to the Update Candidate fingerprint (source drift); run a fresh Marketplace Refresh and rebuild the plan',
+        );
+      }
     }
   }
 
@@ -254,6 +268,9 @@ export async function applyUpdate(plan: UpdatePlan, opts: ApplyUpdateOptions = {
     }
 
     const newRevision = write.newRevision!;
+    // The Update Candidate has been applied: its pending-cache pin is no longer needed
+    // (the new Registration/Installation snapshots now pin the fingerprint via Bridge State).
+    opts.cache?.clearPendingUpdate(plan.scope, plan.registrationId);
     const diagnostics = plan.entries.some((entry) => entry.choice === 'remove' || entry.currentState === 'disabled');
     return {
       status: 'completed',

--- a/src/registration/git-acquisition.ts
+++ b/src/registration/git-acquisition.ts
@@ -275,6 +275,18 @@ async function resolveRevision(
   return { ok: true, sha: sha.toLowerCase() };
 }
 
+/** Resolve a selector to a full commit SHA via non-executing ls-remote (#22 cache seam). */
+export async function resolveGitRevision(
+  locator: CanonicalGitLocator,
+  selector: NormalizedGitSelector,
+  scope: Scope,
+  opts: { executor?: GitExecutor; trust?: AcquisitionTrustOptions } = {},
+): Promise<{ ok: true; sha: string } | { ok: false; findings: ValidationFinding[]; stderr?: string }> {
+  const env = hardenedEnv(opts.trust, locator);
+  const configArgs = hardenedConfigArgs(opts.trust);
+  return resolveRevision(locator, selector, scope, opts.executor ?? defaultGitExecutor(), env, configArgs);
+}
+
 /**
  * Acquire a Git source non-executingly at its Resolved Revision.
  * Uses `clone --no-checkout` with hardened config/env, then checks out the resolved revision.

--- a/src/registration/git-flow.ts
+++ b/src/registration/git-flow.ts
@@ -27,6 +27,7 @@ import { gitSourceKey, type SourceKey } from './source-key.js';
 import { normalizeGitLocator, type CanonicalGitLocator } from './git-locator.js';
 import { normalizeGitSelector, parseGitSelectorString, type GitSelectorInput, type NormalizedGitSelector } from './git-selector.js';
 import { acquireGitSource, cleanupAcquisition, type GitExecutor, type AcquisitionTrustOptions } from './git-acquisition.js';
+import { SourceCache } from '../cache/source-cache.js';
 import { MARKETPLACE_CATALOG_RELPATH } from './flow.js';
 
 export interface GitRegistrationFlowOptions {
@@ -39,6 +40,8 @@ export interface GitRegistrationFlowOptions {
   executor?: GitExecutor;
   /** Trust base options */
   trust?: AcquisitionTrustOptions;
+  /** Injected Source Cache (defaults to a cache under the given agentDir). */
+  cache?: SourceCache;
   /** Destination dir for acquisition (tests) — if not provided, temp is created */
   destDir?: string;
 }
@@ -371,6 +374,21 @@ export async function preflightGitRegistration(
       catalog.name,
       registrations.map((r) => r.alias).filter((a): a is string => Boolean(a)),
     );
+
+    // Cache the validated tree under its fingerprint and record the locator+selector index
+    // entry for future exact-fingerprint hits (#22).
+    const cache = opts.cache ?? new SourceCache({ agentDir: opts.agentDir });
+    try {
+      await cache.storeTree(acquiredPath, snapshotResult.snapshot!.fingerprint);
+      cache.recordIndex({
+        fingerprint: snapshotResult.snapshot!.fingerprint,
+        resolvedRevision,
+        canonicalLocator: locator.canonicalUrl,
+        selectorCanonical: selCanonical,
+      });
+    } catch {
+      // Cache is non-authoritative: store failures never block registration.
+    }
 
     // Keep acquiredPath for potential cleanup on cancel/confirm; snapshot already captured
     const preflight: GitRegistrationPreflight = {

--- a/tests/integration/lifecycle-cache.test.ts
+++ b/tests/integration/lifecycle-cache.test.ts
@@ -1,0 +1,192 @@
+import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { SourceCache } from '../../src/cache/source-cache.js';
+import { readBridgeState } from '../../src/bridge-state/store.js';
+import { refreshRegistration } from '../../src/lifecycle/refresh.js';
+import { confirmGitRegistration, preflightGitRegistration } from '../../src/registration/git-flow.js';
+import type { GitExecutor } from '../../src/registration/git-acquisition.js';
+import type { GitSelectorInput } from '../../src/registration/git-selector.js';
+
+const SHA_A = 'a'.repeat(40);
+const SHA_B = 'b'.repeat(40);
+const OFFLINE_ERR = 'fatal: Could not resolve host: github.com';
+
+function makeEnv() {
+  const root = mkdtempSync(join(tmpdir(), 'cache-drift-git-'));
+  return {
+    root,
+    agentDir: join(root, 'agent'),
+    projectDir: join(root, 'project'),
+    fixture: join(root, 'fixture'),
+  };
+}
+
+function makeFixture(root: string, opts: { extra?: boolean } = {}): void {
+  mkdirSync(join(root, '.agents', 'plugins'), { recursive: true });
+  mkdirSync(join(root, 'plugins', 'demo', '.codex-plugin'), { recursive: true });
+  mkdirSync(join(root, 'plugins', 'demo', 'skills', 'demo-skill'), { recursive: true });
+  writeFileSync(join(root, 'plugins', 'demo', '.codex-plugin', 'plugin.json'), JSON.stringify({ name: 'demo', skills: './skills/' }));
+  writeFileSync(
+    join(root, 'plugins', 'demo', 'skills', 'demo-skill', 'SKILL.md'),
+    '---\nname: demo-skill\ndescription: Demo\n---\n\nDemo.\n',
+  );
+  writeFileSync(
+    join(root, '.agents', 'plugins', 'marketplace.json'),
+    JSON.stringify({ name: 'demo-marketplace', plugins: [{ name: 'demo', path: './plugins/demo' }] }),
+  );
+  if (opts.extra) {
+    mkdirSync(join(root, 'plugins', 'demo', 'skills', 'extra-skill'), { recursive: true });
+    writeFileSync(
+      join(root, 'plugins', 'demo', 'skills', 'extra-skill', 'SKILL.md'),
+      '---\nname: extra-skill\ndescription: Extra\n---\n\nExtra.\n',
+    );
+  }
+}
+
+interface Counters { clones: number }
+
+function makeExecutor(fixtureRoot: string, sha: string, counters?: Counters, offline = false): GitExecutor {
+  return async (args) => {
+    if (args.includes('ls-remote')) {
+      if (offline) return { exitCode: 128, stdout: '', stderr: OFFLINE_ERR };
+      const ref = args[args.length - 1];
+      return { exitCode: 0, stdout: `${sha}\t${ref}\n`, stderr: '' };
+    }
+    if (args.includes('clone')) {
+      if (offline) return { exitCode: 128, stdout: '', stderr: OFFLINE_ERR };
+      if (counters) counters.clones += 1;
+      const dest = args[args.length - 1];
+      cpSync(fixtureRoot, dest, { recursive: true });
+      mkdirSync(join(dest, '.git'), { recursive: true });
+      return { exitCode: 0, stdout: '', stderr: '' };
+    }
+    return { exitCode: 0, stdout: '', stderr: '' };
+  };
+}
+
+describe('Source Cache + Source Drift — Git lifecycle (#22)', () => {
+  let env: ReturnType<typeof makeEnv>;
+  let counters: Counters;
+
+  beforeEach(() => {
+    env = makeEnv();
+    makeFixture(env.fixture);
+    counters = { clones: 0 };
+  });
+
+  afterEach(() => rmSync(env.root, { recursive: true, force: true }));
+
+  async function register(sha: string): Promise<string> {
+    const opts = { agentDir: env.agentDir, cwd: env.projectDir, executor: makeExecutor(env.fixture, sha, counters) };
+    const preflight = await preflightGitRegistration('global', 'https://github.com/acme/plugins.git', { kind: 'branch', value: 'main' }, opts);
+    expect(preflight.ok).toBe(true);
+    if (!preflight.ok) throw new Error('preflight failed');
+    const confirmed = await confirmGitRegistration(preflight.preflight, true, opts);
+    expect(confirmed.status).toBe('completed');
+    return confirmed.status === 'completed' ? confirmed.registration.id : '';
+  }
+
+  it('registration populates the fingerprint-addressed cache and index', async () => {
+    const registrationId = await register(SHA_A);
+    const state = await readBridgeState('global', { agentDir: env.agentDir, cwd: env.projectDir });
+    const fingerprint = state.state!.registrations[0].validationSnapshot!;
+    const cache = new SourceCache({ agentDir: env.agentDir });
+    const hit = await cache.hitExact(fingerprint);
+    expect(hit).not.toBeNull();
+    expect(existsSync(join(hit!.path, '.agents', 'plugins', 'marketplace.json'))).toBe(true);
+    const rec = cache.readIndex()['https://github.com/acme/plugins.git\u001frefs/heads/main'];
+    expect(rec?.fingerprint).toBe(fingerprint);
+    void registrationId;
+  });
+
+  it('a same-revision refresh hits the cache without any clone (p50 path)', async () => {
+    const registrationId = await register(SHA_A);
+    expect(counters.clones).toBeGreaterThanOrEqual(1);
+
+    // Second refresh at the same Resolved Revision: served entirely from cache.
+    const secondCounters: Counters = { clones: 0 };
+    const start = Date.now();
+    const outcome = await refreshRegistration('global', registrationId, {
+      agentDir: env.agentDir,
+      cwd: env.projectDir,
+      executor: makeExecutor(env.fixture, SHA_A, secondCounters),
+    });
+    const elapsed = Date.now() - start;
+    expect(outcome.status).toBe('no-change');
+    expect(secondCounters.clones).toBe(0);
+    // Exact-fingerprint hit path stays well under the 200ms p50 budget on fixture trees.
+    expect(elapsed).toBeLessThan(200);
+  });
+
+  it('an offline refresh reuses only the exact fingerprint hit and never mutates state', async () => {
+    const registrationId = await register(SHA_A);
+    const before = await readBridgeState('global', { agentDir: env.agentDir, cwd: env.projectDir });
+
+    const outcome = await refreshRegistration('global', registrationId, {
+      agentDir: env.agentDir,
+      cwd: env.projectDir,
+      executor: makeExecutor(env.fixture, SHA_A, undefined, true),
+    });
+
+    expect(outcome.status).toBe('no-change');
+    if (outcome.status !== 'no-change') return;
+    expect(outcome.receipt.stateChanged).toBe(false);
+    const after = await readBridgeState('global', { agentDir: env.agentDir, cwd: env.projectDir });
+    expect(after.state!.stateRevision).toBe(before.state!.stateRevision);
+  });
+
+  it('a tampered cached tree offline is Source Drift — Blocking Finding, never success', async () => {
+    const registrationId = await register(SHA_A);
+    const state = await readBridgeState('global', { agentDir: env.agentDir, cwd: env.projectDir });
+    const fingerprint = state.state!.registrations[0].validationSnapshot!;
+    const before = await readBridgeState('global', { agentDir: env.agentDir, cwd: env.projectDir });
+
+    // External tampering of the local cached tree.
+    writeFileSync(
+      join(new SourceCache({ agentDir: env.agentDir }).entryPath(fingerprint), 'plugins', 'demo', 'skills', 'demo-skill', 'SKILL.md'),
+      '---\nname: demo-skill\ndescription: drifted\n---\n\ndrifted.\n',
+    );
+
+    const outcome = await refreshRegistration('global', registrationId, {
+      agentDir: env.agentDir,
+      cwd: env.projectDir,
+      executor: makeExecutor(env.fixture, SHA_A, undefined, true),
+    });
+
+    expect(outcome.status).toBe('blocked');
+    if (outcome.status !== 'blocked') return;
+    expect(outcome.findings.map((f) => f.code)).toContain('SOURCE_DRIFT');
+    expect(outcome.findings[0].rule).toBe('DRIFT-01');
+    expect(outcome.receipt.summary).toBe('Blocked');
+    const after = await readBridgeState('global', { agentDir: env.agentDir, cwd: env.projectDir });
+    expect(after.state!.stateRevision).toBe(before.state!.stateRevision);
+    expect(after.state!.registrations[0].validationSnapshot).toBe(fingerprint);
+  });
+
+  it('pins an Update Candidate fingerprint so LRU pruning never evicts it', async () => {
+    const registrationId = await register(SHA_A);
+
+    // Upstream advances.
+    makeFixture(env.fixture, { extra: true });
+    const outcome = await refreshRegistration('global', registrationId, {
+      agentDir: env.agentDir,
+      cwd: env.projectDir,
+      executor: makeExecutor(env.fixture, SHA_B, counters),
+    });
+    expect(outcome.status).toBe('update-candidate');
+    if (outcome.status !== 'update-candidate') return;
+
+    const cache = new SourceCache({ agentDir: env.agentDir });
+    const pending = cache.pendingUpdates().filter((r) => r.registrationId === registrationId);
+    expect(pending.map((r) => r.fingerprint)).toEqual([outcome.candidate.snapshot.fingerprint]);
+    // Candidate tree is cached under its fingerprint.
+    expect(await cache.hitExact(outcome.candidate.snapshot.fingerprint)).not.toBeNull();
+    // Pruning (even forced) keeps the pending candidate.
+    await cache.prune();
+    expect(await cache.hitExact(outcome.candidate.snapshot.fingerprint)).not.toBeNull();
+  });
+});

--- a/tests/integration/lifecycle-cache.test.ts
+++ b/tests/integration/lifecycle-cache.test.ts
@@ -189,4 +189,33 @@ describe('Source Cache + Source Drift — Git lifecycle (#22)', () => {
     await cache.prune();
     expect(await cache.hitExact(outcome.candidate.snapshot.fingerprint)).not.toBeNull();
   });
+
+  it('Apply Update fails closed when no cached tree verifies the Git candidate', async () => {
+    const { applyUpdate } = await import('../../src/lifecycle/update.js');
+    const { buildUpdatePlan } = await import('../../src/lifecycle/update-plan.js');
+    const registrationId = await register(SHA_A);
+
+    makeFixture(env.fixture, { extra: true });
+    const refreshed = await refreshRegistration('global', registrationId, {
+      agentDir: env.agentDir,
+      cwd: env.projectDir,
+      executor: makeExecutor(env.fixture, SHA_B, counters),
+    });
+    expect(refreshed.status).toBe('update-candidate');
+    if (refreshed.status !== 'update-candidate') return;
+    const candidate = refreshed.candidate;
+
+    const state = await readBridgeState('global', { agentDir: env.agentDir, cwd: env.projectDir });
+    const planResult = buildUpdatePlan(candidate, [], state.state!.stateRevision, { registrationConfirmed: true, choices: {} });
+    expect(planResult.ok).toBe(true);
+    if (!planResult.ok) throw new Error(`plan problems: ${planResult.problems.map((p) => p.outcome).join('; ')}`);
+
+    // Evict the candidate tree so nothing can verify its fingerprint.
+    rmSync(new SourceCache({ agentDir: env.agentDir }).entryPath(candidate.snapshot.fingerprint), { recursive: true, force: true });
+
+    const applied = await applyUpdate(planResult.plan, { agentDir: env.agentDir, cwd: env.projectDir });
+    expect(applied.status).toBe('rejected-as-stale');
+    if (applied.status !== 'rejected-as-stale') return;
+    expect(applied.receipt.summary).toBe('Rejected as Stale');
+  });
 });

--- a/tests/unit/cache/source-cache.test.ts
+++ b/tests/unit/cache/source-cache.test.ts
@@ -1,0 +1,170 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  CACHE_TOTAL_BUDGET_BYTES,
+  SourceCache,
+  treeBytes,
+} from '../../../src/cache/source-cache.js';
+import type { BridgeState, Registration } from '../../../src/bridge-state/types.js';
+
+const FP_A = 'a'.repeat(64);
+const FP_B = 'b'.repeat(64);
+const FP_C = 'c'.repeat(64);
+const FP_PINNED = 'd'.repeat(64);
+
+function makeTree(root: string, marker = 'one'): string {
+  mkdirSync(join(root, 'sub'), { recursive: true });
+  writeFileSync(join(root, 'file.txt'), marker);
+  writeFileSync(join(root, 'sub', 'nested.txt'), `${marker}-nested`);
+  return root;
+}
+
+describe('SourceCache (Git-only, fingerprint-addressed)', () => {
+  let root: string;
+  let cache: SourceCache;
+  let tick: number;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'source-cache-'));
+    tick = 1000;
+    cache = new SourceCache({ root, budgetBytes: 100, clock: () => (tick += 10) });
+  });
+
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('stores a tree by fingerprint and serves an exact-fingerprint hit', async () => {
+    const src = makeTree(join(root, 'src'));
+    const stored = await cache.storeTree(src, FP_A);
+    expect(stored.stored).toBe(true);
+
+    const hit = await cache.hitExact(FP_A);
+    expect(hit).not.toBeNull();
+    expect(hit!.fingerprint).toBe(FP_A);
+    expect(existsSync(join(hit!.path, 'file.txt'))).toBe(true);
+    // No false positives.
+    expect(await cache.hitExact(FP_B)).toBeNull();
+    expect(await cache.hitExact('not-a-fingerprint')).toBeNull();
+  });
+
+  it('is idempotent when the same fingerprint is stored twice', async () => {
+    const src = makeTree(join(root, 'src'));
+    await cache.storeTree(src, FP_A);
+    const again = await cache.storeTree(src, FP_A);
+    expect(again.stored).toBe(false);
+    expect((await cache.hitExact(FP_A))!.path).toBe(cache.entryPath(FP_A));
+  });
+
+  it('evicts unpinned entries LRU-first beyond the budget and never evicts pinned entries', async () => {
+    const marker = 'm'.repeat(60);
+    const mk = (fp: string) => makeTree(join(root, `src-${fp.slice(0, 4)}`), marker);
+    // Budget sized so exactly one LRU eviction occurs among three equal trees.
+    const probe = treeBytes(mk(FP_A));
+    cache = new SourceCache({ root, budgetBytes: Math.floor(probe * 2.5), clock: () => (tick += 10) });
+
+    await cache.storeTree(mk(FP_A), FP_A); // oldest
+    await cache.storeTree(mk(FP_B), FP_B);
+    // A pending Update Candidate fingerprint is pinned (not itself stored here).
+    cache.recordPendingUpdate({ scope: 'global', registrationId: 'r1', fingerprint: FP_PINNED });
+    await cache.storeTree(mk(FP_C), FP_C);
+    await cache.prune();
+
+    // FP_A (oldest unpinned) must be evicted; newer entries remain.
+    expect(existsSync(cache.entryPath(FP_A))).toBe(false);
+    expect(existsSync(cache.entryPath(FP_B))).toBe(true);
+    expect(existsSync(cache.entryPath(FP_C))).toBe(true);
+  });
+
+  it('never evicts in-flight entries even over budget', async () => {
+    const src = makeTree(join(root, 'inflight'), 'x'.repeat(200));
+    const release = cache.pinInFlight(FP_A);
+    await cache.storeTree(src, FP_A);
+    await cache.prune();
+    expect(existsSync(cache.entryPath(FP_A))).toBe(true);
+    release();
+    await cache.prune();
+    // Over budget now → evicted once no longer in flight.
+    expect(existsSync(cache.entryPath(FP_A))).toBe(false);
+  });
+
+  it('serializes concurrent operations on the same fingerprint (flock mutual exclusion)', async () => {
+    const order: string[] = [];
+    const first = cache.withFingerprintLock(FP_A, () => {
+      order.push('first-enter');
+      return new Promise<void>((resolve) => setTimeout(resolve, 50)).then(() => {
+        order.push('first-exit');
+      });
+    });
+    const second = cache.withFingerprintLock(FP_A, () => {
+      order.push('second-enter');
+    }, 5000);
+    await Promise.all([first, second]);
+    // The second holder can only enter after the first exits.
+    expect(order.indexOf('first-exit')).toBeLessThan(order.indexOf('second-enter'));
+  });
+
+  it('denies the lock when another holder exceeds the timeout instead of queueing forever', async () => {
+    const slow = cache.withFingerprintLock(FP_A, async () => {
+      await new Promise((r) => setTimeout(r, 120));
+    });
+    let timedOut = false;
+    try {
+      await cache.withFingerprintLock(FP_A, () => {}, 30);
+    } catch {
+      timedOut = true;
+    }
+    expect(timedOut).toBe(true);
+    await slow;
+    // After release the lock is acquirable again.
+    await expect(cache.withFingerprintLock(FP_A, () => 'ok')).resolves.toBe('ok');
+  });
+
+  it('records and clears pending Update Candidate fingerprints', () => {
+    cache.recordPendingUpdate({ scope: 'global', registrationId: 'reg-1', fingerprint: FP_A });
+    cache.recordPendingUpdate({ scope: 'global', registrationId: 'reg-1', fingerprint: FP_B }); // replaces
+    cache.recordPendingUpdate({ scope: 'project', registrationId: 'reg-2', fingerprint: FP_C });
+    expect(cache.pendingUpdates().map((r) => r.fingerprint).sort()).toEqual([FP_B, FP_C].sort());
+    cache.clearPendingUpdate('global', 'reg-1');
+    expect(cache.pendingUpdates().map((r) => r.fingerprint)).toEqual([FP_C]);
+  });
+
+  it('offline reuse requires an exact index fingerprint match AND a present entry', async () => {
+    const src = makeTree(join(root, 'src'));
+    await cache.storeTree(src, FP_A);
+    cache.recordIndex({
+      fingerprint: FP_A,
+      resolvedRevision: '1'.repeat(40),
+      canonicalLocator: 'https://github.com/acme/plugins.git',
+      selectorCanonical: 'refs/heads/main',
+    });
+    const hit = cache.offlineHit('https://github.com/acme/plugins.git', 'refs/heads/main', FP_A);
+    expect(hit?.fingerprint).toBe(FP_A);
+    // Different expected fingerprint → no hit (Stale Snapshot never becomes success).
+    expect(cache.offlineHit('https://github.com/acme/plugins.git', 'refs/heads/main', FP_B)).toBeNull();
+    // Unknown selector → no hit.
+    expect(cache.offlineHit('https://github.com/acme/plugins.git', 'refs/tags/v1', FP_A)).toBeNull();
+    // Missing entry → no hit even with matching index.
+    rmSync(cache.entryPath(FP_A), { recursive: true, force: true });
+    expect(cache.offlineHit('https://github.com/acme/plugins.git', 'refs/heads/main', FP_A)).toBeNull();
+  });
+
+  it('collects pinned fingerprints from Bridge State documents without I/O', () => {
+    const globalState = {
+      registrations: [{ validationSnapshot: FP_A }],
+      installations: [{ validationSnapshot: FP_B }],
+    } as unknown as BridgeState;
+    const projectState = {
+      registrations: [],
+      installations: [{ validationSnapshot: FP_C }],
+    } as unknown as BridgeState;
+    const pinned = SourceCache.pinnedFromStates([globalState, projectState]);
+    expect(pinned).toEqual(new Set([FP_A, FP_B, FP_C]));
+  });
+
+  it('exposes the production budget constant at 2 GiB', () => {
+    expect(CACHE_TOTAL_BUDGET_BYTES).toBe(2 * 1024 * 1024 * 1024);
+  });
+});

--- a/tests/unit/cache/source-cache.test.ts
+++ b/tests/unit/cache/source-cache.test.ts
@@ -140,15 +140,15 @@ describe('SourceCache (Git-only, fingerprint-addressed)', () => {
       canonicalLocator: 'https://github.com/acme/plugins.git',
       selectorCanonical: 'refs/heads/main',
     });
-    const hit = cache.offlineHit('https://github.com/acme/plugins.git', 'refs/heads/main', FP_A);
+    const hit = await cache.offlineHit('https://github.com/acme/plugins.git', 'refs/heads/main', FP_A);
     expect(hit?.fingerprint).toBe(FP_A);
     // Different expected fingerprint → no hit (Stale Snapshot never becomes success).
-    expect(cache.offlineHit('https://github.com/acme/plugins.git', 'refs/heads/main', FP_B)).toBeNull();
+    expect(await cache.offlineHit('https://github.com/acme/plugins.git', 'refs/heads/main', FP_B)).toBeNull();
     // Unknown selector → no hit.
-    expect(cache.offlineHit('https://github.com/acme/plugins.git', 'refs/tags/v1', FP_A)).toBeNull();
+    expect(await cache.offlineHit('https://github.com/acme/plugins.git', 'refs/tags/v1', FP_A)).toBeNull();
     // Missing entry → no hit even with matching index.
     rmSync(cache.entryPath(FP_A), { recursive: true, force: true });
-    expect(cache.offlineHit('https://github.com/acme/plugins.git', 'refs/heads/main', FP_A)).toBeNull();
+    expect(await cache.offlineHit('https://github.com/acme/plugins.git', 'refs/heads/main', FP_A)).toBeNull();
   });
 
   it('collects pinned fingerprints from Bridge State documents without I/O', () => {


### PR DESCRIPTION
Closes #22

## Summary
- **Source Cache（Git-only）**：以 Validation Snapshot fingerprint 定址，位於 `${getAgentDir()}/codex-marketplace/cache`；註冊與 Refresh 成功取得後寫入快取並登錄 locator⊕selector 索引。
- **Pinned 集**：Bridge State 引用（Registration/Installation snapshots）+ 待決 Update Candidate + 飛行中 pin（引用計數），永不 LRU 驅逐。
- **2 GiB 總量**：僅對 unpinned 以 LRU 同歩驅逐/修剪（store 後內聯執行），無背景任務、無 TTL。
- **互斥**：每 fingerprint 鎖（O_EXCL advisory lockfile，沿用 Bridge 慣例）序列化 store/hit/prune 該 entry。
- **離線**：遠端不可達時僅精確 fingerprint 命中可復用，且重雜湊必須完全一致；竄改的快取樹 → `SOURCE_DRIFT`（DRIFT-01）Blocking Finding，Stale Snapshot 永不轉成功。Bridge State 不變，僅 Marketplace Refresh 可產生新 Update Candidate。
- **Apply Update**：Git candidate 於提交前對快取樹重新驗證 fingerprint；套用/移除時清除待決 pin。

## Verification
- `npm run check`：typecheck + 268 tests green
- 新增 10 個 SourceCache 單元測試（store/hit、LRU/pinned/in-flight、flock 序列化與逾時、pending registry、offline exact-hit、Bridge State pinned 集、2 GiB 常數）
- 新增 5 個 Git lifecycle 整合測試（快取填充、同 revision 零 clone 且 <200ms、離線精確命中、離線竄改 → DRIFT-01 Blocking、candidate pin 不被 prune）
- 兩軸 code review（Standards + Spec 子代理）已完成並修正其發現
