### PR TITLE
feat: 支援 Git Marketplace 的 Plugin 檢驗與安裝（接合 Source Cache） (#34)

### DIFF
--- a/extensions/pi/installation.ts
+++ b/extensions/pi/installation.ts
@@ -13,6 +13,7 @@ import {
   type InstallationOutcome,
 } from '../../src/installation/flow.js';
 import { inspectMarketplaceEntries } from '../../src/installation/inspection.js';
+import type { SourceCache } from '../../src/cache/source-cache.js';
 import type { Registration, Scope } from '../../src/bridge-state/types.js';
 import { reportOutcome } from './registration.js';
 
@@ -23,9 +24,9 @@ function labelText(value: string): string { return JSON.stringify(value); }
 export async function entryChoices(
   registration: Registration,
   scope: Scope,
-  _opts: { cwd?: string; projectTrusted?: boolean },
+  opts: { cwd?: string; agentDir?: string; projectTrusted?: boolean; cache?: SourceCache } = {},
 ): Promise<EntryChoice[]> {
-  const inspection = inspectMarketplaceEntries(registration, scope);
+  const inspection = inspectMarketplaceEntries(registration, scope, { agentDir: opts.agentDir, cache: opts.cache });
   if (!inspection.marketplaceId) return [{ label: `${labelText(registration.alias ?? registration.id)} — Unavailable (${labelText(inspection.findings[0]?.outcome ?? 'Marketplace Catalog cannot be read')})` }];
   return inspection.entries.map((item) => {
     const status = item.unavailableReason ? `Unavailable (${item.unavailableReason})` : '可安裝';

--- a/src/cache/source-cache.ts
+++ b/src/cache/source-cache.ts
@@ -27,7 +27,7 @@ import {
 import { cpSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { acquireLock, releaseLock, atomicWriteFile } from '../bridge-state/atomic.js';
+import { acquireLock, acquireLockSync, releaseLock, atomicWriteFile } from '../bridge-state/atomic.js';
 import { readBridgeState } from '../bridge-state/store.js';
 import type { BridgeState } from '../bridge-state/types.js';
 import type { Scope } from '../bridge-state/types.js';
@@ -123,6 +123,19 @@ export class SourceCache {
     }
   }
 
+  /**
+   * Synchronous per-fingerprint mutual exclusion around store/prune/touch for that entry.
+   */
+  withFingerprintLockSync<T>(fingerprint: string, fn: () => T, timeoutMs = 5000): T {
+    const lockPath = this.lockPath(fingerprint);
+    const fd = acquireLockSync(lockPath, timeoutMs);
+    try {
+      return fn();
+    } finally {
+      releaseLock(fd, lockPath);
+    }
+  }
+
   /** Register an in-flight pin (reference-counted); returns its release function. In-flight entries are never evicted. */
   pinInFlight(fingerprint: string): () => void {
     this.inFlight.set(fingerprint, (this.inFlight.get(fingerprint) ?? 0) + 1);
@@ -143,6 +156,18 @@ export class SourceCache {
     const meta = this.readMeta(fingerprint);
     if (!existsSync(dir) || !meta || meta.fingerprint !== fingerprint) return null;
     await this.withFingerprintLock(fingerprint, () => {
+      this.touchMeta(fingerprint);
+    });
+    return { path: dir, fingerprint };
+  }
+
+  /** Synchronous exact fingerprint hit: entry directory + matching meta must exist. Touches lastAccess. */
+  hitExactSync(fingerprint: string): CacheHit | null {
+    if (!isSafeFingerprint(fingerprint)) return null;
+    const dir = this.entryPath(fingerprint);
+    const meta = this.readMeta(fingerprint);
+    if (!existsSync(dir) || !meta || meta.fingerprint !== fingerprint) return null;
+    this.withFingerprintLockSync(fingerprint, () => {
       this.touchMeta(fingerprint);
     });
     return { path: dir, fingerprint };

--- a/src/installation/flow.ts
+++ b/src/installation/flow.ts
@@ -13,12 +13,14 @@ import { CODE, RULE, blocking, hasBlocking, sortFindings, type ValidationFinding
 import { acquireAttemptFence, type AttemptFenceHandle } from '../registration/fence.js';
 import { createReceipt, type AttemptReceipt } from '../registration/receipt.js';
 import { appendReceipt } from '../journal/journal.js';
+import type { SourceCache } from '../cache/source-cache.js';
 import type { ValidationSnapshot } from '../registration/snapshot.js';
 import { inspectMarketplaceEntries } from './inspection.js';
 
 export interface InstallationFlowOptions {
   cwd?: string;
   agentDir?: string;
+  cache?: SourceCache;
   projectTrusted?: boolean;
   fenceTimeoutMs?: number;
   /** Integration synchronization seam; production callers leave this undefined. */
@@ -148,18 +150,16 @@ async function makePreflight(
       operationFinding(scope, CODE.INSTALLATION_NOT_FOUND, RULE.INSTALLATION_NOT_FOUND, `Registration '${registrationId}' is not in ${scope} Bridge State`, 'registration'),
     ], null, opts);
   }
-  if (registration.sourceKind !== 'local' || !registration.source) {
-    return blocked(operation, scope, registrationId, entryPointer, state.stateRevision, [
-      operationFinding(scope, CODE.SOURCE_REACQUISITION_REQUIRED, RULE.SOURCE_REACQUISITION_REQUIRED, 'This Registration has no retained local Validation Snapshot tree; Git Installation waits for the Source Cache lifecycle', 'registration'),
-    ], null, opts);
-  }
 
   const fenceResult = await acquireAttemptFence(scope, { cwd: opts.cwd, agentDir: opts.agentDir, fenceTimeoutMs: opts.fenceTimeoutMs, projectTrusted: opts.projectTrusted });
   if (!fenceResult.ok) return blocked(operation, scope, registrationId, entryPointer, state.stateRevision, [fenceResult.finding!], null, opts);
   const fence = fenceResult.handle!;
 
   try {
-    const inspection = inspectMarketplaceEntries(registration, scope);
+    const inspection = inspectMarketplaceEntries(registration, scope, {
+      agentDir: opts.agentDir,
+      cache: opts.cache,
+    });
     const inspected = inspection.entries.find((item) => item.entry.entryId === entryPointer);
     const rejectedFindings = inspected?.findings ?? (inspection.findings.length > 0 ? inspection.findings : [
       operationFinding(scope, CODE.INSTALLATION_NOT_FOUND, RULE.INSTALLATION_NOT_FOUND, `Marketplace Entry '${entryPointer}' is Unavailable`, 'entry'),
@@ -315,7 +315,10 @@ export async function confirmPluginInstallation(
   if (current.state!.stateRevision !== preflight.stateRevision) {
     return rejectedAsStale(preflight, 'State Revision changed since Installation disclosure; re-run preflight and confirmation', opts);
   }
-  const fresh = inspectMarketplaceEntries(preflight.registration, preflight.scope);
+  const fresh = inspectMarketplaceEntries(preflight.registration, preflight.scope, {
+    agentDir: opts.agentDir,
+    cache: opts.cache,
+  });
   if (!fresh.snapshot || fresh.snapshot.fingerprint !== preflight.snapshot.fingerprint) {
     return rejectedAsStale(preflight, 'Validation Snapshot changed since Installation disclosure; re-run preflight and confirmation', opts);
   }

--- a/src/installation/inspection.ts
+++ b/src/installation/inspection.ts
@@ -6,7 +6,7 @@
  */
 
 import { createHash } from 'node:crypto';
-import { lstatSync, readFileSync } from 'node:fs';
+import { lstatSync, readFileSync, realpathSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { classifyPlugin, type CompatiblePlugin } from '../compatibility/profile.js';
@@ -15,8 +15,9 @@ import type { MarketplaceEntry } from '../registration/catalog.js';
 import { parseCatalog } from '../registration/catalog.js';
 import { resolveContained } from '../registration/contained.js';
 import { CODE, RULE, blocking, hasBlocking, sortFindings, type ValidationFinding } from '../registration/findings.js';
-import { localSourceKey } from '../registration/source-key.js';
-import { bindCapturedMaterial, buildLocalSnapshot, type ValidationSnapshot } from '../registration/snapshot.js';
+import { SourceCache } from '../cache/source-cache.js';
+import { localSourceKey, type SourceKey } from '../registration/source-key.js';
+import { bindCapturedMaterial, buildGitSnapshot, buildLocalSnapshot, type ValidationSnapshot } from '../registration/snapshot.js';
 import { BUDGET } from '../registration/budget.js';
 
 export interface InspectedMarketplaceEntry {
@@ -43,6 +44,8 @@ export interface InspectionOptions {
   baseSnapshot?: ValidationSnapshot;
   /** Suppress the recorded-snapshot drift Blocking Finding — Refresh compares fingerprints explicitly instead. */
   ignoreRecordedDrift?: boolean;
+  agentDir?: string;
+  cache?: SourceCache;
 }
 
 function inspectionFinding(scope: Scope, code: string, rule: string, target: ValidationFinding['target'], outcome: string): ValidationFinding {
@@ -55,11 +58,60 @@ export function inspectMarketplaceEntries(registration: Registration, scope: Sco
   let root: string;
   let snapshotResult: { ok: boolean; snapshot?: ValidationSnapshot; findings: ValidationFinding[] };
   if (override) {
-    root = opts.root!;
+    try {
+      root = realpathSync.native(opts.root!);
+    } catch {
+      root = opts.root!;
+    }
     snapshotResult = { ok: true, snapshot: opts.baseSnapshot, findings: [] };
-  } else {
-    if (registration.sourceKind !== 'local' || !registration.source) {
-      return { entries: [], findings: [inspectionFinding(scope, CODE.SOURCE_REACQUISITION_REQUIRED, RULE.SOURCE_REACQUISITION_REQUIRED, 'registration', 'Git Source Cache lifecycle is not available yet')] };
+  } else if (registration.sourceKind === 'git') {
+    if (!registration.validationSnapshot) {
+      return {
+        entries: [],
+        findings: [inspectionFinding(scope, CODE.SOURCE_REACQUISITION_REQUIRED, RULE.SOURCE_REACQUISITION_REQUIRED, 'registration', 'Git Registration has no retained Validation Snapshot; re-registration or Marketplace Refresh is required')],
+      };
+    }
+    const cache = opts.cache ?? new SourceCache({ agentDir: opts.agentDir });
+    const hit = cache.hitExactSync(registration.validationSnapshot);
+    if (!hit) {
+      return {
+        entries: [],
+        findings: [inspectionFinding(scope, CODE.SOURCE_REACQUISITION_REQUIRED, RULE.SOURCE_REACQUISITION_REQUIRED, 'registration', `Git Source Cache miss: Validation Snapshot '${registration.validationSnapshot.slice(0, 16)}…' is not retained in Source Cache; Marketplace Refresh or re-acquisition is required`)],
+      };
+    }
+    try {
+      root = realpathSync.native(hit.path);
+    } catch {
+      root = hit.path;
+    }
+    const canonicalLocator = registration.canonicalLocator ?? registration.source ?? '';
+    const selectorCanonical = registration.gitSelector?.canonical ?? '';
+    const resolvedRevision = registration.resolvedRevision ?? '';
+    const sourceKey: SourceKey = registration.sourceKey ?? {
+      kind: 'git',
+      key: `git:${canonicalLocator}#${selectorCanonical}`,
+      canonicalUrl: canonicalLocator,
+      selector: selectorCanonical,
+      resolvedRevision,
+    };
+    const snapResult = buildGitSnapshot(root, sourceKey, scope, {
+      canonicalLocator,
+      resolvedRevision,
+      selectorCanonical,
+    });
+    if (!snapResult.ok || !snapResult.snapshot) {
+      return { entries: [], findings: snapResult.findings };
+    }
+    if (snapResult.snapshot.fingerprint !== registration.validationSnapshot) {
+      return {
+        entries: [],
+        findings: [inspectionFinding(scope, CODE.SOURCE_DRIFT, RULE.SOURCE_DRIFT, 'registration', `Source Drift: cached tree at fingerprint ${registration.validationSnapshot.slice(0, 16)}… no longer hashes to the recorded Validation Snapshot; Marketplace Refresh is required`)],
+      };
+    }
+    snapshotResult = snapResult;
+  } else if (registration.sourceKind === 'local' || (!registration.sourceKind && registration.source && !registration.canonicalLocator)) {
+    if (!registration.source) {
+      return { entries: [], findings: [inspectionFinding(scope, CODE.SOURCE_REACQUISITION_REQUIRED, RULE.SOURCE_REACQUISITION_REQUIRED, 'registration', 'Local Registration has no source path')] };
     }
     const key = localSourceKey(registration.source);
     if (!key.ok) return { entries: [], findings: [inspectionFinding(scope, CODE.SOURCE_REACQUISITION_REQUIRED, RULE.SOURCE_REACQUISITION_REQUIRED, 'registration', key.error ?? 'Marketplace Root cannot be revalidated')] };
@@ -74,6 +126,11 @@ export function inspectMarketplaceEntries(registration: Registration, scope: Sco
     }
     snapshotResult = buildLocalSnapshot(root, key.sourceKey!, scope);
     if (!snapshotResult.ok) return { entries: [], findings: snapshotResult.findings };
+  } else {
+    return {
+      entries: [],
+      findings: [inspectionFinding(scope, CODE.SOURCE_REACQUISITION_REQUIRED, RULE.SOURCE_REACQUISITION_REQUIRED, 'registration', `Unknown or unsupported sourceKind '${registration.sourceKind}'`)],
+    };
   }
 
   const catalogPath = join(root, '.agents', 'plugins', 'marketplace.json');

--- a/src/projection/project.ts
+++ b/src/projection/project.ts
@@ -125,7 +125,7 @@ export function projectEffectiveState(
   const findings: ValidationFinding[] = [];
 
   const inspections = new Map<string, MarketplaceInspection>();
-  const inspect = opts.inspectRegistration ?? ((registration: EffectiveRegistration) => inspectMarketplaceEntries(registration, registration.sourceScope));
+  const inspect = opts.inspectRegistration ?? ((registration: EffectiveRegistration) => inspectMarketplaceEntries(registration, registration.sourceScope, { agentDir: opts.agentDir }));
   const inspectionFor = (registration: EffectiveRegistration): MarketplaceInspection => {
     const key = `${registration.sourceScope}:${registration.id}`;
     let value = inspections.get(key);

--- a/src/registration/contained.ts
+++ b/src/registration/contained.ts
@@ -69,7 +69,12 @@ export function resolveContained(root: string, relPath: string, checkType: 'any'
     };
   }
 
-  const abs = root + sep + relPath.slice(2);
+  let canonicalRoot = root;
+  try {
+    canonicalRoot = realpathSync.native(root);
+  } catch {}
+
+  const abs = canonicalRoot + sep + relPath.slice(2);
   let canonical: string;
   try {
     canonical = realpathSync.native(abs);
@@ -80,7 +85,7 @@ export function resolveContained(root: string, relPath: string, checkType: 'any'
   }
 
   // containment check
-  if (!isWithin(root, canonical)) {
+  if (!isWithin(canonicalRoot, canonical)) {
     return {
       outcome: { kind: 'blocking', blockClass: 'path', reason: `canonical target '${canonical}' escapes owning root '${root}'` },
       type: 'special',

--- a/tests/integration/installation-git.test.ts
+++ b/tests/integration/installation-git.test.ts
@@ -1,0 +1,243 @@
+import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { SourceCache } from '../../src/cache/source-cache.js';
+import { commitBridgeState, readBridgeState } from '../../src/bridge-state/store.js';
+import {
+  confirmPluginEnable,
+  confirmPluginInstallation,
+  disablePluginInstallation,
+  installationDisclosure,
+  preflightPluginEnable,
+  preflightPluginInstallation,
+} from '../../src/installation/flow.js';
+import { inspectMarketplaceEntries } from '../../src/installation/inspection.js';
+import { entryChoices } from '../../extensions/pi/installation.js';
+import { confirmGitRegistration, preflightGitRegistration } from '../../src/registration/git-flow.js';
+import type { GitExecutor } from '../../src/registration/git-acquisition.js';
+import { CODE, RULE } from '../../src/registration/findings.js';
+import { projectEffectiveState } from '../../src/projection/project.js';
+
+const SHA_A = 'a'.repeat(40);
+
+function makeEnv() {
+  const root = mkdtempSync(join(tmpdir(), 'installation-git-integration-'));
+  return {
+    root,
+    agentDir: join(root, 'agent'),
+    projectDir: join(root, 'project'),
+    fixture: join(root, 'fixture'),
+  };
+}
+
+function makeFixture(root: string) {
+  mkdirSync(join(root, '.agents', 'plugins'), { recursive: true });
+  mkdirSync(join(root, 'plugins', 'release-helper', '.codex-plugin'), { recursive: true });
+  mkdirSync(join(root, 'plugins', 'release-helper', 'skills', 'release-notes'), { recursive: true });
+  writeFileSync(
+    join(root, '.agents', 'plugins', 'marketplace.json'),
+    JSON.stringify({
+      name: 'acme-marketplace',
+      plugins: [{ name: 'wrong-entry-name', source: { source: 'local', path: './plugins/release-helper' } }],
+    }),
+  );
+  writeFileSync(
+    join(root, 'plugins', 'release-helper', '.codex-plugin', 'plugin.json'),
+    JSON.stringify({ name: 'release-helper', skills: './skills/' }),
+  );
+  writeFileSync(
+    join(root, 'plugins', 'release-helper', 'skills', 'release-notes', 'SKILL.md'),
+    '---\nname: release-notes\ndescription: Write release notes\n---\n\nWrite release notes.\n',
+  );
+}
+
+function makeExecutor(fixtureRoot: string, sha: string): GitExecutor {
+  return async (args) => {
+    if (args.includes('ls-remote')) {
+      const ref = args[args.length - 1];
+      return { exitCode: 0, stdout: `${sha}\t${ref}\n`, stderr: '' };
+    }
+    if (args.includes('clone')) {
+      const dest = args[args.length - 1];
+      cpSync(fixtureRoot, dest, { recursive: true });
+      mkdirSync(join(dest, '.git'), { recursive: true });
+      return { exitCode: 0, stdout: '', stderr: '' };
+    }
+    return { exitCode: 0, stdout: '', stderr: '' };
+  };
+}
+
+describe('Git Marketplace Plugin Inspection & Installation lifecycle (#34)', () => {
+  let env: ReturnType<typeof makeEnv>;
+  let registrationId: string;
+
+  beforeEach(async () => {
+    env = makeEnv();
+    makeFixture(env.fixture);
+
+    const opts = {
+      agentDir: env.agentDir,
+      cwd: env.projectDir,
+      executor: makeExecutor(env.fixture, SHA_A),
+    };
+    const preflight = await preflightGitRegistration(
+      'global',
+      'https://github.com/acme/marketplace.git',
+      { kind: 'branch', value: 'main' },
+      opts,
+    );
+    expect(preflight.ok).toBe(true);
+    if (!preflight.ok) throw new Error('git registration preflight failed');
+
+    const confirmed = await confirmGitRegistration(preflight.preflight, true, opts);
+    expect(confirmed.status).toBe('completed');
+    if (confirmed.status !== 'completed') throw new Error('git registration confirm failed');
+    registrationId = confirmed.registration.id;
+  });
+
+  afterEach(() => rmSync(env.root, { recursive: true, force: true }));
+
+  it('inspectMarketplaceEntries reads cached Git tree and returns available Plugin entries', async () => {
+    const opts = { agentDir: env.agentDir, cwd: env.projectDir };
+    const state = (await readBridgeState('global', opts)).state!;
+    const registration = state.registrations.find((r) => r.id === registrationId)!;
+
+    const inspection = inspectMarketplaceEntries(registration, 'global', opts);
+    expect(inspection.findings.filter((f) => f.classification === 'blocking')).toHaveLength(0);
+    expect(inspection.marketplaceId).toBe(`${registrationId}/acme-marketplace`);
+    expect(inspection.entries).toHaveLength(1);
+    expect(inspection.entries[0]?.entry.name).toBe('wrong-entry-name');
+    expect(inspection.entries[0]?.plugin?.manifestName).toBe('release-helper');
+    expect(inspection.entries[0]?.unavailableReason).toBeUndefined();
+    expect(inspection.snapshot).toBeDefined();
+  });
+
+  it('entryChoices formats Git Marketplace plugins as 可安裝 in TUI', async () => {
+    const opts = { agentDir: env.agentDir, cwd: env.projectDir };
+    const state = (await readBridgeState('global', opts)).state!;
+    const registration = state.registrations.find((r) => r.id === registrationId)!;
+
+    const choices = await entryChoices(registration, 'global', opts);
+    expect(choices).toHaveLength(1);
+    expect(choices[0]?.pointer).toBe('/plugins/0');
+    expect(choices[0]?.label).toContain('可安裝');
+  });
+
+  it('returns SOURCE_REACQUISITION_REQUIRED when cache entry is missing', async () => {
+    const opts = { agentDir: env.agentDir, cwd: env.projectDir };
+    const state = (await readBridgeState('global', opts)).state!;
+    const registration = state.registrations.find((r) => r.id === registrationId)!;
+
+    // Clear cache entries
+    const cache = new SourceCache({ agentDir: env.agentDir });
+    rmSync(cache.entryPath(registration.validationSnapshot!), { recursive: true, force: true });
+    rmSync(cache.metaPath(registration.validationSnapshot!), { force: true });
+
+    const inspection = inspectMarketplaceEntries(registration, 'global', opts);
+    expect(inspection.entries).toHaveLength(0);
+    expect(inspection.findings.some((f) => f.code === CODE.SOURCE_REACQUISITION_REQUIRED)).toBe(true);
+
+    const preflight = await preflightPluginInstallation('global', registrationId, '/plugins/0', opts);
+    expect(preflight.ok).toBe(false);
+    if (!preflight.ok && preflight.outcome.status === 'blocked') {
+      expect(preflight.outcome.findings.some((f) => f.code === CODE.SOURCE_REACQUISITION_REQUIRED)).toBe(true);
+    }
+  });
+
+  it('returns SOURCE_DRIFT when cached tree has been tampered with', async () => {
+    const opts = { agentDir: env.agentDir, cwd: env.projectDir };
+    const state = (await readBridgeState('global', opts)).state!;
+    const registration = state.registrations.find((r) => r.id === registrationId)!;
+
+    // Tamper with the cached tree
+    const cache = new SourceCache({ agentDir: env.agentDir });
+    writeFileSync(join(cache.entryPath(registration.validationSnapshot!), 'tampered.txt'), 'tampered');
+
+    const inspection = inspectMarketplaceEntries(registration, 'global', opts);
+    expect(inspection.entries).toHaveLength(0);
+    expect(inspection.findings.some((f) => f.code === CODE.SOURCE_DRIFT)).toBe(true);
+
+    const preflight = await preflightPluginInstallation('global', registrationId, '/plugins/0', opts);
+    expect(preflight.ok).toBe(false);
+    if (!preflight.ok && preflight.outcome.status === 'blocked') {
+      expect(preflight.outcome.findings.some((f) => f.code === CODE.SOURCE_DRIFT)).toBe(true);
+    }
+  });
+
+  it('completes Install Disabled lifecycle for Git Marketplace Plugin', async () => {
+    const opts = { agentDir: env.agentDir, cwd: env.projectDir };
+    const preflight = await preflightPluginInstallation('global', registrationId, '/plugins/0', opts);
+    expect(preflight.ok).toBe(true);
+    if (!preflight.ok) return;
+
+    expect(preflight.preflight.disclosure.plugin.id).toBe(`${registrationId}/acme-marketplace/release-helper`);
+
+    const outcome = await confirmPluginInstallation(preflight.preflight, 'disabled', opts);
+    expect(outcome.status).toBe('completed');
+    if (outcome.status !== 'completed') return;
+
+    expect(outcome.installation.installationState).toBe('disabled');
+    expect(outcome.receipt.summary).toBe('Completed');
+
+    const state = await readBridgeState('global', opts);
+    expect(state.state!.installations).toEqual([
+      expect.objectContaining({
+        id: `global/${registrationId}/acme-marketplace/release-helper`,
+        pluginId: `${registrationId}/acme-marketplace/release-helper`,
+        installationState: 'disabled',
+        registrationId,
+        marketplaceEntryId: `${registrationId}/acme-marketplace/plugins/0`,
+        manifestName: 'release-helper',
+      }),
+    ]);
+  });
+
+  it('completes Install and Enable lifecycle and enables disabled installation for Git Plugin', async () => {
+    const opts = { agentDir: env.agentDir, cwd: env.projectDir };
+    const preflight = await preflightPluginInstallation('global', registrationId, '/plugins/0', opts);
+    expect(preflight.ok).toBe(true);
+    if (!preflight.ok) return;
+
+    // Declined without activation confirmation
+    const declined = await confirmPluginInstallation(preflight.preflight, 'enabled', false, opts);
+    expect(declined.status).toBe('declined');
+
+    // Confirm with activation confirmation
+    const preflight2 = await preflightPluginInstallation('global', registrationId, '/plugins/0', opts);
+    expect(preflight2.ok).toBe(true);
+    if (!preflight2.ok) return;
+
+    const outcome = await confirmPluginInstallation(preflight2.preflight, 'enabled', true, opts);
+    expect(outcome.status).toBe('completed');
+    if (outcome.status !== 'completed') return;
+
+    expect(outcome.installation.installationState).toBe('enabled');
+
+    // Verify projection works with the Git-installed plugin
+    const state = (await readBridgeState('global', opts)).state!;
+    const projectState = (await readBridgeState('project', opts)).state!;
+    const projection = projectEffectiveState(state, projectState, { ...opts, projectTrusted: true });
+    expect(projection.plugins.map((p) => p.pluginId)).toEqual([`${registrationId}/acme-marketplace/release-helper`]);
+    expect(projection.plugins[0]?.skills).toHaveLength(1);
+    expect(projection.plugins[0]?.skills[0]?.name).toBe('release-notes');
+
+    // Disable plugin
+    const disabled = await disablePluginInstallation('global', outcome.installation.id, opts);
+    expect(disabled.status).toBe('completed');
+    if (disabled.status !== 'completed') return;
+    expect(disabled.installation.installationState).toBe('disabled');
+
+    // Re-enable plugin via preflightPluginEnable + confirmPluginEnable
+    const enablePreflight = await preflightPluginEnable('global', outcome.installation.id, opts);
+    expect(enablePreflight.ok).toBe(true);
+    if (!enablePreflight.ok) return;
+
+    const enabled = await confirmPluginEnable(enablePreflight.preflight, true, opts);
+    expect(enabled.status).toBe('completed');
+    if (enabled.status !== 'completed') return;
+    expect(enabled.installation.installationState).toBe('enabled');
+  });
+});

--- a/tests/unit/cache/source-cache.test.ts
+++ b/tests/unit/cache/source-cache.test.ts
@@ -164,6 +164,29 @@ describe('SourceCache (Git-only, fingerprint-addressed)', () => {
     expect(pinned).toEqual(new Set([FP_A, FP_B, FP_C]));
   });
 
+  it('serves an exact-fingerprint hit synchronously with hitExactSync', async () => {
+    const src = makeTree(join(root, 'src'));
+    await cache.storeTree(src, FP_A);
+
+    const hit = cache.hitExactSync(FP_A);
+    expect(hit).not.toBeNull();
+    expect(hit!.fingerprint).toBe(FP_A);
+    expect(existsSync(join(hit!.path, 'file.txt'))).toBe(true);
+
+    expect(cache.hitExactSync(FP_B)).toBeNull();
+    expect(cache.hitExactSync('not-a-fingerprint')).toBeNull();
+  });
+
+  it('serializes synchronous operations with withFingerprintLockSync', () => {
+    let ran = false;
+    const res = cache.withFingerprintLockSync(FP_A, () => {
+      ran = true;
+      return 42;
+    });
+    expect(ran).toBe(true);
+    expect(res).toBe(42);
+  });
+
   it('exposes the production budget constant at 2 GiB', () => {
     expect(CACHE_TOTAL_BUDGET_BYTES).toBe(2 * 1024 * 1024 * 1024);
   });


### PR DESCRIPTION
Closes #34

## What

接合 Git Marketplace 註冊與 `SourceCache` 定址快取，支援 Git Marketplace 的 Plugin 檢驗（Inspection）、TUI 條目呈現、安裝（`Install Disabled` / `Install and Enable`）與啟用（Enable）生命週期，並於快取遺失或指紋漂移時精確回傳失敗封閉 Finding。

## How

1. **Inspection (`src/installation/inspection.ts`)**：
   - 支援 `registration.sourceKind === 'git'`。
   - 透過 `SourceCache`（支援傳入 `opts.cache` 或以 `opts.agentDir` 初始化）依 `registration.validationSnapshot` 取得快取目錄。
   - 透過 `buildGitSnapshot` 驗證快照 fingerprint 是否相符。
   - 快取未命中時回傳 `SOURCE_REACQUISITION_REQUIRED` Blocking Finding；快取受損或竄改導致指紋不符時回傳 `SOURCE_DRIFT` Blocking Finding。
   - 規範化路徑解析（`realpathSync.native`），確保 macOS / symlink 環境下的 Contained Path 驗證一致。
   - 對快取目錄正常解析 catalog 並分類 Plugin。
2. **Installation Flow (`src/installation/flow.ts`)**：
   - 移除 `registration.sourceKind !== 'local'` 限制。
   - `InstallationFlowOptions` 支援 `cache` 選項，並於 preflight 與 confirmation 時傳遞 `agentDir` 與 `cache` 至 `inspectMarketplaceEntries`。
3. **SourceCache (`src/cache/source-cache.ts`)**：
   - 提供 `hitExactSync` 與 `withFingerprintLockSync` 支援同步檢驗路徑。
4. **Projection & TUI (`src/projection/project.ts`, `extensions/pi/installation.ts`)**：
   - `projectEffectiveState` 與 `entryChoices` 正確傳遞 `agentDir` / `cache` 選項，使 Git Marketplace Plugin 可在 TUI 正確顯示為「可安裝」並完成技能投影。
5. **測試覆蓋**：
   - 新增 `tests/integration/installation-git.test.ts` 完整覆蓋 Git Marketplace Plugin 檢驗、`entryChoices` TUI 格式化、快取遺失（`SOURCE_REACQUISITION_REQUIRED`）、快取竄改（`SOURCE_DRIFT`）、`Install Disabled`、`Install and Enable`、`disable`、`enable` 及投影。
   - 新增 `tests/unit/cache/source-cache.test.ts` 中 `hitExactSync` 與 `withFingerprintLockSync` 單元測試。

## Checks

- [x] `npx tsc --noEmit` 綠（零型別錯誤）
- [x] `npm test` 綠（41 test files / 330 tests 全數通過）
- [x] Git Marketplace 檢驗能正確讀取 SourceCache 並回傳條目清單與可用狀態
- [x] TUI 條目清單正確顯示 Git Marketplace Plugin 為「可安裝」
- [x] `preflightPluginInstallation` 與 `confirmPluginInstallation` 支援 Git Marketplace Plugin
- [x] 快取遺失與受損正確產生 `SOURCE_REACQUISITION_REQUIRED` 與 `SOURCE_DRIFT` Blocking Finding