### PR TITLE
feat: panelize /codex-marketplace TUI shell with host theme semantic tokens

### DIFF
--- a/extensions/pi/bridge-ledger.ts
+++ b/extensions/pi/bridge-ledger.ts
@@ -34,11 +34,11 @@ import type { ValidationFinding } from '../../src/registration/findings.js';
 import type { AttemptReceipt } from '../../src/registration/receipt.js';
 import {
   fitTerminalLine,
-  padTerminalLine,
   quoteTerminalText,
   renderBadge,
   renderPanel,
   renderSelectableRow,
+  renderSideBySidePanels,
 } from './terminal-presentation.js';
 
 export type LedgerSectionId =
@@ -969,26 +969,23 @@ export class BridgeLedgerComponent implements Component {
         }),
       ];
     }
-    const gutter = '  ';
-    const leftWidth = Math.max(24, Math.floor((width - gutter.length) / 2));
-    const rightWidth = Math.max(24, width - gutter.length - leftWidth);
-    const leftFrame = renderPanel(this.theme, {
-      title: this.model.rails.global.label,
-      lines: this.railContentLines('global', leftWidth - 3),
-      width: leftWidth,
-      borderToken: 'borderMuted',
+    const leftWidth = Math.max(24, Math.floor((width - 2) / 2));
+    const rightWidth = Math.max(24, width - 2 - leftWidth);
+    return renderSideBySidePanels(this.theme, {
+      left: {
+        title: this.model.rails.global.label,
+        lines: this.railContentLines('global', leftWidth - 3),
+        width: leftWidth,
+        borderToken: 'borderMuted',
+      },
+      right: {
+        title: this.model.rails.project.label,
+        lines: this.railContentLines('project', rightWidth - 3),
+        width: rightWidth,
+        borderToken: 'borderAccent',
+      },
+      totalWidth: width,
     });
-    const rightFrame = renderPanel(this.theme, {
-      title: this.model.rails.project.label,
-      lines: this.railContentLines('project', rightWidth - 3),
-      width: rightWidth,
-      borderToken: 'borderAccent',
-    });
-    const height = Math.max(leftFrame.length, rightFrame.length);
-    return Array.from({ length: height }, (_, index) =>
-      padTerminalLine(leftFrame[index] ?? '', leftWidth) +
-      gutter +
-      padTerminalLine(rightFrame[index] ?? '', rightWidth));
   }
 
   private railBadge(scope: Scope): string {
@@ -1040,28 +1037,26 @@ export class BridgeLedgerComponent implements Component {
   private wideWorkspace(width: number): string[] {
     const navWidth = Math.min(34, Math.max(22, Math.floor(width * 0.28)));
     const detailWidth = Math.max(24, width - navWidth - 2);
-    const navFrame = renderPanel(this.theme, {
-      title: 'Navigation',
-      lines: this.sectionNavLines(navWidth - 3),
-      width: navWidth,
-      borderToken: 'borderMuted',
-    });
     const section = this.currentSection();
-    const detailContent = [
-      this.fit(section.description, detailWidth - 3, 'dim'),
-      '',
-      ...this.actionEntryLines(detailWidth - 3),
-    ];
-    const detailFrame = renderPanel(this.theme, {
-      title: section.label,
-      lines: detailContent,
-      width: detailWidth,
-      borderToken: 'borderAccent',
+    return renderSideBySidePanels(this.theme, {
+      left: {
+        title: 'Navigation',
+        lines: this.sectionNavLines(navWidth - 3),
+        width: navWidth,
+        borderToken: 'borderMuted',
+      },
+      right: {
+        title: section.label,
+        lines: [
+          this.fit(section.description, detailWidth - 3, 'dim'),
+          '',
+          ...this.actionEntryLines(detailWidth - 3),
+        ],
+        width: detailWidth,
+        borderToken: 'borderAccent',
+      },
+      totalWidth: width,
     });
-    const height = Math.max(navFrame.length, detailFrame.length);
-    return Array.from({ length: height }, (_, index) =>
-      padTerminalLine(navFrame[index] ?? '', navWidth) + '  ' +
-      padTerminalLine(detailFrame[index] ?? '', detailWidth));
   }
 
   private drilldownWorkspace(width: number): string[] {

--- a/extensions/pi/bridge-ledger.ts
+++ b/extensions/pi/bridge-ledger.ts
@@ -7,7 +7,7 @@
  */
 
 import type { Theme } from '@earendil-works/pi-coding-agent';
-import { Key, matchesKey, type Component, type TUI } from '@earendil-works/pi-tui';
+import { Key, matchesKey, wrapTextWithAnsi, type Component, type TUI } from '@earendil-works/pi-tui';
 
 import { checkGlobalPendingBarrier, type GlobalBarrierStatus } from '../../src/barrier/global-barrier.js';
 import { readBothStates } from '../../src/bridge-state/store.js';
@@ -36,6 +36,9 @@ import {
   fitTerminalLine,
   padTerminalLine,
   quoteTerminalText,
+  renderBadge,
+  renderPanel,
+  renderSelectableRow,
 } from './terminal-presentation.js';
 
 export type LedgerSectionId =
@@ -762,6 +765,21 @@ export function buildBridgeLedgerModel(snapshot: BridgeLedgerSnapshot): BridgeLe
 
 // The custom component is added below the presentation model so callers can use the
 // pure buildBridgeLedgerModel seam independently of Pi's runtime objects.
+
+/** Widths at or above this breakpoint render the two-column panel workspace. */
+const WIDE_WORKSPACE_WIDTH = 96;
+
+const HEALTH_BADGES: Record<LedgerHealth, { tone: 'success' | 'warning' | 'error'; label: string }> = {
+  healthy: { tone: 'success', label: 'HEALTHY' },
+  incompatible: { tone: 'error', label: 'INCOMPATIBLE' },
+  indeterminate: { tone: 'warning', label: 'INDETERMINATE' },
+};
+
+const AVAILABILITY = {
+  ready: { icon: '\u25cf', token: 'success', word: 'Ready' },
+  blocked: { icon: '\u25cb', token: 'warning', word: 'Blocked' },
+} as const;
+
 export class BridgeLedgerComponent implements Component {
   private readonly model: BridgeLedgerModel;
   private readonly theme: Theme;
@@ -771,7 +789,10 @@ export class BridgeLedgerComponent implements Component {
   private rowIndex = 0;
   private browseFocus: Scope = 'global';
   private helpVisible = false;
-  private narrowDetail = false;
+  /** Single-column drill-down state for sub-96-column workspaces. */
+  private sectionDetail = false;
+  /** Expanded metadata layer for the selected entry; never consulted by dispatch. */
+  private metadataExpanded = false;
   private lastWidth = 80;
 
   constructor(
@@ -799,64 +820,75 @@ export class BridgeLedgerComponent implements Component {
     if (matchesKey(data, Key.escape)) {
       if (this.helpVisible) {
         this.helpVisible = false;
-        this.tui.requestRender();
-      } else if (this.lastWidth < 64 && this.narrowDetail) {
-        this.narrowDetail = false;
+      } else if (this.metadataExpanded) {
+        this.metadataExpanded = false;
+      } else if (this.lastWidth < WIDE_WORKSPACE_WIDTH && this.sectionDetail) {
+        this.sectionDetail = false;
         this.rowIndex = 0;
-        this.tui.requestRender();
       } else {
         this.onDone(undefined);
+        return;
       }
+      this.tui.requestRender();
       return;
     }
+    if (this.helpVisible) return;
+
     if (matchesKey(data, 'g') || matchesKey(data, 'p')) {
       const nextFocus: Scope = matchesKey(data, 'g') ? 'global' : 'project';
       if (nextFocus !== this.browseFocus) {
         this.browseFocus = nextFocus;
         this.rowIndex = 0;
+        this.metadataExpanded = false;
         this.tui.requestRender();
       }
       return;
     }
-    if (this.helpVisible) return;
+    if (matchesKey(data, 'i')) {
+      this.metadataExpanded = !this.metadataExpanded;
+      this.tui.requestRender();
+      return;
+    }
 
-    const narrowSections = this.lastWidth < 64 && !this.narrowDetail;
+    const wide = this.lastWidth >= WIDE_WORKSPACE_WIDTH;
     if (matchesKey(data, Key.right)) {
-      if (this.lastWidth < 64) {
-        if (!this.narrowDetail) {
-          this.narrowDetail = true;
-          this.rowIndex = 0;
-          this.tui.requestRender();
-        }
-      } else {
+      if (!wide && !this.sectionDetail) {
+        this.sectionDetail = true;
+        this.rowIndex = 0;
+        this.metadataExpanded = false;
+        this.tui.requestRender();
+      } else if (wide) {
         this.moveSection(1);
       }
       return;
     }
     if (matchesKey(data, Key.left)) {
-      if (this.lastWidth < 64 && this.narrowDetail) {
-        this.narrowDetail = false;
+      if (!wide && this.sectionDetail) {
+        this.sectionDetail = false;
         this.rowIndex = 0;
+        this.metadataExpanded = false;
         this.tui.requestRender();
-      } else if (this.lastWidth >= 64) {
+      } else if (wide) {
         this.moveSection(-1);
       }
       return;
     }
+    const listView = !wide && !this.sectionDetail;
     if (matchesKey(data, 'j') || matchesKey(data, Key.down)) {
-      if (narrowSections) this.moveSection(1);
+      if (listView) this.moveSection(1);
       else this.moveRow(1);
       return;
     }
     if (matchesKey(data, 'k') || matchesKey(data, Key.up)) {
-      if (narrowSections) this.moveSection(-1);
+      if (listView) this.moveSection(-1);
       else this.moveRow(-1);
       return;
     }
     if (matchesKey(data, Key.enter)) {
-      if (narrowSections) {
-        this.narrowDetail = true;
+      if (listView) {
+        this.sectionDetail = true;
         this.rowIndex = 0;
+        this.metadataExpanded = false;
         this.tui.requestRender();
         return;
       }
@@ -872,13 +904,20 @@ export class BridgeLedgerComponent implements Component {
 
   render(width: number): string[] {
     this.lastWidth = Math.max(1, Math.floor(width));
-    const out = this.authorityHeader(this.lastWidth);
+    const out = [
+      this.fit('CODEX MARKETPLACE / BRIDGE LEDGER', this.lastWidth, 'accent'),
+      ...this.railPanels(this.lastWidth),
+    ];
     if (this.helpVisible) {
-      out.push(...this.helpLines(this.lastWidth));
-    } else if (this.lastWidth >= 64) {
+      out.push(...renderPanel(this.theme, {
+        title: 'Help',
+        lines: this.helpLines().map((line) => this.fit(line, Math.max(1, this.lastWidth - 3), 'text')),
+        width: this.lastWidth,
+      }));
+    } else if (this.lastWidth >= WIDE_WORKSPACE_WIDTH) {
       out.push(...this.wideWorkspace(this.lastWidth));
     } else {
-      out.push(...this.narrowWorkspace(this.lastWidth));
+      out.push(...this.drilldownWorkspace(this.lastWidth));
     }
     out.push(this.fit(this.statusText(), this.lastWidth, 'dim'));
     out.push(this.fit(this.keyHints(), this.lastWidth, 'dim'));
@@ -895,6 +934,7 @@ export class BridgeLedgerComponent implements Component {
     if (count === 0) return;
     this.sectionIndex = (this.sectionIndex + delta + count) % count;
     this.rowIndex = 0;
+    this.metadataExpanded = false;
     this.tui.requestRender();
   }
 
@@ -902,6 +942,7 @@ export class BridgeLedgerComponent implements Component {
     const count = this.actionEntries().length;
     if (count === 0) return;
     this.rowIndex = (this.rowIndex + delta + count) % count;
+    this.metadataExpanded = false;
     this.tui.requestRender();
   }
 
@@ -909,117 +950,206 @@ export class BridgeLedgerComponent implements Component {
     return fitTerminalLine(this.theme.fg(token, text), width);
   }
 
-  private authorityHeader(width: number): string[] {
-    const global = this.model.rails.global;
-    const project = this.model.rails.project;
-    const globalLine = width < 96
-      ? `G rev ${quoteTerminalText(global.revision)} | reg ${global.registrationCount} | ` +
-        `inst ${global.installationEnabledCount} on/${global.installationDisabledCount} off | health ${global.health}`
-      : `G rev ${quoteTerminalText(global.revision)} | registrations ${global.registrationCount} | ` +
-        `installations ${global.installationEnabledCount} enabled/${global.installationDisabledCount} disabled | ` +
-        `health ${global.health}: ${quoteTerminalText(global.healthText)}`;
-    const projectLine = width < 96
-      ? `P rev ${quoteTerminalText(project.revision)} | reg ${project.registrationCount} | ` +
-        `inst ${project.installationEnabledCount} on/${project.installationDisabledCount} off | ` +
-        `ovr ${project.overrideCount} | health ${project.health}`
-      : `P rev ${quoteTerminalText(project.revision)} | registrations ${project.registrationCount} | ` +
-        `installations ${project.installationEnabledCount} enabled/${project.installationDisabledCount} disabled | ` +
-        `overrides ${project.overrideCount} | health ${project.health}: ${quoteTerminalText(project.healthText)}`;
-    const barrier = this.model.barrier.active
-      ? `Barrier: ACTIVE ${quoteTerminalText(this.model.barrier.text)}`
-      : 'Barrier: Clear';
-    return [
-      this.fit('CODEX MARKETPLACE / BRIDGE LEDGER', width, 'accent'),
-      this.fit(globalLine, width, global.health === 'healthy' ? 'text' : 'error'),
-      this.fit(projectLine, width, project.health === 'healthy' ? 'text' : 'error'),
-      this.fit(project.trustText, width, this.model.projectTrusted ? 'success' : 'warning'),
-      this.fit(barrier, width, this.model.barrier.active ? 'warning' : 'success'),
-    ];
+  // --- Authority rails -----------------------------------------------------
+
+  private railPanels(width: number): string[] {
+    if (width < WIDE_WORKSPACE_WIDTH) {
+      return [
+        ...renderPanel(this.theme, {
+          title: this.model.rails.global.label,
+          lines: this.railContentLines('global', width - 3),
+          width,
+          borderToken: 'borderMuted',
+        }),
+        ...renderPanel(this.theme, {
+          title: this.model.rails.project.label,
+          lines: this.railContentLines('project', width - 3),
+          width,
+          borderToken: 'borderAccent',
+        }),
+      ];
+    }
+    const gutter = '  ';
+    const leftWidth = Math.max(24, Math.floor((width - gutter.length) / 2));
+    const rightWidth = Math.max(24, width - gutter.length - leftWidth);
+    const leftFrame = renderPanel(this.theme, {
+      title: this.model.rails.global.label,
+      lines: this.railContentLines('global', leftWidth - 3),
+      width: leftWidth,
+      borderToken: 'borderMuted',
+    });
+    const rightFrame = renderPanel(this.theme, {
+      title: this.model.rails.project.label,
+      lines: this.railContentLines('project', rightWidth - 3),
+      width: rightWidth,
+      borderToken: 'borderAccent',
+    });
+    const height = Math.max(leftFrame.length, rightFrame.length);
+    return Array.from({ length: height }, (_, index) =>
+      padTerminalLine(leftFrame[index] ?? '', leftWidth) +
+      gutter +
+      padTerminalLine(rightFrame[index] ?? '', rightWidth));
   }
 
-  private helpLines(width: number): string[] {
-    return [
-      this.fit('Help', width, 'accent'),
-      this.fit('Up/Down or j/k: move selection', width),
-      this.fit('Left/Right: change section in wide layout', width),
-      this.fit('Enter: open section or activate available structured action', width),
-      this.fit('g/p: browse Global/Project only; mutation authority remains explicit', width),
-      this.fit('Esc: back/cancel | q or Ctrl-C: exit | ?: close help', width),
-    ];
+  private railBadge(scope: Scope): string {
+    const rail = scope === 'global' ? this.model.rails.global : this.model.rails.project;
+    const badges = [renderBadge(this.theme, HEALTH_BADGES[rail.health].tone, HEALTH_BADGES[rail.health].label)];
+    if (scope === 'project') {
+      badges.push(renderBadge(
+        this.theme,
+        this.model.projectTrusted ? 'success' : 'warning',
+        this.model.projectTrusted ? 'TRUST GRANTED' : 'NO PROJECT TRUST',
+      ));
+    } else {
+      badges.push(renderBadge(this.theme, this.model.barrier.active ? 'error' : 'success',
+        this.model.barrier.active ? 'BARRIER ACTIVE' : 'BARRIER CLEAR'));
+    }
+    return badges.join(' ');
   }
 
-  private wideWorkspace(width: number): string[] {
-    const separator = this.theme.fg('borderMuted', ' | ');
-    const navWidth = Math.min(30, Math.max(20, Math.floor(width * 0.28)));
-    const detailWidth = Math.max(1, width - navWidth - 3);
-    const nav = [
-      this.theme.fg('accent', 'Navigation'),
-      ...this.model.sections.map((section, index) =>
-        this.theme.fg(index === this.sectionIndex ? 'accent' : 'text',
-          `${index === this.sectionIndex ? '>' : ' '} ${section.label}`)),
+  private railContentLines(scope: Scope, width: number): string[] {
+    const rail = scope === 'global' ? this.model.rails.global : this.model.rails.project;
+    const marker = scope === 'global' ? 'G' : 'P';
+    const fitDim = (text: string): string => this.fit(text, width, 'dim');
+    const lines = [
+      this.railBadge(scope),
+      `${marker} rev ${quoteTerminalText(rail.revision)}`,
+      `registrations ${rail.registrationCount}`,
+      `installations ${rail.installationEnabledCount} enabled / ${rail.installationDisabledCount} disabled`,
     ];
-    const section = this.currentSection();
-    const detail = [
-      this.theme.fg('accent', section.label),
-      this.theme.fg('dim', section.description),
-      ...this.actionLines(section),
-    ];
-    const height = Math.max(nav.length, detail.length);
-    const lines: string[] = [];
-    for (let index = 0; index < height; index++) {
-      const left = padTerminalLine(nav[index] ?? '', navWidth);
-      const right = fitTerminalLine(detail[index] ?? '', detailWidth);
-      lines.push(fitTerminalLine(left + separator + right, width));
+    if (scope === 'project') lines.push(`overrides ${rail.overrideCount}`);
+    if (rail.health !== 'healthy') lines.push(fitDim(quoteTerminalText(rail.healthText)));
+    if (scope === 'project') lines.push(fitDim(rail.trustText));
+    if (scope === 'global' && this.model.barrier.active) {
+      lines.push(this.fit(`\u21b3 Barrier reason: ${quoteTerminalText(this.model.barrier.text)}`, width, 'warning'));
     }
     return lines;
   }
 
-  private narrowWorkspace(width: number): string[] {
-    if (!this.narrowDetail) {
-      return [
-        this.fit('Sections', width, 'accent'),
-        ...this.model.sections.map((section, index) =>
-          this.fit(`${index === this.sectionIndex ? '>' : ' '} ${section.label}`, width,
-            index === this.sectionIndex ? 'accent' : 'text')),
-      ];
-    }
-    const section = this.currentSection();
-    return [
-      this.fit(`Section: ${section.label}`, width, 'accent'),
-      this.fit(section.description, width, 'dim'),
-      ...this.actionLines(section).map((line) => fitTerminalLine(line, width)),
-    ];
+  // --- Workspaces ----------------------------------------------------------
+
+  private sectionNavLines(width: number): string[] {
+    return this.model.sections.map((section, index) =>
+      renderSelectableRow(this.theme, {
+        selected: index === this.sectionIndex,
+        text: this.theme.fg(index === this.sectionIndex ? 'accent' : 'text', section.label),
+        width,
+      }));
   }
 
-  private actionLines(section: LedgerSection): string[] {
-    const rows = this.visibleRows(section);
-    if (rows.length === 0) return [this.theme.fg('muted', 'No rows in this section')];
+  private wideWorkspace(width: number): string[] {
+    const navWidth = Math.min(34, Math.max(22, Math.floor(width * 0.28)));
+    const detailWidth = Math.max(24, width - navWidth - 2);
+    const navFrame = renderPanel(this.theme, {
+      title: 'Navigation',
+      lines: this.sectionNavLines(navWidth - 3),
+      width: navWidth,
+      borderToken: 'borderMuted',
+    });
+    const section = this.currentSection();
+    const detailContent = [
+      this.fit(section.description, detailWidth - 3, 'dim'),
+      '',
+      ...this.actionEntryLines(detailWidth - 3),
+    ];
+    const detailFrame = renderPanel(this.theme, {
+      title: section.label,
+      lines: detailContent,
+      width: detailWidth,
+      borderToken: 'borderAccent',
+    });
+    const height = Math.max(navFrame.length, detailFrame.length);
+    return Array.from({ length: height }, (_, index) =>
+      padTerminalLine(navFrame[index] ?? '', navWidth) + '  ' +
+      padTerminalLine(detailFrame[index] ?? '', detailWidth));
+  }
+
+  private drilldownWorkspace(width: number): string[] {
+    if (!this.sectionDetail) {
+      return renderPanel(this.theme, {
+        title: 'Sections',
+        lines: this.sectionNavLines(Math.max(1, width - 3)),
+        width,
+        borderToken: 'borderAccent',
+      });
+    }
+    const section = this.currentSection();
+    return renderPanel(this.theme, {
+      title: section.label,
+      lines: [
+        this.fit(section.description, Math.max(1, width - 3), 'dim'),
+        '',
+        ...this.actionEntryLines(Math.max(1, width - 3)),
+      ],
+      width,
+      borderToken: 'borderAccent',
+    });
+  }
+
+  // --- Action entries ------------------------------------------------------
+
+  /**
+   * Renders every visible row in the panel visual language: availability is an
+   * icon+token+word state, selection combines a background wash with a text
+   * cursor, and structured field dumps live only in the expandable metadata layer.
+   */
+  private actionEntryLines(width: number): string[] {
+    const rows = this.visibleRows();
+    if (rows.length === 0) return [this.fit('No rows in this section', width, 'muted')];
     let actionIndex = 0;
-    return rows.flatMap((row) => {
+    const lines: string[] = [];
+    for (const row of rows) {
       if (row.actions.length === 0) {
-        return [
-          this.theme.fg('warning', `  [Unavailable] ${quoteTerminalText(row.label)}`),
-          this.theme.fg('dim',
-            `  detail ${quoteTerminalText(row.detail ?? '(none)')} | target ${row.targetKind ?? 'none'} ` +
-            `${quoteTerminalText(row.targetId ?? '(none)')} | scope ${row.scope ?? 'none'} | actions none`),
-        ];
+        lines.push(
+          this.fit(`${AVAILABILITY.blocked.icon} Unavailable \u00b7 ${quoteTerminalText(row.label)}`, width, 'warning'),
+          this.fit(`   ${quoteTerminalText(row.detail ?? '(no findings reported)')}`, width, 'dim'),
+        );
+        continue;
       }
-      return row.actions.flatMap((action) => {
+      for (const action of row.actions) {
         const selected = actionIndex === this.rowIndex;
         actionIndex += 1;
-        const availabilityText = action.enabled
-          ? 'available'
-          : `disabled: ${quoteTerminalText(action.disabledReason ?? 'unavailable')}`;
-        return [
-          this.theme.fg(selected ? 'accent' : 'text',
-            `${selected ? '>' : ' '} [${availabilityText}] ${action.label} / ${quoteTerminalText(row.label)}`),
-          this.theme.fg('dim',
-            `  detail ${quoteTerminalText(row.detail ?? '(none)')} | target ${action.intent.targetKind ?? 'none'} ` +
-            `${quoteTerminalText(action.intent.targetId ?? '(none)')} | scope ${action.intent.scope ?? 'none'} | ` +
-            `mode ${action.intent.mode}`),
-        ];
-      });
-    });
+        const availability = action.enabled ? AVAILABILITY.ready : AVAILABILITY.blocked;
+        const text =
+          this.theme.fg(availability.token, `${availability.icon} ${availability.word} ${action.label}`) +
+          this.theme.fg('dim', ` \u00b7 ${quoteTerminalText(row.label)}`);
+        lines.push(renderSelectableRow(this.theme, { selected, text, width }));
+        if (!selected) continue;
+        if (!action.enabled) {
+          lines.push(...this.wrapContext(
+            `\u21b3 Blocked: ${quoteTerminalText(action.disabledReason ?? 'unavailable')}`,
+            width, 'warning', 4));
+        }
+        if (this.metadataExpanded) {
+          const intent = action.intent;
+          const meta = [
+            `target ${intent.targetKind ?? row.targetKind ?? 'none'} ` +
+              quoteTerminalText(intent.targetId ?? row.targetId ?? '(none)'),
+            `scope ${intent.scope ?? row.scope ?? 'none'}`,
+            `mode ${intent.mode}`,
+          ];
+          if (row.detail !== undefined) meta.push(`detail ${quoteTerminalText(row.detail)}`);
+          lines.push(...meta.flatMap((entry) => this.wrapContext(`  ${entry}`, width, 'muted', 4)));
+        }
+      }
+    }
+    return lines;
+  }
+
+  private wrapContext(text: string, width: number, token: Parameters<Theme['fg']>[0], maxLines: number): string[] {
+    const wrapped = wrapTextWithAnsi(this.theme.fg(token, text), Math.max(1, width)).slice(0, maxLines);
+    return wrapped.map((line) => fitTerminalLine(line, width));
+  }
+
+  private helpLines(): string[] {
+    return [
+      'Up/Down or j/k: move selection',
+      'Left/Right: change section (wide layout) or drill down',
+      'Enter: open section or activate available structured action',
+      'i: expand or collapse the selected entry metadata',
+      'g/p: browse Global/Project only; mutation authority remains explicit',
+      'Esc: back/cancel | q or Ctrl-C: exit | ?: close help',
+    ];
   }
 
   private visibleRows(section = this.currentSection()): LedgerObjectRow[] {
@@ -1042,15 +1172,15 @@ export class BridgeLedgerComponent implements Component {
 
   private statusText(): string {
     const section = this.currentSection();
-    const pane = this.lastWidth < 64 && !this.narrowDetail ? 'sections' : 'actions';
+    const pane = this.lastWidth >= WIDE_WORKSPACE_WIDTH || this.sectionDetail ? 'actions' : 'sections';
     return `Status: browsing ${this.browseFocus === 'global' ? 'G' : 'P'} | ${section.label} | ${pane}`;
   }
 
   private keyHints(): string {
     if (this.helpVisible) return 'Keys: ?/Esc close help | q/Ctrl-C exit | Esc/q cancel context';
-    if (this.lastWidth < 64 && !this.narrowDetail) {
-      return 'Keys: Esc/q cancel | Enter drill down | j/k move | g/p | ?';
+    if (this.lastWidth < WIDE_WORKSPACE_WIDTH && !this.sectionDetail) {
+      return 'Keys: Esc/q cancel | Enter drill down | j/k move | g/p | ? help';
     }
-    return 'Keys: Esc/q cancel | Enter activate | j/k or arrows move | g/p browse | ? help';
+    return 'Keys: Esc/q cancel | Enter activate | j/k or arrows move | i details | g/p browse | ? help';
   }
 }

--- a/extensions/pi/index.ts
+++ b/extensions/pi/index.ts
@@ -44,6 +44,7 @@ import { renderTransactionSheet } from './transaction-sheet.js';
 
 const STARTUP_RECEIPT_THEME = {
   fg: (_color: string, text: string) => text,
+  bg: (_token: string, text: string) => text,
   bold: (text: string) => text,
 };
 

--- a/extensions/pi/terminal-presentation.ts
+++ b/extensions/pi/terminal-presentation.ts
@@ -89,6 +89,30 @@ export function renderBadge(theme: PresentationTheme, tone: BadgeTone, label: st
   );
 }
 
+/**
+ * Renders two framed panels side by side inside `totalWidth`, equalizing their
+ * heights by padding the shorter content so both frames bottom-align.
+ */
+export function renderSideBySidePanels(
+  theme: PresentationTheme,
+  options: { left: PanelOptions; right: PanelOptions; totalWidth: number; gutter?: string },
+): string[] {
+  const gutter = options.gutter ?? '  ';
+  const leftWidth = Math.max(3, Math.floor(options.left.width));
+  const rightWidth = Math.max(3, options.totalWidth - gutter.length - leftWidth);
+  const height = Math.max(options.left.lines.length, options.right.lines.length);
+  const padToHeight = (lines: string[]): string[] => [
+    ...lines,
+    ...Array.from({ length: height - lines.length }, () => ''),
+  ];
+  const leftFrame = renderPanel(theme, { ...options.left, lines: padToHeight(options.left.lines), width: leftWidth });
+  const rightFrame = renderPanel(theme, { ...options.right, lines: padToHeight(options.right.lines), width: rightWidth });
+  return Array.from({ length: Math.max(leftFrame.length, rightFrame.length) }, (_, index) =>
+    padTerminalLine(leftFrame[index] ?? '', leftWidth) +
+    gutter +
+    padTerminalLine(rightFrame[index] ?? '', rightWidth));
+}
+
 export interface SelectableRowOptions {
   selected: boolean;
   /** Pre-styled row text (may already contain theme sequences). */

--- a/extensions/pi/terminal-presentation.ts
+++ b/extensions/pi/terminal-presentation.ts
@@ -1,4 +1,11 @@
+import type { Theme, ThemeColor } from '@earendil-works/pi-coding-agent';
 import { truncateToWidth, visibleWidth } from '@earendil-works/pi-tui';
+
+/** Structural theme surface used by the presentation contracts; host Pi Theme satisfies it. */
+export type PresentationTheme = Pick<Theme, 'fg' | 'bg' | 'bold'>;
+
+/** Background token vocabulary accepted by Theme.bg. */
+type ThemeBgToken = Parameters<Theme['bg']>[0];
 
 export function quoteTerminalText(value: unknown): string {
   return JSON.stringify(String(value)).replace(
@@ -15,4 +22,92 @@ export function padTerminalLine(text: string, width: number): string {
   const terminalWidth = Math.max(0, Math.floor(width));
   const fitted = fitTerminalLine(text, terminalWidth);
   return fitted + ' '.repeat(Math.max(0, terminalWidth - visibleWidth(fitted)));
+}
+
+export interface PanelOptions {
+  /** Optional panel title rendered into the top border. */
+  title?: string;
+  /** Pre-styled content lines; each is width-safe padded inside the frame. */
+  lines: string[];
+  /** Total terminal columns including the two border columns. */
+  width: number;
+  /** Frame token; defaults to border so panels read as primary containers. */
+  borderToken?: Extract<ThemeColor, 'border' | 'borderAccent' | 'borderMuted'>;
+}
+
+/**
+ * Draws a box-drawing panel (`┌─ Title ─┐ … └──────┘`) exactly `width` columns wide.
+ * Borders and the title are styled with theme tokens only; content lines keep their own styling.
+ */
+export function renderPanel(theme: PresentationTheme, options: PanelOptions): string[] {
+  const width = Math.max(0, Math.floor(options.width));
+  const border = options.borderToken ?? 'border';
+  const frame = (text: string): string => theme.fg(border, text);
+  if (width < 3) {
+    return [padTerminalLine(options.lines.join(''), width)];
+  }
+  const innerWidth = width - 2;
+  let topFill = innerWidth;
+  let titleCell = '';
+  if (options.title !== undefined && innerWidth >= 4) {
+    titleCell = fitTerminalLine(` ${String(options.title)} `, innerWidth - 2);
+    topFill = innerWidth - visibleWidth(titleCell) - 1;
+  }
+  const lines = [
+    frame('┌') + frame('─') + theme.fg('accent', theme.bold(titleCell)) + frame('─'.repeat(Math.max(0, topFill))) + frame('┐'),
+    ...options.lines.map((line) => frame('│') + ' ' + padTerminalLine(line, innerWidth - 1) + frame('│')),
+    frame('└') + frame('─'.repeat(innerWidth)) + frame('┘'),
+  ];
+  return lines.map((line) => truncateToWidth(line, width));
+}
+
+/** Semantic badge tones mapped onto existing host background tokens. */
+export type BadgeTone = 'success' | 'warning' | 'error' | 'neutral';
+
+const BADGE_BG_TOKENS: Record<BadgeTone, ThemeBgToken> = {
+  success: 'toolSuccessBg',
+  warning: 'toolPendingBg',
+  error: 'toolErrorBg',
+  neutral: 'userMessageBg',
+};
+
+const BADGE_FG_TOKENS: Record<BadgeTone, ThemeColor> = {
+  success: 'success',
+  warning: 'warning',
+  error: 'error',
+  neutral: 'text',
+};
+
+/**
+ * Renders a text-labelled background badge. The label is load-bearing: meaning must
+ * survive without color, so badges always carry their canonical word.
+ */
+export function renderBadge(theme: PresentationTheme, tone: BadgeTone, label: string): string {
+  return theme.bg(
+    BADGE_BG_TOKENS[tone],
+    theme.fg(BADGE_FG_TOKENS[tone], ` ${label} `),
+  );
+}
+
+export interface SelectableRowOptions {
+  selected: boolean;
+  /** Pre-styled row text (may already contain theme sequences). */
+  text: string;
+  width: number;
+  /** Textual cursor glyph; defaults to '>' so selection survives without color. */
+  cursor?: string;
+}
+
+/**
+ * Renders one selectable row. Selected rows combine a full-width selected background
+ * wash with a leading text cursor glyph; unselected rows stay unhighlighted but keep
+ * the cursor column for scanning. The result is exactly `width` columns wide.
+ */
+export function renderSelectableRow(theme: PresentationTheme, options: SelectableRowOptions): string {
+  const cursor = options.cursor ?? '>';
+  const marker = options.selected ? cursor : ' ';
+  const content = `${marker} ${options.text}`;
+  return options.selected
+    ? theme.bg('selectedBg', padTerminalLine(content, Math.max(0, Math.floor(options.width))))
+    : padTerminalLine(content, Math.max(0, Math.floor(options.width)));
 }

--- a/extensions/pi/transaction-sheet.ts
+++ b/extensions/pi/transaction-sheet.ts
@@ -9,8 +9,15 @@ import {
 
 import type { Scope } from '../../src/bridge-state/types.js';
 import { sortFindings } from '../../src/registration/findings.js';
-import type { AttemptReceipt } from '../../src/registration/receipt.js';
-import { padTerminalLine, quoteTerminalText } from './terminal-presentation.js';
+import type { AttemptReceipt, AttemptSummary } from '../../src/registration/receipt.js';
+import {
+  padTerminalLine,
+  quoteTerminalText,
+  renderBadge,
+  renderPanel,
+  type BadgeTone,
+  type PresentationTheme,
+} from './terminal-presentation.js';
 
 export const TRANSACTION_STEPS = ['Intent', 'Validation', 'Consent', 'Plan', 'Commit', 'Receipt'] as const;
 
@@ -27,7 +34,7 @@ export interface TransactionSheetModel {
   receipt?: AttemptReceipt;
 }
 
-export type TransactionSheetTheme = Pick<Theme, 'fg' | 'bold'>;
+export type TransactionSheetTheme = PresentationTheme;
 
 function field(theme: TransactionSheetTheme, label: string, value: unknown): string {
   return `${theme.fg('dim', `${label}:`)} ${theme.fg('text', quoteTerminalText(value))}`;
@@ -73,9 +80,9 @@ function receiptAxes(receipt: AttemptReceipt, theme: TransactionSheetTheme): [st
   return [durable, findings, runtime];
 }
 
-function renderWideAxes(axes: [string[], string[], string[]], width: number): string[] {
-  const separator = ' | ';
-  const available = Math.max(0, width - separator.length * 2);
+function renderWideAxes(axes: [string[], string[], string[]], theme: TransactionSheetTheme, width: number): string[] {
+  const separator = theme.fg('borderMuted', ' │ ');
+  const available = Math.max(0, width - 5);
   const firstWidth = Math.floor(available / 3);
   const secondWidth = Math.floor(available / 3);
   const widths = [firstWidth, secondWidth, available - firstWidth - secondWidth];
@@ -102,25 +109,51 @@ function renderStackedAxes(axes: [string[], string[], string[]], width: number):
   return lines;
 }
 
+/** Stage indicator cells: done ✓, active ▸ … ACTIVE, pending numbered. */
+function stageSegments(theme: TransactionSheetTheme, step: TransactionStep): string[] {
+  const activeIndex = TRANSACTION_STEPS.indexOf(step);
+  return TRANSACTION_STEPS.map((name, index) => {
+    if (index < activeIndex) return theme.fg('success', `✓ ${index + 1} ${name}`);
+    if (index === activeIndex) {
+      return theme.fg('accent', theme.bold(`▸ ${index + 1} ${name} ACTIVE`));
+    }
+    return theme.fg('muted', `${index + 1} ${name}`);
+  });
+}
+
+function stageRows(theme: TransactionSheetTheme, step: TransactionStep, width: number): string[] {
+  const segments = stageSegments(theme, step);
+  const connector = theme.fg('borderMuted', ' ─ ');
+  return [segments.slice(0, 3), segments.slice(3)].flatMap((row) =>
+    wrapTextWithAnsi(row.join(connector), Math.max(1, width)));
+}
+
+const SUMMARY_TONES: Record<AttemptSummary, { tone: BadgeTone; label: string }> = {
+  'Completed': { tone: 'success', label: 'COMPLETED' },
+  'Completed with diagnostics': { tone: 'warning', label: 'DIAGNOSTICS' },
+  'Declined': { tone: 'warning', label: 'DECLINED' },
+  'Blocked': { tone: 'error', label: 'BLOCKED' },
+  'Rejected as Stale': { tone: 'warning', label: 'STALE' },
+  'Persistence Failed': { tone: 'error', label: 'PERSISTENCE FAILED' },
+  'Persistence Indeterminate': { tone: 'error', label: 'INDETERMINATE' },
+  'Pending Application': { tone: 'warning', label: 'PENDING' },
+};
+
 export function renderTransactionSheet(
   model: TransactionSheetModel,
   theme: TransactionSheetTheme,
   width: number,
 ): string[] {
-  const sequence = TRANSACTION_STEPS.map((step, index) =>
-    step === model.step
-      ? theme.fg('accent', theme.bold(`[${index + 1} ${step} ACTIVE]`))
-      : theme.fg('muted', `[${index + 1} ${step}]`),
-  );
+  const totalWidth = Math.max(4, Math.floor(width));
+  const innerWidth = Math.max(1, totalWidth - 3);
   const receipt = model.receipt;
   const authority = model.authority ?? receipt?.scope;
   const stateRevision = model.stateRevision ?? receipt?.observedStateRevision ?? receipt?.expectedStateRevision;
   const validationSnapshot = model.validationSnapshot ?? receipt?.validationSnapshot;
-  const lines = [
-    theme.fg('accent', theme.bold('Transaction Sheet')),
+  const body: string[] = [
+    ...stageRows(theme, model.step, innerWidth),
+    '',
     field(theme, 'Action', model.actionLabel),
-    sequence.slice(0, 3).join(' -> '),
-    sequence.slice(3).join(' -> '),
     ...(authority === undefined ? [] : [field(theme, 'Authority', authorityLabel(authority))]),
     ...(model.target === undefined ? [] : [field(theme, 'Target', model.target)]),
     ...(stateRevision === undefined ? [] : [field(theme, 'State Revision', stateRevision)]),
@@ -129,12 +162,16 @@ export function renderTransactionSheet(
   ];
 
   if (receipt) {
-    lines.push('');
+    body.push('');
     const axes = receiptAxes(receipt, theme);
-    lines.push(...(width >= 64 ? renderWideAxes(axes, width) : renderStackedAxes(axes, width)));
-    lines.push('');
-    lines.push(`${theme.fg('accent', theme.bold('Attempt Summary:'))} ${quoteTerminalText(receipt.summary)}`);
-    lines.push(
+    body.push(...(innerWidth >= 64 ? renderWideAxes(axes, theme, innerWidth) : renderStackedAxes(axes, innerWidth)));
+    body.push('');
+    const summaryTone = SUMMARY_TONES[receipt.summary];
+    body.push(
+      `${theme.fg('accent', theme.bold('Attempt Summary:'))} ${quoteTerminalText(receipt.summary)} ` +
+        renderBadge(theme, summaryTone.tone, summaryTone.label),
+    );
+    body.push(
       `${theme.fg('accent', theme.bold('Recovery Actions:'))} ${
         receipt.recoveryActions.length > 0
           ? receipt.recoveryActions.map((action) => quoteTerminalText(action)).join(', ')
@@ -143,9 +180,11 @@ export function renderTransactionSheet(
     );
   }
 
-  lines.push('');
-  lines.push(theme.fg('dim', 'Enter: continue | Esc/q/Ctrl-C: cancel'));
-  return lines.flatMap((line) => wrapTextWithAnsi(line, Math.max(1, Math.floor(width))));
+  body.push('');
+  body.push(theme.fg('dim', 'Enter: continue | Esc/q/Ctrl-C: cancel'));
+  // Wrap every content line to the panel interior so no tail is lost inside the frame.
+  const wrappedBody = body.flatMap((line) => wrapTextWithAnsi(line, Math.max(1, totalWidth - 3)));
+  return renderPanel(theme, { title: 'Transaction Sheet', lines: wrappedBody, width: totalWidth });
 }
 
 export class TransactionSheetComponent implements Component {
@@ -217,6 +256,7 @@ export class TransactionSheetComponent implements Component {
 
 const PLAIN_THEME: TransactionSheetTheme = {
   fg: (_color, text) => text,
+  bg: (_token, text) => text,
   bold: (text) => text,
 };
 

--- a/tests/e2e/bridge-ledger-command.test.ts
+++ b/tests/e2e/bridge-ledger-command.test.ts
@@ -27,6 +27,7 @@ function captureCodexMarketplaceCommand(): CapturedCommand {
 
 const identityTheme = {
   fg: (_color: string, text: string) => text,
+  bg: (_token: string, text: string) => text,
   bold: (text: string) => text,
 };
 
@@ -125,7 +126,8 @@ describe('/codex-marketplace Bridge Ledger command seam', () => {
         );
         screens.push(component.render(80));
         if (customCalls === 1) {
-          component.handleInput?.('\r');
+          component.handleInput?.('\r'); // drill into the section (single-column layout at 80)
+          component.handleInput?.('\r'); // activate the first available structured action
           await commitBridgeState(
             'global',
             (state) => ({
@@ -212,9 +214,12 @@ describe('/codex-marketplace Bridge Ledger command seam', () => {
       },
     });
 
-    expect(screen).toMatch(/Barrier: ACTIVE/);
-    expect(screen).toMatch(/Project.*Register local Marketplace.*disabled:.*Global Pen/s);
-    expect(screen).toMatch(/Global.*Register local Marketplace.*available/s);
+    expect(screen).toMatch(/BARRIER ACTIVE/);
+    // Blocked Project mutation: availability is icon+word, and its reason is visible on selection.
+    expect(screen).toMatch(/○ Blocked Register local Marketplace/);
+    expect(screen).toMatch(/Global Pending Barrier/);
+    expect(screen).not.toMatch(/\[available\]|\[Unavailable\]|disabled:/);
+    expect(screen).toMatch(/● Ready Register local Marketplace/);
   });
 
   it.each([

--- a/tests/unit/extensions/bridge-ledger.test.ts
+++ b/tests/unit/extensions/bridge-ledger.test.ts
@@ -610,12 +610,61 @@ describe('Bridge Ledger presentation model', () => {
     expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
     expect(screen).toContain('G rev "12"');
     expect(screen).toContain('P rev "7"');
-    expect(screen.match(/health healthy/g)).toHaveLength(2);
+    expect(screen.match(/HEALTHY/g)).toHaveLength(2);
     expect(screen).toContain('Project Trust: granted');
-    expect(screen).toContain('Barrier: Clear');
+    expect(screen).toContain('BARRIER CLEAR');
     expect(screen).toContain('Status:');
     expect(screen).toContain('Esc/q');
-    expect(screen).toContain(width >= 64 ? 'Navigation' : 'Sections');
+    expect(screen).toContain(width >= 96 ? 'Navigation' : 'Sections');
+  });
+
+  it.each([120, 80, 60])('presents both authority rails as bordered panels at every width %i', (width) => {
+    const { instance } = component();
+    const lines = instance.render(width);
+    const screen = lines.join('\n');
+
+    expect(screen).toContain('┌─ Global Scope');
+    expect(screen).toContain('┌─ Project Scope');
+    expect(lines.filter((line) => line.includes('│')).length).toBeGreaterThanOrEqual(6);
+    if (width >= 96) {
+      const railRow = lines.find((line) => line.includes('Global Scope') && line.includes('Project Scope'));
+      expect(railRow).toBeDefined();
+    } else {
+      const shared = lines.find((line) => line.includes('Global Scope') && line.includes('Project Scope'));
+      expect(shared).toBeUndefined();
+    }
+  });
+
+  it('highlights the selected action row with the selected background token and a text cursor', () => {
+    const backgrounds: string[] = [];
+    const model = buildBridgeLedgerModel(snapshot());
+    const spyingTheme = {
+      ...identityTheme,
+      bg: (token: string, text: string) => {
+        backgrounds.push(token);
+        return text;
+      },
+    } as unknown as Theme;
+    const instance = new BridgeLedgerComponent(
+      model,
+      spyingTheme,
+      { requestRender: () => {} },
+      () => {},
+    );
+
+    instance.render(120); // establish wide workspace
+    instance.handleInput('\x1b[C'); // Sources
+    const idle = instance.render(120);
+    const baselineWashes = backgrounds.filter((token) => token === 'selectedBg').length;
+    expect(idle.some((line) => line.includes('● Ready Register local Marketplace'))).toBe(true);
+
+    instance.handleInput('j'); // move onto the registration row's actions
+    instance.render(120);
+    expect(backgrounds.filter((token) => token === 'selectedBg').length).toBeGreaterThan(baselineWashes);
+
+    const screen = instance.render(120).join('\n');
+    expect(screen).not.toContain('[available]');
+    expect(screen).not.toContain('[Unavailable]');
   });
 
   it('changes g/p browsing focus while keeping the visible action authority explicit', () => {
@@ -835,19 +884,19 @@ describe('Bridge Ledger presentation model', () => {
       expect(inspections).toEqual([]);
 
       const first = component(buildBridgeLedgerModel(loaded));
-      first.instance.render(80); // Observe
+      first.instance.render(120); // Observe
       expect(inspections).toEqual([]);
       first.instance.handleInput('\x1b[C'); // Sources
-      first.instance.render(80);
+      first.instance.render(120);
       expect(inspections).toEqual([]);
       first.instance.handleInput('\x1b[C'); // Plugins
-      first.instance.render(80);
+      first.instance.render(120);
       expect(inspections).toEqual([
         'global:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         'project:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
       ]);
 
-      first.instance.render(80);
+      first.instance.render(120);
       buildBridgeLedgerModel(loaded).sections.find((section) => section.id === 'plugins')!.rows;
       expect(inspections).toHaveLength(2);
 
@@ -870,30 +919,34 @@ describe('Bridge Ledger presentation model', () => {
     }
   });
 
-  it('supports arrows, j/k, Enter, Esc, q, Ctrl-C, help, and narrow back navigation', () => {
+  it('supports arrows, j/k, Enter, Esc, q, Ctrl-C, help, and metadata expansion in the wide workspace', () => {
     const wide = component();
-    wide.instance.render(80);
+    wide.instance.render(120);
     wide.instance.handleInput('\x1b[57418u'); // Kitty right
-    expect(wide.instance.render(80).join('\n')).toContain('> Sources');
+    expect(wide.instance.render(120).join('\n')).toContain('> Sources');
     wide.instance.handleInput('j');
     wide.instance.handleInput('\x1b[57420u'); // Kitty down
     wide.instance.handleInput('\x1b[57419u'); // Kitty up
     wide.instance.handleInput('k');
     wide.instance.handleInput('?');
-    expect(wide.instance.render(80).join('\n')).toContain('Help');
+    expect(wide.instance.render(120).join('\n')).toContain('Help');
     wide.instance.handleInput('\x1b[27u'); // Kitty Escape closes help
     expect(wide.results).toEqual([]);
+
+    // The structured dump is hidden until expanded, then fully retrievable.
+    const collapsed = wide.instance.render(120).join('\n');
+    expect(collapsed).not.toContain('| mode ');
+    expect(collapsed).not.toContain('detail ');
+    wide.instance.handleInput('i');
+    const expanded = wide.instance.render(120).join('\n');
+    expect(expanded).toContain('mode mutation');
+    expect(expanded).toContain('scope global');
+    expect(expanded).toContain('target scope "global"');
+    wide.instance.handleInput('i');
+    expect(wide.instance.render(120).join('\n')).not.toContain('mode mutation');
+
     wide.instance.handleInput('\x1b[13u'); // Kitty Enter activates first Global action
     expect(wide.results[0]).toMatchObject({ actionId: 'register-local', scope: 'global' });
-
-    const narrow = component();
-    narrow.instance.render(60);
-    narrow.instance.handleInput('\r');
-    expect(narrow.instance.render(60).join('\n')).toContain('Section: Observe');
-    narrow.instance.handleInput('\x1b');
-    expect(narrow.instance.render(60).join('\n')).toContain('Sections');
-    narrow.instance.handleInput('q');
-    expect(narrow.results).toEqual([undefined]);
 
     const ctrlC = component();
     ctrlC.instance.handleInput('\x1b[99;5u');
@@ -904,7 +957,24 @@ describe('Bridge Ledger presentation model', () => {
     expect(escape.results).toEqual([undefined]);
   });
 
-  it('does not return an intent when Enter activates a disabled row', () => {
+  it.each([80, 60])('drills down through single-column sections at %i columns', (width) => {
+    const narrow = component();
+    narrow.instance.render(width);
+    expect(narrow.instance.render(width).join('\n')).toContain('Sections');
+
+    narrow.instance.handleInput('\r');
+    const detail = narrow.instance.render(width).join('\n');
+    expect(detail).toContain('Observe');
+    expect(detail).toContain('● Ready Inspect authority partitions');
+
+    narrow.instance.handleInput('\x1b');
+    expect(narrow.instance.render(width).join('\n')).toContain('Sections');
+
+    narrow.instance.handleInput('q');
+    expect(narrow.results).toEqual([undefined]);
+  });
+
+  it('does not return an intent when Enter activates a disabled row and reveals its reason by selection', () => {
     const blockedSnapshot = snapshot();
     blockedSnapshot.global.state!.registrations = [];
     blockedSnapshot.global.state!.installations = [];
@@ -912,10 +982,16 @@ describe('Bridge Ledger presentation model', () => {
     blockedSnapshot.project.state!.installations = [];
     blockedSnapshot.barrier = { active: true, reason: 'global application pending' };
     const blocked = component(buildBridgeLedgerModel(blockedSnapshot));
-    blocked.instance.render(80);
+    blocked.instance.render(120);
     blocked.instance.handleInput('\x1b[C'); // Sources
     blocked.instance.handleInput('p'); // Project register-local
-    expect(blocked.instance.render(80).join('\n')).toContain('disabled:');
+    const screen = blocked.instance.render(120).join('\n');
+
+    expect(screen).toContain('○ Blocked Register local Marketplace');
+    expect(screen).toContain('Global Pending Barrier');
+    expect(screen).not.toContain('[available]');
+    expect(screen).not.toContain('[Unavailable]');
+    expect(screen).not.toContain('disabled:');
 
     blocked.instance.handleInput('\r');
 
@@ -929,7 +1005,10 @@ describe('Bridge Ledger presentation model', () => {
     hostile.journals.global.receipts[0]!.summary = 'Blocked\nFORGED-RECEIPT' as never;
     const rendered = component(buildBridgeLedgerModel(hostile));
     rendered.instance.render(120);
-    rendered.instance.handleInput('\x1b[C');
+    rendered.instance.handleInput('\x1b[C'); // Sources
+    rendered.instance.handleInput('j'); // onto Register Git (same create row)
+    rendered.instance.handleInput('j'); // onto the hostile registration row's Refresh action
+    rendered.instance.handleInput('i'); // expand its metadata layer
     const sourceLines = rendered.instance.render(120);
     rendered.instance.handleInput('\x1b[C');
     rendered.instance.handleInput('\x1b[C');

--- a/tests/unit/extensions/ledger-flow-adapters.test.ts
+++ b/tests/unit/extensions/ledger-flow-adapters.test.ts
@@ -28,6 +28,7 @@ const SECOND_REGISTRATION_ID = '22222222-2222-4222-8222-222222222222';
 
 const identityTheme = {
   fg: (_color: string, text: string) => text,
+  bg: (_token: string, text: string) => text,
   bold: (text: string) => text,
 };
 

--- a/tests/unit/extensions/terminal-presentation.test.ts
+++ b/tests/unit/extensions/terminal-presentation.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+
+import { stripTerminalSequences, visibleWidth } from '@earendil-works/pi-tui';
+
+import {
+  fitTerminalLine,
+  padTerminalLine,
+  quoteTerminalText,
+  renderBadge,
+  renderPanel,
+  renderSelectableRow,
+  type PresentationTheme,
+} from '../../../extensions/pi/terminal-presentation.js';
+
+const identityTheme: PresentationTheme = {
+  fg: (_token: string, text: string) => text,
+  bg: (_token: string, text: string) => text,
+  bold: (text: string) => text,
+};
+
+/** Records which semantic token each helper applies; returns text unchanged so width math stays honest. */
+function tokenRecorder() {
+  const used: string[] = [];
+  const theme: PresentationTheme = {
+    fg: (token: string, text: string) => {
+      used.push(`fg:${token}`);
+      return text;
+    },
+    bg: (token: string, text: string) => {
+      used.push(`bg:${token}`);
+      return text;
+    },
+    bold: (text: string) => {
+      used.push('bold');
+      return text;
+    },
+  };
+  return { theme, used };
+}
+
+describe('panel presentation', () => {
+  it('draws an exact-width box-drawing panel around content lines', () => {
+    const lines = renderPanel(identityTheme, {
+      title: 'Global Scope',
+      lines: ['rev "12"', 'registrations 2'],
+      width: 30,
+    });
+
+    // Spec geometry: two border columns; one-cell content inset; title consumes
+    // its own cells plus exactly one leading rule on the top border.
+    expect(lines[0]).toBe('┌─ Global Scope ' + '─'.repeat(30 - 16 - 1) + '┐');
+    expect(lines[1]).toBe('│ rev "12"' + ' '.repeat(28 - 1 - 8) + '│');
+    expect(lines[2]).toBe('│ registrations 2' + ' '.repeat(28 - 1 - 15) + '│');
+    expect(lines[3]).toBe('└' + '─'.repeat(28) + '┘');
+    expect(lines.every((line) => visibleWidth(line) === 30)).toBe(true);
+  });
+
+  it('styles borders and titles through theme tokens only', () => {
+    const { theme, used } = tokenRecorder();
+    renderPanel(theme, { title: 'Project Scope', lines: ['rev "7"'], width: 20 });
+
+    expect(used).toContain('fg:border');
+    expect(used).toContain('fg:accent');
+    expect(used).toContain('bold');
+  });
+
+  it('truncates oversized content and titles to stay inside the frame', () => {
+    const lines = renderPanel(identityTheme, {
+      title: 'an unreasonably long panel title that cannot fit',
+      lines: ['漢字漢字漢字漢字漢字漢字漢字漢字'],
+      width: 12,
+    });
+
+    expect(lines.every((line) => visibleWidth(line) === 12)).toBe(true);
+    expect(stripTerminalSequences(lines.join('\n'))).toContain('an u');
+    expect(stripTerminalSequences(lines[1]!)).not.toBe('│ 漢字漢字漢字漢字漢字漢字漢字漢字 │');
+  });
+
+  it('keeps ANSI-styled content lines inside the frame width', () => {
+    const styled = identityTheme.fg('success', '● Ready');
+    const lines = renderPanel(identityTheme, { lines: [styled], width: 16 });
+    expect(lines.every((line) => visibleWidth(line) === 16)).toBe(true);
+    expect(stripTerminalSequences(lines[1]!)).toBe('│ ● Ready' + ' '.repeat(14 - 1 - 7) + '│');
+  });
+
+  it('degrades safely at zero and minimal widths', () => {
+    expect(renderPanel(identityTheme, { lines: ['content'], width: 0 })).toEqual(['']);
+    const minimal = renderPanel(identityTheme, { title: 'T', lines: ['a'], width: 5 });
+    expect(minimal.every((line) => visibleWidth(line) === 5)).toBe(true);
+  });
+});
+
+describe('badge presentation', () => {
+  it.each([
+    ['success', 'bg:toolSuccessBg', 'fg:success'],
+    ['warning', 'bg:toolPendingBg', 'fg:warning'],
+    ['error', 'bg:toolErrorBg', 'fg:error'],
+    ['neutral', 'bg:userMessageBg', 'fg:text'],
+  ] as const)('renders %s badges with a background token and its text label', (tone, bgToken, fgToken) => {
+    const { theme, used } = tokenRecorder();
+    renderBadge(theme, tone, 'HEALTHY');
+
+    expect(used).toContain(bgToken);
+    expect(used).toContain(fgToken);
+  });
+
+  it('keeps badges readable without color through the text label', () => {
+    const badge = renderBadge(identityTheme, 'error', 'BARRIER ACTIVE');
+    expect(badge).toBe(' BARRIER ACTIVE ');
+    expect(visibleWidth(badge)).toBe(16);
+  });
+});
+
+describe('selection presentation', () => {
+  it('marks the selected row with a background wash and a text cursor across the full width', () => {
+    const row = renderSelectableRow(identityTheme, {
+      selected: true,
+      text: 'Register local Marketplace',
+      width: 40,
+    });
+
+    expect(row.startsWith('> ')).toBe(true);
+    expect(visibleWidth(row)).toBe(40);
+    expect(row.endsWith(' '.repeat(40 - '> Register local Marketplace'.length))).toBe(true);
+  });
+
+  it('applies the selection background token to the padded row', () => {
+    const { theme, used } = tokenRecorder();
+    renderSelectableRow(theme, { selected: true, text: 'row', width: 10 });
+
+    expect(used).toContain('bg:selectedBg');
+  });
+
+  it('leaves unselected rows unhighlighted with a blank cursor column', () => {
+    const { theme, used } = tokenRecorder();
+    const row = renderSelectableRow(theme, { selected: false, text: 'row', width: 10 });
+
+    expect(used).not.toContain('bg:selectedBg');
+    expect(stripTerminalSequences(row).startsWith('  row')).toBe(true);
+  });
+
+  it('supports a custom cursor glyph while keeping a textual marker', () => {
+    const row = renderSelectableRow(identityTheme, {
+      selected: true,
+      text: 'Sources',
+      width: 12,
+      cursor: '▸',
+    });
+    expect(stripTerminalSequences(row).startsWith('▸ Sources')).toBe(true);
+    expect(visibleWidth(row)).toBe(12);
+  });
+
+  it('fits hostile oversized row text into the given width', () => {
+    const row = renderSelectableRow(identityTheme, {
+      selected: true,
+      text: quoteTerminalText('x'.repeat(200)),
+      width: 20,
+    });
+    expect(visibleWidth(row)).toBe(20);
+  });
+});
+
+describe('existing width-safe helpers (regression)', () => {
+  it('still quotes, fits, and pads by terminal cell width', () => {
+    expect(quoteTerminalText('evil\nrow')).toBe('"evil\\nrow"');
+    expect(visibleWidth(fitTerminalLine('漢字abc', 5))).toBe(5);
+    expect(padTerminalLine('漢', 5)).toBe('漢   ');
+  });
+});

--- a/tests/unit/extensions/transaction-flows.test.ts
+++ b/tests/unit/extensions/transaction-flows.test.ts
@@ -20,6 +20,7 @@ import { createReceipt } from '../../../src/registration/receipt.js';
 
 const theme = {
   fg: (_color: string, text: string) => text,
+  bg: (_token: string, text: string) => text,
   bold: (text: string) => text,
 };
 

--- a/tests/unit/extensions/transaction-sheet.test.ts
+++ b/tests/unit/extensions/transaction-sheet.test.ts
@@ -18,6 +18,7 @@ import type { AttemptReceipt, AttemptSummary } from '../../../src/registration/r
 
 const identityTheme = {
   fg: (_color: string, text: string) => text,
+  bg: (_token: string, text: string) => text,
   bold: (text: string) => text,
 };
 
@@ -69,12 +70,56 @@ describe('Transaction Sheet presentation', () => {
     const positions = TRANSACTION_STEPS.map((step, index) => output.indexOf(`${index + 1} ${step}`));
     expect(positions.every((position) => position >= 0)).toBe(true);
     expect([...positions].sort((a, b) => a - b)).toEqual(positions);
-    expect(output).toContain('2 Validation ACTIVE');
-    expect(output).toContain('[1 Intent] -> [2 Validation ACTIVE] -> [3 Consent]');
+    expect(output).toContain('▸ 2 Validation ACTIVE');
+    expect(output).toContain('✓ 1 Intent');
+    expect(output).not.toContain('[1 Intent] ->');
     expect(output).toContain('Authority: "[G] GLOBAL"');
     expect(output).toContain('State Revision: "18"');
     expect(output).toContain('Validation Snapshot: "snapshot-18"');
     expect(renderTransactionSheet(model, identityTheme, 80).every((line) => visibleWidth(line) <= 80)).toBe(true);
+  });
+
+  it('frames the sheet in a box-drawing panel at every width without overflow', () => {
+    const model: TransactionSheetModel = {
+      step: 'Commit',
+      actionLabel: 'Enable plugin',
+      authority: 'project',
+    };
+
+    for (const width of [120, 80, 60]) {
+      const lines = renderTransactionSheet(model, identityTheme, width);
+      expect(lines[0]).toContain('┌─ Transaction Sheet');
+      expect(lines.at(-1)).toContain('┘');
+      expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
+      expect(lines.join('\n')).toContain('5 Commit ACTIVE');
+    }
+  });
+
+  it.each<[AttemptSummary, 'success' | 'error' | 'warning']>([
+    ['Completed', 'success'],
+    ['Blocked', 'error'],
+    ['Pending Application', 'warning'],
+  ])("pairs Attempt Summary %s with a %s tone badge", (summary, tone) => {
+    const tokens: string[] = [];
+    const spyingTheme = {
+      ...identityTheme,
+      bg: (token: string, text: string) => {
+        tokens.push(token);
+        return text;
+      },
+    };
+    const output = renderTransactionSheet({
+      step: 'Receipt',
+      actionLabel: 'Lifecycle operation',
+      receipt: { ...receipt(summary), recoveryActions: [] },
+    }, spyingTheme, 60).join('\n');
+    expect(output).toContain(`Attempt Summary: "${summary}"`);
+    expect(tokens).toContain(`tool${tone === 'success' ? 'Success' : tone === 'error' ? 'Error' : 'Pending'}Bg`);
+    expect(renderTransactionSheet({
+      step: 'Receipt',
+      actionLabel: 'Lifecycle operation',
+      receipt: { ...receipt(summary), recoveryActions: [] },
+    }, identityTheme, 60).join('\n')).toContain(summary);
   });
 
   it('quotes terminal-controlled text and fits or pads by terminal cell width', () => {
@@ -120,8 +165,11 @@ describe('Transaction Sheet presentation', () => {
       validationSnapshot: 'snapshot-5',
       receipt: receipt(),
     }, identityTheme, 60);
-    const axisLines = lines.filter((line) => ['Durable', 'Findings', 'Runtime'].includes(line.trim()));
-    expect(axisLines.map((line) => line.trim())).toEqual(['Durable', 'Findings', 'Runtime']);
+    const axisLines = lines.map((line) => stripTerminalSequences(line));
+    const positions = ['Durable', 'Findings', 'Runtime'].map((header) =>
+      axisLines.findIndex((line) => line.trim().startsWith(`│ ${header}`) || line.trim() === header));
+    expect(positions.every((position) => position >= 0)).toBe(true);
+    expect([...positions].sort((a, b) => a - b)).toEqual(positions);
     expect(lines.every((line) => visibleWidth(line) <= 60)).toBe(true);
   });
 
@@ -252,7 +300,9 @@ describe('Transaction Sheet presentation', () => {
     component.handleInput('d');
     const expanded = component.render(60).join('\n');
     expect(expanded).toContain('FULL-DISCLOSURE-TAIL');
-    expect(expanded).toMatch(/press d to\s+collapse/);
+    // At 60 columns the hint may wrap inside the panel frame; both fragments must survive.
+    expect(expanded).toMatch(/press d to/);
+    expect(expanded).toMatch(/collapse/);
     expect(results).toEqual([]);
     expect(renderRequests).toBe(1);
   });


### PR DESCRIPTION
## Summary

- add width-aware presentation contracts to the terminal helper layer: box-drawing panels, text-labelled background badges, and full-width selection rows with a text cursor
- rework the Bridge Ledger workspace: Global/Project authority rails render as simultaneously visible bordered panels at ≥96 columns, degrading to single-column drill-down below, with health/trust/barrier badges and icon+token+word availability states
- move the structured `detail | target | scope | mode` dump into an expandable metadata layer (`i` key); disabled reasons surface on selection; no `[available]`/`[Unavailable]`/`disabled:` labels remain
- frame the transaction sheet in a panel with a numbered six-stage indicator (✓ done / ▸ ACTIVE / pending) and tone badges beside the canonical Attempt Summary value
- keep structured action intents and dispatch untouched: visual state is never consulted for dispatch

## Acceptance criteria (issue #40)

- ≥96 columns: both rails visible as bordered panels; 60/80 degrade to drill-down without overflow — covered by width-matrix unit tests (120/80/60) and the e2e seam
- selected rows combine selectedBg wash with a `>` cursor, recognizable without color
- health/trust/barrier badges carry textual labels (HEALTHY / TRUST GRANTED / BARRIER ACTIVE …), never color-only meaning
- no inline availability labels; disabled reasons visible on selection or expansion
- target/scope/mode dumps hidden by default, fully retrievable via expansion
- #38 behavioral acceptance preserved: keyboard navigation, Kitty keys, barrier gating, Default No confirmations, post-action state re-read

## Safety

- only existing ThemeColor/ThemeBg vocabulary via fg()/bg()/bold(); no raw ANSI, no new tokens
- hostile-text quoting and per-width overflow assertions retained across all rendered surfaces
- LedgerActionIntent structure unchanged; domain flows still revalidate after dispatch

## Verification

- npm run typecheck
- npm test: 48 files, 566 tests passed
- spec review vs issue #40: acceptance criteria all addressed; standards review findings (duplicated panel-join logic) fixed by extracting renderSideBySidePanels

Closes #40