### PR TITLE
feat: 正體中文化 /codex-marketplace TUI——集中字串模組與 CJK 寬度安全

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `pi-codex-marketplace` are documented here. Format follows Keep a Changelog and SemVer (starting at `0.1.0`; Git tags `v*` mirror npm versions).
 
+## [Unreleased]
+
+### Added
+- **TUI 正體中文化** (#41)：新增集中式呈現字串模組 `extensions/pi/ui-strings.ts`（以穩定訊息 ID 索引的 zh_TW 字典，保留 locale 切換模組縫），`/codex-marketplace` TUI 全部使用者可見字串改由字串模組供應——分區名與描述、列標籤、按鍵提示、狀態列、確認與 consent 文案、help 全譯；Attempt Summary／Recovery Action／Verdict 封閉值以正典在前、中文釋義在後並列（如 `Blocked（受阻）`）；findings 於呈現邊界依 rule code 對應中文文案（rule code／classification／順序不變）；glossary 術語（Bridge State、Receipt Journal…）維持英文；CJK 雙寬字元於 120/80/60 欄寬度安全（無溢位、面板框線完整）；分派續用結構化 intent，顯示語言不影響任何行為。非 TUI 的 `list`/`inspect` 輸出依議題範圍維持原樣。
+
 ## [0.1.8] - 2026-08-24
 
 ### Added

--- a/extensions/pi/bridge-ledger.ts
+++ b/extensions/pi/bridge-ledger.ts
@@ -40,6 +40,7 @@ import {
   renderSelectableRow,
   renderSideBySidePanels,
 } from './terminal-presentation.js';
+import { attemptSummaryText, findingOutcomeText, uiText } from './ui-strings.js';
 
 export type LedgerSectionId =
   | 'observe'
@@ -286,14 +287,16 @@ function rail(scope: Scope, result: ReadResult, projectTrusted: boolean): Ledger
       ? 'indeterminate'
       : 'healthy';
   const healthText = health === 'healthy'
-    ? result.status === 'missing' ? 'Healthy (empty initial state)' : 'Healthy'
+    ? result.status === 'missing'
+      ? uiText('ledger.rail.health.healthyEmpty')
+      : uiText('ledger.rail.health.healthy')
     : health === 'incompatible'
-      ? `Incompatible: ${result.error ?? 'unknown schema'}`
-      : `Persistence Indeterminate: ${result.error ?? 'unreadable Bridge State'}`;
+      ? uiText('ledger.rail.health.incompatible', { error: result.error ?? uiText('common.unknown') })
+      : uiText('ledger.rail.health.indeterminate', { error: result.error ?? uiText('common.unknown') });
   return {
     scope,
-    label: scope === 'global' ? 'Global Scope' : 'Project Scope',
-    revision: state?.stateRevision ?? 'unavailable',
+    label: scope === 'global' ? uiText('common.scope.global') : uiText('common.scope.project'),
+    revision: state?.stateRevision ?? uiText('ledger.revision.unavailable'),
     registrationCount: state?.registrations.length ?? 0,
     installationEnabledCount:
       state?.installations.filter((item) => item.installationState === 'enabled').length ?? 0,
@@ -303,8 +306,8 @@ function rail(scope: Scope, result: ReadResult, projectTrusted: boolean): Ledger
     health,
     healthText,
     trustText: scope === 'global'
-      ? 'Project Trust: not applicable'
-      : projectTrusted ? 'Project Trust: granted' : 'Project Trust: not granted',
+      ? uiText('ledger.rail.trust.notApplicable')
+      : projectTrusted ? uiText('ledger.rail.trust.granted') : uiText('ledger.rail.trust.notGranted'),
   };
 }
 
@@ -316,14 +319,15 @@ function availability(
   if (intent.scope === 'project' && snapshot.barrier.active) {
     return {
       enabled: false,
-      disabledReason: `Global Pending Barrier: ${snapshot.barrier.reason ?? 'global recovery is required'}; ` +
-        'open Recovery & receipts and complete an eligible Global Recovery Action',
+      disabledReason: uiText('ledger.disabledReason.barrier', {
+        reason: snapshot.barrier.reason ?? uiText('ledger.barrier.defaultReason'),
+      }),
     };
   }
   if (intent.scope === 'project' && !snapshot.projectTrusted) {
     return {
       enabled: false,
-      disabledReason: 'Project Trust is not granted; Project Scope mutation is unavailable',
+      disabledReason: uiText('ledger.disabledReason.trust'),
     };
   }
   const authority = intent.scope === 'global' ? snapshot.global : snapshot.project;
@@ -334,7 +338,7 @@ function availability(
     if (!chain?.receipts[0]?.validationSnapshot) {
       return {
         enabled: false,
-        disabledReason: 'Pending Application has no bound Validation Snapshot; start a fresh validated Lifecycle Intent instead of replaying it',
+        disabledReason: uiText('ledger.disabledReason.retryNoSnapshot'),
       };
     }
   }
@@ -343,7 +347,9 @@ function availability(
     if (authority.status === 'incompatible') {
       return {
         enabled: false,
-        disabledReason: `Bridge State schema is incompatible: ${authority.error ?? 'unknown schema'}; update the Bridge Package`,
+        disabledReason: uiText('ledger.disabledReason.incompatible', {
+          error: authority.error ?? uiText('common.unknown'),
+        }),
       };
     }
     if (snapshot.journals[intent.scope].isDegraded) return { enabled: true };
@@ -353,52 +359,56 @@ function availability(
     if (repairable) return { enabled: true };
     const activeConditions = snapshot.journals[intent.scope].activeChains.map((chain) =>
       chain.condition === 'pending-application'
-        ? 'Pending Application'
+        ? uiText('ledger.condition.pending-application')
         : chain.condition === 'persistence-failed'
-          ? 'Persistence Failed'
+          ? uiText('ledger.condition.persistence-failed')
           : chain.condition,
     );
     return {
       enabled: false,
       disabledReason: activeConditions.length > 0
-        ? `State Repair is not eligible for ${activeConditions.join(', ')}; use the exact declared Recovery Action`
-        : 'State Repair has no eligible Persistence Indeterminate recovery chain or unreadable state',
+        ? uiText('ledger.disabledReason.repairIneligible', { conditions: activeConditions.join(', ') })
+        : uiText('ledger.disabledReason.repairNothing'),
     };
   }
   if (authority.status === 'incompatible') {
     return {
       enabled: false,
-      disabledReason: `Bridge State is incompatible: ${authority.error ?? 'unknown schema'}; update the Bridge Package before mutation`,
+      disabledReason: uiText('ledger.disabledReason.incompatibleMutation', {
+        error: authority.error ?? uiText('common.unknown'),
+      }),
     };
   }
   if (authority.status === 'corrupted') {
     return {
       enabled: false,
-      disabledReason: `Persistence Indeterminate: ${authority.error ?? 'Bridge State is unreadable'}; use Repair State`,
+      disabledReason: uiText('ledger.disabledReason.corrupted', {
+        error: authority.error ?? uiText('ledger.disabledReason.corruptState'),
+      }),
     };
   }
   return { enabled: true };
 }
 
 const ACTION_LABELS: Record<LedgerActionId, string> = {
-  'observe-partitions': 'Inspect authority partitions',
-  'observe-effective-state': 'Inspect Effective State and Projected Skills',
-  'register-local': 'Register local Marketplace',
-  'register-git': 'Register Git Marketplace',
-  'refresh-registration': 'Refresh Marketplace',
-  'rebind-registration': 'Rebind Registration',
-  'remove-registration': 'Remove Registration',
-  'install-disabled': 'Install Disabled',
-  'install-and-enable': 'Install and Enable',
-  'enable-installation': 'Enable Installation',
-  'disable-installation': 'Disable Installation',
-  'remove-installation': 'Remove Installation',
-  'create-scope-override': 'Create Scope Override',
-  'remove-scope-override': 'Remove Scope Override',
-  'view-receipt-journal': 'View Receipt Journal',
-  'repair-state': 'Repair Bridge State',
-  'retry-application': 'Retry Runtime Application',
-  'inspect-receipt': 'Inspect Attempt Receipt',
+  'observe-partitions': uiText('ledger.action.observe-partitions'),
+  'observe-effective-state': uiText('ledger.action.observe-effective-state'),
+  'register-local': uiText('ledger.action.register-local'),
+  'register-git': uiText('ledger.action.register-git'),
+  'refresh-registration': uiText('ledger.action.refresh-registration'),
+  'rebind-registration': uiText('ledger.action.rebind-registration'),
+  'remove-registration': uiText('ledger.action.remove-registration'),
+  'install-disabled': uiText('ledger.action.install-disabled'),
+  'install-and-enable': uiText('ledger.action.install-and-enable'),
+  'enable-installation': uiText('ledger.action.enable-installation'),
+  'disable-installation': uiText('ledger.action.disable-installation'),
+  'remove-installation': uiText('ledger.action.remove-installation'),
+  'create-scope-override': uiText('ledger.action.create-scope-override'),
+  'remove-scope-override': uiText('ledger.action.remove-scope-override'),
+  'view-receipt-journal': uiText('ledger.action.view-receipt-journal'),
+  'repair-state': uiText('ledger.action.repair-state'),
+  'retry-application': uiText('ledger.action.retry-application'),
+  'inspect-receipt': uiText('ledger.action.inspect-receipt'),
 };
 
 function action(snapshot: BridgeLedgerSnapshot, intent: LedgerActionIntent): LedgerActionRow {
@@ -432,7 +442,9 @@ function scopeRegistrationRows(
 ): LedgerObjectRow[] {
   const createRow: LedgerObjectRow = {
     id: `registration-create:${scope}`,
-    label: `${scope === 'global' ? 'Global' : 'Project'} registration actions`,
+    label: uiText('ledger.row.registrationActions', {
+      scopeWord: scope === 'global' ? uiText('common.scope.word.global') : uiText('common.scope.word.project'),
+    }),
     scope,
     targetKind: 'scope',
     targetId: scope,
@@ -444,7 +456,7 @@ function scopeRegistrationRows(
   const records = (state?.registrations ?? []).map((registration): LedgerObjectRow => ({
     id: `registration:${scope}:${registration.id}`,
     label: registrationName(registration),
-    detail: `${registration.sourceKind ?? 'unknown source'} · ${registration.source ?? '(source unavailable)'}`,
+    detail: `${registration.sourceKind ?? uiText('ledger.row.registration.sourceUnknown')} · ${registration.source ?? uiText('ledger.row.registration.sourceUnavailable')}`,
     scope,
     targetKind: 'registration',
     targetId: registration.id,
@@ -466,13 +478,13 @@ function pluginRows(
     if (!('marketplaceEntryId' in entry)) {
       const findings = entry.findings.length > 0
         ? entry.findings.map((finding) =>
-            `${finding.code} · ${finding.rule} · ${finding.outcome}`,
+            `${finding.code} · ${finding.rule} · ${findingOutcomeText(finding)}`,
           ).join('; ')
-        : 'no Marketplace Entries were reported';
+        : uiText('ledger.row.diagnostic.noEntries');
       return {
         id: `marketplace-diagnostic:${scope}:${entry.registrationId}`,
         label: entry.name,
-        detail: `Unavailable · ${findings}`,
+        detail: uiText('ledger.row.diagnostic.unavailable', { findings }),
         scope,
         targetKind: 'registration',
         targetId: entry.registrationId,
@@ -487,15 +499,21 @@ function pluginRows(
         installation.pluginId === compatiblePluginId);
     const skillDetail = entry.plugin?.skills.length
       ? entry.plugin.skills.map((skill) =>
-          `${skill.name} ${skill.invocationPolicy} resources ${skill.resources.length > 0 ? skill.resources.join(', ') : 'none'}`,
+          uiText('ledger.row.skills.resources', {
+            name: skill.name,
+            policy: skill.invocationPolicy,
+            resources: skill.resources.length > 0 ? skill.resources.join(', ') : uiText('ledger.row.skills.noResources'),
+          }),
         ).join('; ')
-      : 'skills none';
+      : uiText('ledger.row.skills.none');
     const unavailableReason = installed
-      ? 'this Marketplace Entry already has a scope-local Installation'
+      ? uiText('ledger.row.install.alreadyInstalled')
       : entry.unavailableReason
         ?? (entry.classification === 'compatible' && !entry.validationSnapshot
-          ? 'Validation Snapshot is unavailable; reopen Plugins after source inspection'
-          : entry.classification === 'compatible' ? undefined : `${entry.classification} Marketplace Entry`);
+          ? uiText('ledger.row.install.snapshotMissing')
+          : entry.classification === 'compatible'
+            ? undefined
+            : uiText('ledger.row.install.classification', { classification: entry.classification }));
     const installAction = (
       actionId: 'install-disabled' | 'install-and-enable',
       desiredInstallationState: 'disabled' | 'enabled',
@@ -560,7 +578,7 @@ function createOverrideRow(
   return {
     id: `inherited:${kind}:${targetId}`,
     label,
-    detail: `Inherited Global ${kind} · canonical target ${targetId}`,
+    detail: uiText('ledger.row.override.inherited', { kind, targetId }),
     scope: 'global',
     targetKind: kind,
     targetId,
@@ -600,8 +618,8 @@ function overrideRows(
     const canonicalOverrideId = `${override.kind}/${override.targetId}`;
     return {
       id: `scope-override:${canonicalOverrideId}`,
-      label: `${override.kind} override`,
-      detail: `Suppresses inherited ${override.targetId}`,
+      label: uiText('ledger.row.override.label', { kind: override.kind }),
+      detail: uiText('ledger.row.override.suppresses', { targetId: override.targetId }),
       scope: 'project',
       targetKind: 'scope-override',
       targetId: canonicalOverrideId,
@@ -622,7 +640,7 @@ function overrideRows(
 function receiptRow(receipt: AttemptReceipt, snapshot: BridgeLedgerSnapshot): LedgerObjectRow {
   return {
     id: `receipt:${receipt.scope}:${receipt.id}`,
-    label: `${receipt.summary} · ${receipt.operation}`,
+    label: `${attemptSummaryText(receipt.summary)} · ${receipt.operation}`,
     detail: `${receipt.createdAt} · ${receipt.id}`,
     scope: receipt.scope,
     targetKind: 'receipt',
@@ -639,8 +657,13 @@ function retryApplicationRows(snapshot: BridgeLedgerSnapshot): LedgerObjectRow[]
       .filter((chain) => chain.condition === 'pending-application')
       .map((chain): LedgerObjectRow => ({
         id: `retry-application:${scope}:${chain.rootReceiptId}`,
-        label: `${scope === 'global' ? 'Global' : 'Project'} Pending Application`,
-        detail: `Active recovery chain ${chain.rootReceiptId} · revision ${chain.stateRevision}`,
+        label: uiText('ledger.row.retry.label', {
+          scopeWord: scope === 'global' ? uiText('common.scope.word.global') : uiText('common.scope.word.project'),
+        }),
+        detail: uiText('ledger.row.retry.detail', {
+          receiptId: chain.rootReceiptId,
+          revision: chain.stateRevision,
+        }),
         scope,
         targetKind: 'receipt',
         targetId: chain.rootReceiptId,
@@ -661,30 +684,35 @@ export function buildBridgeLedgerModel(snapshot: BridgeLedgerSnapshot): BridgeLe
   const effective = snapshot.effective;
   const observe: LedgerSection = {
     id: 'observe',
-    label: 'Observe',
-    description: 'Inspect authoritative partitions and the derived Effective State',
+    label: uiText('ledger.section.observe.label'),
+    description: uiText('ledger.section.observe.description'),
     rows: [
       {
         id: 'observe:partitions',
-        label: 'Global / Project authority partitions',
-        detail: `Global revision ${snapshot.global.state?.stateRevision ?? 'unavailable'} · ` +
-          `Project revision ${snapshot.project.state?.stateRevision ?? 'unavailable'}`,
+        label: uiText('ledger.row.observe.partitions'),
+        detail: uiText('ledger.row.observe.partitionsDetail', {
+          global: snapshot.global.state?.stateRevision ?? uiText('ledger.revision.unavailable'),
+          project: snapshot.project.state?.stateRevision ?? uiText('ledger.revision.unavailable'),
+        }),
         actions: [action(snapshot, { actionId: 'observe-partitions', mode: 'read' })],
       },
       {
         id: 'observe:effective',
-        label: 'Effective State and Projected Skills',
-        detail: `registrations ${effective?.registrations.length ?? 0} · ` +
-          `installations ${effective?.installations.length ?? 0} · ` +
-          `suppressed ${effective?.suppressed.length ?? 0} · excluded ${effective?.excluded.length ?? 0}`,
+        label: uiText('ledger.row.observe.effective'),
+        detail: uiText('ledger.row.observe.effectiveDetail', {
+          registrations: effective?.registrations.length ?? 0,
+          installations: effective?.installations.length ?? 0,
+          suppressed: effective?.suppressed.length ?? 0,
+          excluded: effective?.excluded.length ?? 0,
+        }),
         actions: [action(snapshot, { actionId: 'observe-effective-state', mode: 'read' })],
       },
     ],
   };
   const sources: LedgerSection = {
     id: 'sources',
-    label: 'Sources',
-    description: 'Marketplace Registrations and source lifecycle actions',
+    label: uiText('ledger.section.sources.label'),
+    description: uiText('ledger.section.sources.description'),
     rows: [
       ...scopeRegistrationRows('global', globalState, snapshot),
       ...scopeRegistrationRows('project', projectState, snapshot),
@@ -693,8 +721,8 @@ export function buildBridgeLedgerModel(snapshot: BridgeLedgerSnapshot): BridgeLe
   let pluginRowCache: LedgerObjectRow[] | undefined;
   const plugins: LedgerSection = {
     id: 'plugins',
-    label: 'Plugins',
-    description: 'Compatible candidates and scope-local Installation state',
+    label: uiText('ledger.section.plugins.label'),
+    description: uiText('ledger.section.plugins.description'),
     get rows() {
       pluginRowCache ??= [
         ...pluginRows('global', globalState, snapshot),
@@ -705,22 +733,26 @@ export function buildBridgeLedgerModel(snapshot: BridgeLedgerSnapshot): BridgeLe
   };
   const inheritance: LedgerSection = {
     id: 'scope-inheritance',
-    label: 'Scope & inheritance',
-    description: 'Project Scope overrides suppress inherited Global records without mutating them',
+    label: uiText('ledger.section.scope-inheritance.label'),
+    description: uiText('ledger.section.scope-inheritance.description'),
     rows: overrideRows(globalState, projectState, snapshot),
   };
   const recovery: LedgerSection = {
     id: 'recovery-receipts',
-    label: 'Recovery & receipts',
-    description: 'Non-authoritative Attempt Receipt history and explicit State Repair',
+    label: uiText('ledger.section.recovery-receipts.label'),
+    description: uiText('ledger.section.recovery-receipts.description'),
     rows: [
       ...(['global', 'project'] as const).flatMap((scope): LedgerObjectRow[] => [
         {
           id: `journal:${scope}`,
-          label: `${scope === 'global' ? 'Global' : 'Project'} Receipt Journal`,
-          detail: `${snapshot.journals[scope].receipts.length} receipts · ` +
-            `${snapshot.journals[scope].activeChains.length} active recovery chains · ` +
-            `degraded ${snapshot.journals[scope].isDegraded ? 'yes' : 'no'}`,
+          label: uiText('ledger.row.journal.label', {
+            scopeWord: scope === 'global' ? uiText('common.scope.word.global') : uiText('common.scope.word.project'),
+          }),
+          detail: uiText('ledger.row.journal.detail', {
+            receipts: snapshot.journals[scope].receipts.length,
+            chains: snapshot.journals[scope].activeChains.length,
+            degraded: snapshot.journals[scope].isDegraded ? uiText('common.yes') : uiText('common.no'),
+          }),
           scope,
           targetKind: 'scope',
           targetId: scope,
@@ -728,7 +760,9 @@ export function buildBridgeLedgerModel(snapshot: BridgeLedgerSnapshot): BridgeLe
         },
         {
           id: `repair:${scope}`,
-          label: `${scope === 'global' ? 'Global' : 'Project'} State Repair`,
+          label: uiText('ledger.row.repair.label', {
+            scopeWord: scope === 'global' ? uiText('common.scope.word.global') : uiText('common.scope.word.project'),
+          }),
           scope,
           targetKind: 'scope',
           targetId: scope,
@@ -750,8 +784,8 @@ export function buildBridgeLedgerModel(snapshot: BridgeLedgerSnapshot): BridgeLe
     barrier: {
       active: snapshot.barrier.active,
       text: snapshot.barrier.active
-        ? snapshot.barrier.reason ?? 'global recovery is required'
-        : 'Clear',
+        ? snapshot.barrier.reason ?? uiText('ledger.barrier.defaultReason')
+        : uiText('ledger.barrier.clear'),
     },
     effective: {
       registrationCount: effective?.registrations.length ?? 0,
@@ -769,15 +803,15 @@ export function buildBridgeLedgerModel(snapshot: BridgeLedgerSnapshot): BridgeLe
 /** Widths at or above this breakpoint render the two-column panel workspace. */
 const WIDE_WORKSPACE_WIDTH = 96;
 
-const HEALTH_BADGES: Record<LedgerHealth, { tone: 'success' | 'warning' | 'error'; label: string }> = {
-  healthy: { tone: 'success', label: 'HEALTHY' },
-  incompatible: { tone: 'error', label: 'INCOMPATIBLE' },
-  indeterminate: { tone: 'warning', label: 'INDETERMINATE' },
+const HEALTH_BADGES: Record<LedgerHealth, { tone: 'success' | 'warning' | 'error'; labelId: Parameters<typeof uiText>[0] }> = {
+  healthy: { tone: 'success', labelId: 'ledger.badge.healthy' },
+  incompatible: { tone: 'error', labelId: 'ledger.badge.incompatible' },
+  indeterminate: { tone: 'warning', labelId: 'ledger.badge.indeterminate' },
 };
 
 const AVAILABILITY = {
-  ready: { icon: '\u25cf', token: 'success', word: 'Ready' },
-  blocked: { icon: '\u25cb', token: 'warning', word: 'Blocked' },
+  ready: { icon: '\u25cf', token: 'success', word: uiText('ledger.availability.ready') },
+  blocked: { icon: '\u25cb', token: 'warning', word: uiText('ledger.availability.blocked') },
 } as const;
 
 export class BridgeLedgerComponent implements Component {
@@ -910,7 +944,7 @@ export class BridgeLedgerComponent implements Component {
     ];
     if (this.helpVisible) {
       out.push(...renderPanel(this.theme, {
-        title: 'Help',
+        title: uiText('ledger.panel.help'),
         lines: this.helpLines().map((line) => this.fit(line, Math.max(1, this.lastWidth - 3), 'text')),
         width: this.lastWidth,
       }));
@@ -990,16 +1024,16 @@ export class BridgeLedgerComponent implements Component {
 
   private railBadge(scope: Scope): string {
     const rail = scope === 'global' ? this.model.rails.global : this.model.rails.project;
-    const badges = [renderBadge(this.theme, HEALTH_BADGES[rail.health].tone, HEALTH_BADGES[rail.health].label)];
+    const badges = [renderBadge(this.theme, HEALTH_BADGES[rail.health].tone, uiText(HEALTH_BADGES[rail.health].labelId))];
     if (scope === 'project') {
       badges.push(renderBadge(
         this.theme,
         this.model.projectTrusted ? 'success' : 'warning',
-        this.model.projectTrusted ? 'TRUST GRANTED' : 'NO PROJECT TRUST',
+        this.model.projectTrusted ? uiText('ledger.badge.trustGranted') : uiText('ledger.badge.noTrust'),
       ));
     } else {
       badges.push(renderBadge(this.theme, this.model.barrier.active ? 'error' : 'success',
-        this.model.barrier.active ? 'BARRIER ACTIVE' : 'BARRIER CLEAR'));
+        this.model.barrier.active ? uiText('ledger.badge.barrierActive') : uiText('ledger.badge.barrierClear')));
     }
     return badges.join(' ');
   }
@@ -1010,15 +1044,21 @@ export class BridgeLedgerComponent implements Component {
     const fitDim = (text: string): string => this.fit(text, width, 'dim');
     const lines = [
       this.railBadge(scope),
-      `${marker} rev ${quoteTerminalText(rail.revision)}`,
-      `registrations ${rail.registrationCount}`,
-      `installations ${rail.installationEnabledCount} enabled / ${rail.installationDisabledCount} disabled`,
+      uiText('ledger.rail.revision', { marker, revision: quoteTerminalText(rail.revision) }),
+      uiText('ledger.rail.registrations', { count: rail.registrationCount }),
+      uiText('ledger.rail.installations', {
+        enabled: rail.installationEnabledCount,
+        disabled: rail.installationDisabledCount,
+      }),
     ];
-    if (scope === 'project') lines.push(`overrides ${rail.overrideCount}`);
+    if (scope === 'project') lines.push(uiText('ledger.rail.overrides', { count: rail.overrideCount }));
     if (rail.health !== 'healthy') lines.push(fitDim(quoteTerminalText(rail.healthText)));
     if (scope === 'project') lines.push(fitDim(rail.trustText));
     if (scope === 'global' && this.model.barrier.active) {
-      lines.push(this.fit(`\u21b3 Barrier reason: ${quoteTerminalText(this.model.barrier.text)}`, width, 'warning'));
+      lines.push(this.fit(
+        uiText('ledger.rail.barrierReason', { reason: quoteTerminalText(this.model.barrier.text) }),
+        width, 'warning',
+      ));
     }
     return lines;
   }
@@ -1040,7 +1080,7 @@ export class BridgeLedgerComponent implements Component {
     const section = this.currentSection();
     return renderSideBySidePanels(this.theme, {
       left: {
-        title: 'Navigation',
+        title: uiText('ledger.panel.navigation'),
         lines: this.sectionNavLines(navWidth - 3),
         width: navWidth,
         borderToken: 'borderMuted',
@@ -1062,7 +1102,7 @@ export class BridgeLedgerComponent implements Component {
   private drilldownWorkspace(width: number): string[] {
     if (!this.sectionDetail) {
       return renderPanel(this.theme, {
-        title: 'Sections',
+        title: uiText('ledger.panel.sections'),
         lines: this.sectionNavLines(Math.max(1, width - 3)),
         width,
         borderToken: 'borderAccent',
@@ -1090,14 +1130,14 @@ export class BridgeLedgerComponent implements Component {
    */
   private actionEntryLines(width: number): string[] {
     const rows = this.visibleRows();
-    if (rows.length === 0) return [this.fit('No rows in this section', width, 'muted')];
+    if (rows.length === 0) return [this.fit(uiText('ledger.rows.empty'), width, 'muted')];
     let actionIndex = 0;
     const lines: string[] = [];
     for (const row of rows) {
       if (row.actions.length === 0) {
         lines.push(
-          this.fit(`${AVAILABILITY.blocked.icon} Unavailable \u00b7 ${quoteTerminalText(row.label)}`, width, 'warning'),
-          this.fit(`   ${quoteTerminalText(row.detail ?? '(no findings reported)')}`, width, 'dim'),
+          this.fit(`${AVAILABILITY.blocked.icon} ${uiText('ledger.entry.unavailableRow', { label: quoteTerminalText(row.label) })}`, width, 'warning'),
+          this.fit(`   ${quoteTerminalText(row.detail ?? uiText('ledger.entry.noFindings'))}`, width, 'dim'),
         );
         continue;
       }
@@ -1112,18 +1152,20 @@ export class BridgeLedgerComponent implements Component {
         if (!selected) continue;
         if (!action.enabled) {
           lines.push(...this.wrapContext(
-            `\u21b3 Blocked: ${quoteTerminalText(action.disabledReason ?? 'unavailable')}`,
+            `\u21b3 ${uiText('ledger.entry.blocked', { reason: quoteTerminalText(action.disabledReason ?? uiText('common.unavailable')) })}`,
             width, 'warning', 4));
         }
         if (this.metadataExpanded) {
           const intent = action.intent;
           const meta = [
-            `target ${intent.targetKind ?? row.targetKind ?? 'none'} ` +
-              quoteTerminalText(intent.targetId ?? row.targetId ?? '(none)'),
-            `scope ${intent.scope ?? row.scope ?? 'none'}`,
-            `mode ${intent.mode}`,
+            uiText('ledger.meta.target', {
+              kind: intent.targetKind ?? row.targetKind ?? uiText('common.none'),
+              target: quoteTerminalText(intent.targetId ?? row.targetId ?? uiText('common.none')),
+            }),
+            uiText('ledger.meta.scope', { scope: intent.scope ?? row.scope ?? uiText('common.none') }),
+            uiText('ledger.meta.mode', { mode: intent.mode }),
           ];
-          if (row.detail !== undefined) meta.push(`detail ${quoteTerminalText(row.detail)}`);
+          if (row.detail !== undefined) meta.push(uiText('ledger.meta.detail', { detail: quoteTerminalText(row.detail) }));
           lines.push(...meta.flatMap((entry) => this.wrapContext(`  ${entry}`, width, 'muted', 4)));
         }
       }
@@ -1138,12 +1180,12 @@ export class BridgeLedgerComponent implements Component {
 
   private helpLines(): string[] {
     return [
-      'Up/Down or j/k: move selection',
-      'Left/Right: change section (wide layout) or drill down',
-      'Enter: open section or activate available structured action',
-      'i: expand or collapse the selected entry metadata',
-      'g/p: browse Global/Project only; mutation authority remains explicit',
-      'Esc: back/cancel | q or Ctrl-C: exit | ?: close help',
+      uiText('ledger.help.move'),
+      uiText('ledger.help.sections'),
+      uiText('ledger.help.enter'),
+      uiText('ledger.help.metadata'),
+      uiText('ledger.help.browse'),
+      uiText('ledger.help.close'),
     ];
   }
 
@@ -1167,15 +1209,21 @@ export class BridgeLedgerComponent implements Component {
 
   private statusText(): string {
     const section = this.currentSection();
-    const pane = this.lastWidth >= WIDE_WORKSPACE_WIDTH || this.sectionDetail ? 'actions' : 'sections';
-    return `Status: browsing ${this.browseFocus === 'global' ? 'G' : 'P'} | ${section.label} | ${pane}`;
+    const pane = this.lastWidth >= WIDE_WORKSPACE_WIDTH || this.sectionDetail
+      ? uiText('ledger.status.pane.actions')
+      : uiText('ledger.status.pane.sections');
+    return uiText('ledger.status.browsing', {
+      marker: this.browseFocus === 'global' ? 'G' : 'P',
+      section: section.label,
+      pane,
+    });
   }
 
   private keyHints(): string {
-    if (this.helpVisible) return 'Keys: ?/Esc close help | q/Ctrl-C exit | Esc/q cancel context';
+    if (this.helpVisible) return uiText('ledger.keys.help');
     if (this.lastWidth < WIDE_WORKSPACE_WIDTH && !this.sectionDetail) {
-      return 'Keys: Esc/q cancel | Enter drill down | j/k move | g/p | ? help';
+      return uiText('ledger.keys.drilldown');
     }
-    return 'Keys: Esc/q cancel | Enter activate | j/k or arrows move | i details | g/p browse | ? help';
+    return uiText('ledger.keys.wide');
   }
 }

--- a/extensions/pi/git-registration.ts
+++ b/extensions/pi/git-registration.ts
@@ -3,6 +3,8 @@
  * Mirrors local registration contract: explicit scope → Git locator + Git Selector
  * → normalization (Canonical Locator + selector canonical) + Acquisition Trust Base + snapshot
  * → Validation Disclosure → Registration Confirmation (Snapshot+Revision bound, Default No) → atomic commit → Attempt Receipt.
+ *
+ * All user-visible strings come from the centralized ui-strings module (Issue #41).
  */
 
 import type { ExtensionCommandContext, ExtensionUIContext } from '@earendil-works/pi-coding-agent';
@@ -13,6 +15,7 @@ import {
 } from '../../src/registration/git-flow.js';
 import type { GitSelectorInput } from '../../src/registration/git-selector.js';
 import type { Scope } from '../../src/bridge-state/types.js';
+import { uiText } from './ui-strings.js';
 import {
   fullValidationDisclosureLines,
   reportOutcome,
@@ -28,7 +31,7 @@ async function transactionStep(
 ): Promise<boolean> {
   if (await openTransactionSheet(ctx, model) === 'continue') return true;
   if (cancel) await cancel();
-  else ctx.ui.notify('已取消 Transaction；Bridge State 未變更。', 'info');
+  else ctx.ui.notify(uiText('common.cancelled.transaction'), 'info');
   return false;
 }
 
@@ -40,33 +43,33 @@ export async function runGitRegistrationFlow(
   let scope = target.scope;
   if (!scope) {
     const scopeLabels = new Map<string, Scope>([
-      ['Global Scope', 'global'],
-      ['Project Scope', 'project'],
+      [uiText('common.scope.global'), 'global'],
+      [uiText('common.scope.project'), 'project'],
     ]);
-    const scopeChoice = await ui.select('Marketplace Registration (Git) — 選擇 Scope', [...scopeLabels.keys()]);
+    const scopeChoice = await ui.select(uiText('reg.select.scope.git'), [...scopeLabels.keys()]);
     if (!scopeChoice) {
-      ui.notify('已取消 Git Registration', 'info');
+      ui.notify(uiText('reg.git.cancelled'), 'info');
       return;
     }
     scope = scopeLabels.get(scopeChoice);
     if (!scope) return;
   }
 
-  const locator = await ui.input('Git Marketplace Locator（https:// 或 ssh:// 或 scp-like user@host:path，無憑證、無 query/fragment）', 'https://github.com/owner/repo.git');
+  const locator = await ui.input(uiText('reg.git.locator.prompt'), 'https://github.com/owner/repo.git');
   if (!locator) {
-    ui.notify('已取消 Git Registration', 'info');
+    ui.notify(uiText('reg.git.cancelled'), 'info');
     return;
   }
 
   const selectorKinds = new Map<string, GitSelectorInput['kind']>([
-    ['default (跟隨遠端預設分支 HEAD)', 'default'],
-    ['branch (→ refs/heads/*)', 'branch'],
-    ['tag (→ refs/tags/*)', 'tag'],
-    ['commit (小寫完整 40/64 hex)', 'commit'],
+    [uiText('reg.git.selector.default'), 'default'],
+    [uiText('reg.git.selector.branch'), 'branch'],
+    [uiText('reg.git.selector.tag'), 'tag'],
+    [uiText('reg.git.selector.commit'), 'commit'],
   ]);
-  const selectorKindChoice = await ui.select('Git Selector — 選擇型別', [...selectorKinds.keys()]);
+  const selectorKindChoice = await ui.select(uiText('reg.git.selector.prompt'), [...selectorKinds.keys()]);
   if (!selectorKindChoice) {
-    ui.notify('已取消 Git Registration', 'info');
+    ui.notify(uiText('reg.git.cancelled'), 'info');
     return;
   }
   const selectorKind = selectorKinds.get(selectorKindChoice);
@@ -75,23 +78,23 @@ export async function runGitRegistrationFlow(
   if (selectorKind === 'default') {
     selectorInput = { kind: 'default' };
   } else if (selectorKind === 'branch') {
-    const branch = await ui.input('Branch 名稱（例：main / feature/foo，將正規化為 refs/heads/<name>）', 'main');
+    const branch = await ui.input(uiText('reg.git.branch.prompt'), 'main');
     if (!branch) {
-      ui.notify('已取消 Git Registration', 'info');
+      ui.notify(uiText('reg.git.cancelled'), 'info');
       return;
     }
     selectorInput = { kind: 'branch', value: branch };
   } else if (selectorKind === 'tag') {
-    const tag = await ui.input('Tag 名稱（例：v1.2.3，將正規化為 refs/tags/<name>）', 'v1.0.0');
+    const tag = await ui.input(uiText('reg.git.tag.prompt'), 'v1.0.0');
     if (!tag) {
-      ui.notify('已取消 Git Registration', 'info');
+      ui.notify(uiText('reg.git.cancelled'), 'info');
       return;
     }
     selectorInput = { kind: 'tag', value: tag };
   } else {
-    const commit = await ui.input('Commit（完整 40 或 64 hex，將轉為小寫）', 'abc123def456abc123def456abc123def456abcd12');
+    const commit = await ui.input(uiText('reg.git.commit.prompt'), 'abc123def456abc123def456abc123def456abcd12');
     if (!commit) {
-      ui.notify('已取消 Git Registration', 'info');
+      ui.notify(uiText('reg.git.cancelled'), 'info');
       return;
     }
     selectorInput = { kind: 'commit', value: commit };
@@ -105,8 +108,8 @@ export async function runGitRegistrationFlow(
     authority: scope,
     target: intentTarget,
     details: [
-      `Locator ${quoteTerminalText(locator)}`,
-      `Selector ${quoteTerminalText(selectorInput.kind === 'default' ? 'default' : selectorInput.value)}`,
+      uiText('reg.git.detail.locator', { locator: quoteTerminalText(locator) }),
+      uiText('reg.git.detail.selectorValue', { selector: quoteTerminalText(selectorInput.kind === 'default' ? 'default' : selectorInput.value) }),
     ],
   })) return;
 
@@ -119,26 +122,37 @@ export async function runGitRegistrationFlow(
 
   const pf = res.preflight;
   const validationDetails = [
-    `Registration ID ${quoteTerminalText(pf.registrationId)}`,
-    `Canonical Locator ${quoteTerminalText(pf.locator.canonicalUrl)}`,
-    `Locator transport ${quoteTerminalText(pf.locator.transport)}`,
-    `Locator host ${quoteTerminalText(pf.locator.host)}`,
-    `Locator port ${quoteTerminalText(pf.locator.port ?? '(default)')}`,
-    `Locator path ${quoteTerminalText(pf.locator.path)}`,
-    `Locator user ${quoteTerminalText(pf.locator.user ?? '(none)')}`,
-    `Git Selector ${quoteTerminalText(pf.selector.kind)} → ${quoteTerminalText(pf.selector.canonical)}`,
-    `Resolved Revision ${quoteTerminalText(pf.resolvedRevision)}`,
-    `Marketplace ${quoteTerminalText(pf.marketplaceName)}`,
-    `Entries ${pf.catalog.entries.length} (` +
-      `${pf.catalog.entries.filter((entry) => entry.available).length} locatable / ` +
-      `${pf.catalog.entries.filter((entry) => !entry.available).length} unavailable)`,
-    `Compatibility Profile ${quoteTerminalText(pf.snapshot.profile)}`,
-    `Ruleset ${quoteTerminalText(pf.snapshot.ruleset)}`,
-    `Validation Budget ${quoteTerminalText(pf.snapshot.budget)}`,
-    'Acquisition safety: isolated credential-free Git acquisition; remote-controlled hooks and submodules are not executed.',
+    uiText('reg.detail.registrationId', { id: quoteTerminalText(pf.registrationId) }),
+    uiText('reg.git.detail.canonicalLocator', { locator: quoteTerminalText(pf.locator.canonicalUrl) }),
+    uiText('reg.git.detail.transport', { transport: quoteTerminalText(pf.locator.transport) }),
+    uiText('reg.git.detail.host', { host: quoteTerminalText(pf.locator.host) }),
+    uiText('reg.git.detail.port', { port: quoteTerminalText(pf.locator.port ?? `(${uiText('common.none')})`) }),
+    uiText('reg.git.detail.path', { path: quoteTerminalText(pf.locator.path) }),
+    uiText('reg.git.detail.user', { user: quoteTerminalText(pf.locator.user ?? `(${uiText('common.none')})`) }),
+    uiText('reg.git.detail.selector', {
+      kind: quoteTerminalText(pf.selector.kind),
+      canonical: quoteTerminalText(pf.selector.canonical),
+    }),
+    uiText('reg.git.detail.resolvedRevision', { revision: quoteTerminalText(pf.resolvedRevision) }),
+    uiText('reg.detail.marketplace', { name: quoteTerminalText(pf.marketplaceName) }),
+    uiText('reg.detail.entries', {
+      total: pf.catalog.entries.length,
+      locatable: pf.catalog.entries.filter((entry) => entry.available).length,
+      unavailable: pf.catalog.entries.filter((entry) => !entry.available).length,
+    }),
+    uiText('reg.detail.profile', { profile: quoteTerminalText(pf.snapshot.profile) }),
+    uiText('reg.detail.ruleset', { ruleset: quoteTerminalText(pf.snapshot.ruleset) }),
+    uiText('reg.detail.budget', { budget: quoteTerminalText(pf.snapshot.budget) }),
+    uiText('reg.git.detail.acquisitionSafety'),
     ...fullValidationDisclosureLines(pf.findings),
     ...pf.catalog.entries.map((entry) =>
-      `Entry ${quoteTerminalText(entry.entryId)} ${quoteTerminalText(entry.name ?? '(unnamed)')} ${quoteTerminalText(entry.available ? 'locatable' : entry.unavailableReason ?? 'unavailable')}`,
+      uiText('reg.detail.entry', {
+        entryId: quoteTerminalText(entry.entryId),
+        name: quoteTerminalText(entry.name ?? `(${uiText('common.none')})`),
+        status: entry.available
+          ? uiText('reg.entry.locatable')
+          : uiText('reg.entry.unavailable', { reason: quoteTerminalText(entry.unavailableReason ?? uiText('common.unavailable')) }),
+      }),
     ),
   ];
   const boundModel = {
@@ -159,29 +173,33 @@ export async function runGitRegistrationFlow(
   if (!await transactionStep(ctx, {
     ...boundModel,
     step: 'Consent',
-    details: ['Registration Confirmation: separate Default No host gate'],
+    details: [uiText('reg.consent.details')],
   }, cancel)) return;
 
   const yes = await ui.confirm(
-    'Registration Confirmation — 預設 No（綁定 State Revision + Validation Snapshot，不可記憶、不可批次）',
-    `確認 Registration ID ${quoteTerminalText(pf.registrationId)}：` +
-      `${quoteTerminalText(pf.locator.canonicalUrl)}#${quoteTerminalText(pf.selector.canonical)} ` +
-      `(${pf.resolvedRevision.slice(0, 8)}…) 至 ${scope}？\nValidation Disclosure:\n` +
-      validationDetails.join('\n'),
+    uiText('reg.consent.title'),
+    uiText('reg.git.consent.body', {
+      registrationId: quoteTerminalText(pf.registrationId),
+      locator: quoteTerminalText(pf.locator.canonicalUrl),
+      selector: quoteTerminalText(pf.selector.canonical),
+      revision: pf.resolvedRevision.slice(0, 8),
+      scope,
+      disclosure: validationDetails.join('\n'),
+    }),
   );
 
   if (yes) {
     if (!await transactionStep(ctx, {
       ...boundModel,
       step: 'Plan',
-      details: ['Update Plan: N/A — new Registration has no replacement plan'],
+      details: [uiText('reg.plan.details')],
     }, cancel)) return;
     if (!await transactionStep(ctx, {
       ...boundModel,
       step: 'Commit',
       details: [
-        `Persist Registration ID ${quoteTerminalText(pf.registrationId)}`,
-        `Write authority ${scope} at State Revision ${quoteTerminalText(pf.stateRevision)}`,
+        uiText('reg.commit.persist', { id: quoteTerminalText(pf.registrationId) }),
+        uiText('reg.commit.authority', { scope, revision: quoteTerminalText(pf.stateRevision) }),
       ],
     }, cancel)) return;
   }

--- a/extensions/pi/git-registration.ts
+++ b/extensions/pi/git-registration.ts
@@ -15,7 +15,8 @@ import {
 } from '../../src/registration/git-flow.js';
 import type { GitSelectorInput } from '../../src/registration/git-selector.js';
 import type { Scope } from '../../src/bridge-state/types.js';
-import { uiText } from './ui-strings.js';
+import { uiText,
+  scopeOptions } from './ui-strings.js';
 import {
   fullValidationDisclosureLines,
   reportOutcome,
@@ -42,10 +43,7 @@ export async function runGitRegistrationFlow(
   const ui: ExtensionUIContext = ctx.ui;
   let scope = target.scope;
   if (!scope) {
-    const scopeLabels = new Map<string, Scope>([
-      [uiText('common.scope.global'), 'global'],
-      [uiText('common.scope.project'), 'project'],
-    ]);
+    const scopeLabels = scopeOptions();
     const scopeChoice = await ui.select(uiText('reg.select.scope.git'), [...scopeLabels.keys()]);
     if (!scopeChoice) {
       ui.notify(uiText('reg.git.cancelled'), 'info');

--- a/extensions/pi/index.ts
+++ b/extensions/pi/index.ts
@@ -41,6 +41,7 @@ import {
 } from './bridge-ledger.js';
 import { quoteTerminalText } from './terminal-presentation.js';
 import { renderTransactionSheet } from './transaction-sheet.js';
+import { uiText } from './ui-strings.js';
 
 const STARTUP_RECEIPT_THEME = {
   fg: (_color: string, text: string) => text,
@@ -119,6 +120,46 @@ function overrideTarget(intent: LedgerActionIntent): {
   return { targetKind: kind, targetId, expectedStateRevision };
 }
 
+/** Localized state summary for TUI surfaces (the non-TUI list/inspect output stays canonical English). */
+function formatLocalizedStateSummary(result: ReadResult, scope: 'global' | 'project'): string {
+  const scopeLabel = scope === 'project' ? uiText('common.scope.project') : uiText('common.scope.global');
+  if (result.status === 'missing') {
+    const s = result.state!;
+    return uiText('cmd.state.empty', {
+      scope: scopeLabel,
+      version: s.schemaVersion,
+      revision: s.stateRevision,
+    });
+  }
+  if (result.status === 'ok') {
+    const s = result.state!;
+    const regCount = s.registrations.length;
+    const instEnabled = s.installations.filter((i) => i.installationState === 'enabled').length;
+    const instDisabled = s.installations.filter((i) => i.installationState === 'disabled').length;
+    const base = uiText('cmd.state.ok', {
+      scope: scopeLabel,
+      revision: s.stateRevision,
+      registrations: regCount,
+      enabled: instEnabled,
+      disabled: instDisabled,
+    });
+    const ovPart = scope === 'project'
+      ? uiText('cmd.state.ok.overrides', { overrides: s.scopeOverrides.length })
+      : '';
+    return base + ovPart;
+  }
+  if (result.status === 'incompatible') {
+    return uiText('cmd.state.incompatible', {
+      scope: scopeLabel,
+      error: quoteTerminalText(result.error ?? uiText('common.unknown')),
+    });
+  }
+  return uiText('cmd.state.corrupted', {
+    scope: scopeLabel,
+    error: quoteTerminalText(result.error ?? uiText('common.unknown')),
+  });
+}
+
 /** Dispatches only by stable semantic identity; display labels never select behavior. */
 export async function dispatchLedgerAction(
   ctx: ExtensionCommandContext,
@@ -129,7 +170,7 @@ export async function dispatchLedgerAction(
       const global = readBridgeStateSync('global', { cwd: ctx.cwd });
       const project = readBridgeStateSync('project', { cwd: ctx.cwd });
       ctx.ui.notify(
-        `${formatStateSummary(global, 'Global Scope')}\n${formatStateSummary(project, 'Project Scope')}`,
+        `${formatLocalizedStateSummary(global, 'global')}\n${formatLocalizedStateSummary(project, 'project')}`,
         'info',
       );
       return;
@@ -267,7 +308,7 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.registerCommand('codex-marketplace', {
-    description: 'Manage Codex Marketplaces in the Global / Project Bridge Ledger workspace',
+    description: uiText('cmd.description'),
     handler: async (args, ctx) => {
       const cwd = ctx.cwd;
 

--- a/extensions/pi/installation.ts
+++ b/extensions/pi/installation.ts
@@ -28,7 +28,8 @@ import {
   reportTerminalPreflightOutcome,
   validationDisclosureLines,
 } from './registration.js';
-import { findingOutcomeText, uiText } from './ui-strings.js';
+import { findingOutcomeText, uiText,
+  scopeOptions } from './ui-strings.js';
 import { quoteTerminalText } from './terminal-presentation.js';
 import { openTransactionSheet, type TransactionSheetModel } from './transaction-sheet.js';
 
@@ -134,10 +135,7 @@ export async function runPluginInstallationFlow(
   const ui: ExtensionUIContext = ctx.ui;
   let scope = target.scope;
   if (!scope) {
-    const scopeLabels = new Map<string, Scope>([
-      [uiText('common.scope.global'), 'global'],
-      [uiText('common.scope.project'), 'project'],
-    ]);
+    const scopeLabels = scopeOptions();
     const scopeChoice = await ui.select(uiText('inst.select.scope'), [...scopeLabels.keys()]);
     if (!scopeChoice) return;
     scope = scopeLabels.get(scopeChoice);
@@ -399,10 +397,7 @@ export async function runPluginStateFlow(
   const ui: ExtensionUIContext = ctx.ui;
   let scope = target.scope;
   if (!scope) {
-    const scopeLabels = new Map<string, Scope>([
-      [uiText('common.scope.global'), 'global'],
-      [uiText('common.scope.project'), 'project'],
-    ]);
+    const scopeLabels = scopeOptions();
     const scopeChoice = await ui.select(uiText('inst.select.installedScope'), [...scopeLabels.keys()]);
     if (!scopeChoice) return;
     scope = scopeLabels.get(scopeChoice);

--- a/extensions/pi/installation.ts
+++ b/extensions/pi/installation.ts
@@ -1,4 +1,7 @@
-/** TUI flow for Compatibility Profile v1 Plugin Installation and state toggles. */
+/** TUI flow for Compatibility Profile v1 Plugin Installation and state toggles.
+ *
+ * All user-visible strings come from the centralized ui-strings module (Issue #41).
+ */
 
 import type { ExtensionCommandContext, ExtensionUIContext } from '@earendil-works/pi-coding-agent';
 
@@ -9,7 +12,6 @@ import {
   confirmPluginInstallation,
   declinePluginDisable,
   declinePluginInstallation,
-  installationDisclosure,
   preflightPluginDisable,
   preflightPluginEnable,
   preflightPluginInstallation,
@@ -26,6 +28,7 @@ import {
   reportTerminalPreflightOutcome,
   validationDisclosureLines,
 } from './registration.js';
+import { findingOutcomeText, uiText } from './ui-strings.js';
 import { quoteTerminalText } from './terminal-presentation.js';
 import { openTransactionSheet, type TransactionSheetModel } from './transaction-sheet.js';
 
@@ -45,8 +48,46 @@ async function transactionStep(
 ): Promise<boolean> {
   if (await openTransactionSheet(ctx, model) === 'continue') return true;
   if (cancel) await cancel();
-  else ctx.ui.notify('已取消 Transaction；Bridge State 未變更。', 'info');
+  else ctx.ui.notify(uiText('common.cancelled.transaction'), 'info');
   return false;
+}
+
+/** Localized presentation of the activation material for one installation preflight. */
+export function localizedInstallationDisclosure(pf: PluginInstallationPreflight): string[] {
+  const plugin = pf.plugin;
+  const lines = [
+    uiText('inst.disclosure.scope', { scope: pf.scope }),
+    uiText('inst.disclosure.plugin', {
+      name: labelText(plugin.manifestName),
+      id: labelText(plugin.id),
+    }),
+    uiText('inst.disclosure.source', {
+      source: labelText(pf.registration.source ?? pf.registration.canonicalLocator ?? uiText('common.unavailable')),
+    }),
+    uiText('inst.disclosure.marketplaceEntry', { entryId: labelText(plugin.marketplaceEntryId) }),
+    uiText('life.removal.disclosure.revision', { revision: pf.stateRevision }),
+    uiText('reg.detail.snapshotShort', { snapshot: pf.snapshot.fingerprint.slice(0, 16) }),
+    uiText('inst.disclosure.classification'),
+    uiText('inst.disclosure.precedence'),
+    uiText('inst.disclosure.skills', { count: plugin.skills.length }),
+  ];
+  for (const skill of plugin.skills) {
+    lines.push('  ' + uiText('inst.disclosure.skill', {
+      name: labelText(skill.name),
+      policy: skill.invocationPolicy,
+      resources: skill.resources.length === 0
+        ? uiText('common.none')
+        : skill.resources.map(labelText).join(', '),
+    }));
+  }
+  lines.push(uiText('inst.disclosure.findings', {
+    findings: pf.findings.length === 0
+      ? uiText('common.none')
+      : pf.findings.map((finding) =>
+          `${finding.classification} ${finding.code}: ${findingOutcomeText(finding)}`,
+        ).join(' | '),
+  }));
+  return lines;
 }
 
 export async function entryChoices(
@@ -57,16 +98,20 @@ export async function entryChoices(
   const inspection = inspectMarketplaceEntries(registration, scope, { agentDir: opts.agentDir, cache: opts.cache });
   if (!inspection.marketplaceId) {
     return [{
-      label: `${labelText(registration.alias ?? registration.id)} — ` +
-        `Unavailable (${labelText(inspection.findings[0]?.outcome ?? 'Marketplace Catalog cannot be read')})`,
+      label: uiText('inst.choice.unavailable', {
+        name: labelText(registration.alias ?? registration.id),
+        reason: labelText(inspection.findings[0]?.outcome ?? uiText('inst.choice.readFailure')),
+      }),
     }];
   }
   return inspection.entries.map((item) => {
-    const status = item.unavailableReason ? `Unavailable (${item.unavailableReason})` : '可安裝';
+    const status = item.unavailableReason
+      ? `${uiText('common.unavailable')}（${labelText(item.unavailableReason)}）`
+      : uiText('inst.entry.available');
     const marketplaceEntryId = `${inspection.marketplaceId}${item.entry.entryId}`;
     return {
       label: `${labelText(marketplaceEntryId)} · ` +
-        `${labelText(item.entry.name ?? item.plugin?.manifestName ?? 'unnamed')} — ${labelText(status)}`,
+        `${labelText(item.entry.name ?? item.plugin?.manifestName ?? `(${uiText('common.none')})`)} — ${status}`,
       pointer: item.unavailableReason ? undefined : item.entry.entryId,
       marketplaceEntryId: item.unavailableReason ? undefined : marketplaceEntryId,
       validationSnapshot: item.unavailableReason ? undefined : inspection.snapshot?.fingerprint,
@@ -90,10 +135,10 @@ export async function runPluginInstallationFlow(
   let scope = target.scope;
   if (!scope) {
     const scopeLabels = new Map<string, Scope>([
-      ['Global Scope', 'global'],
-      ['Project Scope', 'project'],
+      [uiText('common.scope.global'), 'global'],
+      [uiText('common.scope.project'), 'project'],
     ]);
-    const scopeChoice = await ui.select('Plugin Installation — 選擇 Scope', [...scopeLabels.keys()]);
+    const scopeChoice = await ui.select(uiText('inst.select.scope'), [...scopeLabels.keys()]);
     if (!scopeChoice) return;
     scope = scopeLabels.get(scopeChoice);
     if (!scope) return;
@@ -116,16 +161,23 @@ export async function runPluginInstallationFlow(
     intentValidationSnapshot = target.expectedValidationSnapshot;
   } else {
     const state = await readBridgeState(scope, opts);
-    if (state.status !== 'ok' && state.status !== 'missing') return void ui.notify(`Bridge State 不可讀：${labelText(state.error ?? 'Persistence Indeterminate')}`, 'error');
+    if (state.status !== 'ok' && state.status !== 'missing') {
+      return void ui.notify(
+        uiText('common.bridgeState.unreadable', { error: labelText(state.error ?? 'Persistence Indeterminate') }),
+        'error',
+      );
+    }
     const registrations = state.state?.registrations ?? [];
-    if (registrations.length === 0) return void ui.notify('此 Scope 尚無 Marketplace Registration。', 'info');
+    if (registrations.length === 0) return void ui.notify(uiText('common.registration.none'), 'info');
     let registration: Registration | undefined;
     if (target.registrationId) {
       registration = registrations.find((item) => item.id === target.registrationId);
-      if (!registration) return void ui.notify(`找不到 Marketplace Registration ${labelText(target.registrationId)}。`, 'warning');
+      if (!registration) {
+        return void ui.notify(uiText('inst.notFound.registration', { id: labelText(target.registrationId) }), 'warning');
+      }
     } else {
       const labels = registrations.map((item) => `${labelText(item.alias ?? item.marketplaceName ?? item.id)} · ${labelText(item.id)}`);
-      const selectedLabel = await ui.select('選擇已註冊 Marketplace', labels);
+      const selectedLabel = await ui.select(uiText('inst.select.registered'), labels);
       if (!selectedLabel) return;
       registration = registrations[labels.indexOf(selectedLabel)];
       if (!registration) return;
@@ -136,14 +188,14 @@ export async function runPluginInstallationFlow(
       selected = choices.find((item) => item.pointer === target.entryPointer);
     } else {
       const entryLabel = await ui.select(
-        'Marketplace Entries（顯示 Marketplace Entry ID 與可安裝/Unavailable 原因）',
+        uiText('inst.select.entry'),
         choices.map((item) => item.label),
       );
       if (!entryLabel) return;
       selected = choices[choices.map((item) => item.label).indexOf(entryLabel)];
     }
     if (!selected?.pointer || !selected.marketplaceEntryId || !selected.validationSnapshot) {
-      return void ui.notify('此 Marketplace Entry 為 Unavailable，無法安裝。', 'warning');
+      return void ui.notify(uiText('inst.entry.unavailableNotice'), 'warning');
     }
     registrationId = registration.id;
     entryPointer = selected.pointer;
@@ -152,17 +204,19 @@ export async function runPluginInstallationFlow(
     intentValidationSnapshot = selected.validationSnapshot;
   }
   const installationPaths = new Map<string, 'disabled' | 'enabled'>([
-    ['Install Disabled', 'disabled'],
-    ['Install and Enable', 'enabled'],
+    [uiText('inst.path.disabled'), 'disabled'],
+    [uiText('inst.path.enabled'), 'enabled'],
   ]);
   let targetState = target.targetState;
   if (!targetState) {
-    const pathChoice = await ui.select('Installation path', [...installationPaths.keys()]);
+    const pathChoice = await ui.select(uiText('inst.select.path'), [...installationPaths.keys()]);
     if (!pathChoice) return;
     targetState = installationPaths.get(pathChoice);
   }
   if (!targetState) return;
-  const actionLabel = targetState === 'disabled' ? 'Install Disabled' : 'Install and Enable';
+  const actionLabel = targetState === 'disabled'
+    ? uiText('inst.actionLabel.disabled')
+    : uiText('inst.actionLabel.enabled');
   if (!await transactionStep(ctx, {
     step: 'Intent',
     actionLabel,
@@ -170,9 +224,9 @@ export async function runPluginInstallationFlow(
     target: intentTarget,
     stateRevision: intentStateRevision,
     details: [
-      `Registration ${quoteTerminalText(registrationId)}`,
-      `Marketplace Entry ${quoteTerminalText(entryPointer)}`,
-      `Target state ${quoteTerminalText(targetState)}`,
+      uiText('inst.detail.registration', { id: quoteTerminalText(registrationId) }),
+      uiText('inst.detail.entryPointer', { pointer: quoteTerminalText(entryPointer) }),
+      uiText('inst.detail.targetState', { state: quoteTerminalText(targetState) }),
     ],
   })) return;
   const preflight = await preflightPluginInstallation(scope, registrationId, entryPointer, {
@@ -198,22 +252,25 @@ export async function runPluginInstallationFlow(
     step: 'Validation',
     details: [
       ...fullValidationDisclosureLines(pf.findings),
-      ...installationDisclosure(pf).split('\n'),
+      ...localizedInstallationDisclosure(pf),
     ],
   }, cancel)) return;
   if (!await transactionStep(ctx, {
     ...boundModel,
     step: 'Consent',
-    details: targetState === 'disabled'
-      ? ['Activation Confirmation: N/A — Install Disabled']
-      : ['Activation Confirmation: separate Default No host gate'],
+    details: [targetState === 'disabled'
+      ? uiText('inst.consent.na.disabled')
+      : uiText('inst.consent.activationGate')],
   }, cancel)) return;
 
   let activationConfirmed = false;
   if (targetState === 'enabled') {
     activationConfirmed = await ui.confirm(
-      'Activation Confirmation — 預設 No（獨立於 Registration Confirmation）',
-      `Validation Disclosure:\n${installationDisclosure(pf).split('\n').map(quoteTerminalText).join('\n')}\n\n確認安裝並啟用 ${quoteTerminalText(pf.plugin.manifestName)}？`,
+      uiText('inst.activation.confirmTitle'),
+      uiText('inst.activation.confirmBody', {
+        disclosure: localizedInstallationDisclosure(pf).map(quoteTerminalText).join('\n'),
+        name: quoteTerminalText(pf.plugin.manifestName),
+      }),
     );
     if (!activationConfirmed) {
       await reportOutcome(ctx, await confirmPluginInstallation(pf, 'enabled', false, opts));
@@ -223,12 +280,12 @@ export async function runPluginInstallationFlow(
   if (!await transactionStep(ctx, {
     ...boundModel,
     step: 'Plan',
-    details: ['Update Plan: N/A — Plugin Installation does not replace a Registration snapshot'],
+    details: [uiText('inst.plan.notApplicable')],
   }, cancel)) return;
   if (!await transactionStep(ctx, {
     ...boundModel,
     step: 'Commit',
-    details: [`Write authority ${scope} at State Revision ${quoteTerminalText(pf.stateRevision)}`],
+    details: [uiText('inst.commit.authority', { scope, revision: quoteTerminalText(pf.stateRevision) })],
   }, cancel)) return;
   const outcome = targetState === 'enabled'
     ? await confirmPluginInstallation(pf, 'enabled', activationConfirmed, opts)
@@ -243,7 +300,7 @@ async function completePluginEnableFlow(
 ): Promise<void> {
   const installation = pf.existingInstallation;
   if (!installation) throw new Error('Plugin Enablement preflight requires an existing Installation');
-  const actionLabel = 'Plugin Enablement';
+  const actionLabel = uiText('inst.actionLabel.enablement');
   const boundModel = {
     actionLabel,
     authority: pf.scope,
@@ -259,17 +316,17 @@ async function completePluginEnableFlow(
     step: 'Validation',
     details: [
       ...fullValidationDisclosureLines(pf.findings),
-      ...installationDisclosure(pf).split('\n'),
+      ...localizedInstallationDisclosure(pf),
     ],
   }, cancel)) return;
   if (!await transactionStep(ctx, {
     ...boundModel,
     step: 'Consent',
-    details: ['Activation Confirmation: separate Default No host gate'],
+    details: [uiText('inst.consent.activationGate')],
   }, cancel)) return;
   const confirmed = await ctx.ui.confirm(
-    'Activation Confirmation — 預設 No（重新驗證後才可 re-enable）',
-    installationDisclosure(pf).split('\n').map(quoteTerminalText).join('\n'),
+    uiText('inst.activation.reenableTitle'),
+    localizedInstallationDisclosure(pf).map(quoteTerminalText).join('\n'),
   );
   if (!confirmed) {
     await reportOutcome(ctx, await confirmPluginEnable(pf, false, opts));
@@ -278,12 +335,12 @@ async function completePluginEnableFlow(
   if (!await transactionStep(ctx, {
     ...boundModel,
     step: 'Plan',
-    details: ['Update Plan: N/A — Installation state-only operation'],
+    details: [uiText('inst.plan.stateOnly')],
   }, cancel)) return;
   if (!await transactionStep(ctx, {
     ...boundModel,
     step: 'Commit',
-    details: [`Write authority ${pf.scope} at State Revision ${quoteTerminalText(pf.stateRevision)}`],
+    details: [uiText('inst.commit.authority', { scope: pf.scope, revision: quoteTerminalText(pf.stateRevision) })],
   }, cancel)) return;
   await reportOutcome(ctx, await confirmPluginEnable(pf, true, opts));
 }
@@ -295,7 +352,7 @@ async function completePluginDisableFlow(
 ): Promise<void> {
   const { scope, installation, stateRevision } = preflight;
   const initialModel = {
-    actionLabel: 'Plugin Disablement',
+    actionLabel: uiText('inst.actionLabel.disablement'),
     authority: scope,
     target: installation.id,
     stateRevision,
@@ -309,23 +366,23 @@ async function completePluginDisableFlow(
     step: 'Validation',
     details: [
       ...validationDisclosureLines([]),
-      'Validation Snapshot: N/A — disablement removes runtime participation',
+      uiText('inst.validation.noSnapshot'),
     ],
   }, decline)) return;
   if (!await transactionStep(ctx, {
     ...initialModel,
     step: 'Consent',
-    details: ['Activation Confirmation: N/A — disablement does not activate a Plugin'],
+    details: [uiText('inst.consent.na.disablement')],
   }, decline)) return;
   if (!await transactionStep(ctx, {
     ...initialModel,
     step: 'Plan',
-    details: ['Update Plan: N/A — Installation state-only operation'],
+    details: [uiText('inst.plan.stateOnly')],
   }, decline)) return;
   if (!await transactionStep(ctx, {
     ...initialModel,
     step: 'Commit',
-    details: [`Write authority ${scope} at State Revision ${quoteTerminalText(stateRevision)}`],
+    details: [uiText('inst.commit.authority', { scope, revision: quoteTerminalText(stateRevision) })],
   }, decline)) return;
   await reportOutcome(ctx, await confirmPluginDisable(preflight, opts));
 }
@@ -343,10 +400,10 @@ export async function runPluginStateFlow(
   let scope = target.scope;
   if (!scope) {
     const scopeLabels = new Map<string, Scope>([
-      ['Global Scope', 'global'],
-      ['Project Scope', 'project'],
+      [uiText('common.scope.global'), 'global'],
+      [uiText('common.scope.project'), 'project'],
     ]);
-    const scopeChoice = await ui.select('Installed Plugin — 選擇 Scope', [...scopeLabels.keys()]);
+    const scopeChoice = await ui.select(uiText('inst.select.installedScope'), [...scopeLabels.keys()]);
     if (!scopeChoice) return;
     scope = scopeLabels.get(scopeChoice);
     if (!scope) return;
@@ -355,13 +412,13 @@ export async function runPluginStateFlow(
   if (target.installationId && target.desiredState === 'disabled') {
     if (!await transactionStep(ctx, {
       step: 'Intent',
-      actionLabel: 'Plugin Disablement',
+      actionLabel: uiText('inst.actionLabel.disablement'),
       authority: scope,
       target: target.installationId,
       stateRevision: target.expectedStateRevision,
       details: [
-        `Installation ${quoteTerminalText(target.installationId)}`,
-        'Requested state disabled',
+        uiText('inst.detail.installation', { id: quoteTerminalText(target.installationId) }),
+        uiText('inst.detail.requestedState', { state: quoteTerminalText('disabled') }),
       ],
     })) return;
     const preflight = await preflightPluginDisable(scope, target.installationId, {
@@ -380,13 +437,13 @@ export async function runPluginStateFlow(
   if (target.installationId && target.desiredState === 'enabled') {
     if (!await transactionStep(ctx, {
       step: 'Intent',
-      actionLabel: 'Plugin Enablement',
+      actionLabel: uiText('inst.actionLabel.enablement'),
       authority: scope,
       target: target.installationId,
       stateRevision: target.expectedStateRevision,
       details: [
-        `Installation ${quoteTerminalText(target.installationId)}`,
-        'Requested state enabled',
+        uiText('inst.detail.installation', { id: quoteTerminalText(target.installationId) }),
+        uiText('inst.detail.requestedState', { state: quoteTerminalText('enabled') }),
       ],
     })) return;
     const preflight = await preflightPluginEnable(scope, target.installationId, {
@@ -398,16 +455,23 @@ export async function runPluginStateFlow(
     return;
   }
   const state = await readBridgeState(scope, opts);
-  if (state.status !== 'ok' && state.status !== 'missing') return void ui.notify(`Bridge State 不可讀：${labelText(state.error ?? 'Persistence Indeterminate')}`, 'error');
+  if (state.status !== 'ok' && state.status !== 'missing') {
+    return void ui.notify(
+      uiText('common.bridgeState.unreadable', { error: labelText(state.error ?? 'Persistence Indeterminate') }),
+      'error',
+    );
+  }
   const installations = state.state?.installations ?? [];
-  if (installations.length === 0) return void ui.notify('此 Scope 尚無 Installed Plugin。', 'info');
+  if (installations.length === 0) return void ui.notify(uiText('common.installation.none'), 'info');
   let installation: Installation | undefined;
   if (target.installationId) {
     installation = installations.find((item) => item.id === target.installationId);
-    if (!installation) return void ui.notify(`找不到 Installed Plugin ${labelText(target.installationId)}。`, 'warning');
+    if (!installation) {
+      return void ui.notify(uiText('inst.notFound.installation', { id: labelText(target.installationId) }), 'warning');
+    }
   } else {
     const labels = installations.map((item) => `${labelText(item.manifestName ?? item.pluginId)} · ${item.installationState} · ${labelText(item.id)}`);
-    const chosen = await ui.select('選擇 Installed Plugin', labels);
+    const chosen = await ui.select(uiText('inst.select.installed'), labels);
     if (!chosen) return;
     installation = installations[labels.indexOf(chosen)];
     if (!installation) return;
@@ -415,7 +479,9 @@ export async function runPluginStateFlow(
   const currentRevision = state.state?.stateRevision ?? '?';
   const desiredState = target.desiredState ??
     (installation.installationState === 'enabled' ? 'disabled' : 'enabled');
-  const actionLabel = desiredState === 'disabled' ? 'Plugin Disablement' : 'Plugin Enablement';
+  const actionLabel = desiredState === 'disabled'
+    ? uiText('inst.actionLabel.disablement')
+    : uiText('inst.actionLabel.enablement');
   const initialModel = {
     actionLabel,
     authority: scope,
@@ -427,8 +493,8 @@ export async function runPluginStateFlow(
     ...initialModel,
     step: 'Intent',
     details: [
-      `Installation ${quoteTerminalText(installation.id)}`,
-      `Current state ${quoteTerminalText(installation.installationState)}`,
+      uiText('inst.detail.installation', { id: quoteTerminalText(installation.id) }),
+      uiText('inst.detail.currentState', { state: quoteTerminalText(installation.installationState) }),
     ],
   })) return;
   if (desiredState === 'disabled') {

--- a/extensions/pi/journal.ts
+++ b/extensions/pi/journal.ts
@@ -17,7 +17,8 @@ import { acquireAttemptFence } from '../../src/registration/fence.js';
 import { blocking, CODE, notice, RULE, type ValidationFinding } from '../../src/registration/findings.js';
 import { createReceipt, type AttemptReceipt } from '../../src/registration/receipt.js';
 import { fullValidationDisclosureLines, reportOutcome } from './registration.js';
-import { attemptSummaryText, uiText } from './ui-strings.js';
+import { attemptSummaryText, uiText,
+  scopeOptions } from './ui-strings.js';
 import { quoteTerminalText } from './terminal-presentation.js';
 import { openTransactionSheet, type TransactionSheetModel } from './transaction-sheet.js';
 
@@ -31,10 +32,7 @@ async function pickScope(
   explicit?: Scope,
 ): Promise<Scope | undefined> {
   if (explicit) return explicit;
-  const labels = new Map<string, Scope>([
-    [uiText('common.scope.global'), 'global'],
-    [uiText('common.scope.project'), 'project'],
-  ]);
+  const labels = scopeOptions();
   const selected = await ui.select(prompt, [...labels.keys()]);
   return selected ? labels.get(selected) : undefined;
 }

--- a/extensions/pi/journal.ts
+++ b/extensions/pi/journal.ts
@@ -1,5 +1,6 @@
 /**
  * TUI flows for Receipt Journal inspection and State Repair action (Issue #23).
+ * All user-visible strings come from the centralized ui-strings module (Issue #41).
  */
 
 import type { ExtensionCommandContext, ExtensionUIContext } from '@earendil-works/pi-coding-agent';
@@ -16,6 +17,7 @@ import { acquireAttemptFence } from '../../src/registration/fence.js';
 import { blocking, CODE, notice, RULE, type ValidationFinding } from '../../src/registration/findings.js';
 import { createReceipt, type AttemptReceipt } from '../../src/registration/receipt.js';
 import { fullValidationDisclosureLines, reportOutcome } from './registration.js';
+import { attemptSummaryText, uiText } from './ui-strings.js';
 import { quoteTerminalText } from './terminal-presentation.js';
 import { openTransactionSheet, type TransactionSheetModel } from './transaction-sheet.js';
 
@@ -30,8 +32,8 @@ async function pickScope(
 ): Promise<Scope | undefined> {
   if (explicit) return explicit;
   const labels = new Map<string, Scope>([
-    ['Global Scope', 'global'],
-    ['Project Scope', 'project'],
+    [uiText('common.scope.global'), 'global'],
+    [uiText('common.scope.project'), 'project'],
   ]);
   const selected = await ui.select(prompt, [...labels.keys()]);
   return selected ? labels.get(selected) : undefined;
@@ -52,7 +54,9 @@ function receiptPersistenceFailureFinding(
     scope: receipt.scope,
     pointer: '',
     rule: RULE.RECEIPT_PERSISTENCE_FAILED,
-    outcome: `Failed to persist Attempt Receipt to journal: ${appended.error ?? 'unknown append failure'}`,
+    outcome: uiText('journal.finding.persistFailed', {
+      error: appended.error ?? uiText('common.unknown'),
+    }),
   });
 }
 
@@ -252,7 +256,7 @@ async function runRetryApplicationUnderFence(
         scope,
         CODE.REJECTED_AS_STALE,
         RULE.REJECTED_AS_STALE,
-        'The selected Pending Application recovery chain is no longer active; reopen the Bridge Ledger',
+        uiText('journal.retry.chainStale'),
       )],
     });
     return;
@@ -270,7 +274,7 @@ async function runRetryApplicationUnderFence(
         scope,
         CODE.PERSISTENCE_INDETERMINATE,
         RULE.STATE_CORRUPT,
-        state.error ?? 'Bridge State is unreadable; Runtime Application cannot be verified',
+        state.error ?? uiText('journal.retry.unreadable'),
         'persistence',
       )],
       attachToChain: true,
@@ -288,7 +292,10 @@ async function runRetryApplicationUnderFence(
         scope,
         CODE.REJECTED_AS_STALE,
         RULE.REJECTED_AS_STALE,
-        `State Revision changed (${chain.stateRevision} → ${state.state!.stateRevision}); reopen the Bridge Ledger`,
+        uiText('journal.retry.staleDuringConfirm', {
+          expected: chain.stateRevision,
+          observed: state.state!.stateRevision,
+        }),
         'persistence',
       )],
       attachToChain: true,
@@ -305,7 +312,7 @@ async function runRetryApplicationUnderFence(
         scope,
         CODE.REJECTED_AS_STALE,
         RULE.REJECTED_AS_STALE,
-        'The active Pending Application root has no bound Validation Snapshot; fail closed and revalidate from a fresh Intent',
+        uiText('journal.retry.noSnapshot'),
       )],
       attachToChain: true,
     });
@@ -322,7 +329,7 @@ async function runRetryApplicationUnderFence(
         scope,
         CODE.REJECTED_AS_STALE,
         RULE.REJECTED_AS_STALE_SNAPSHOT,
-        'The bound Validation Snapshot no longer matches live source material; reopen the Bridge Ledger and revalidate',
+        uiText('journal.retry.snapshotMismatch'),
         'validation',
       )],
       attachToChain: true,
@@ -340,7 +347,7 @@ async function runRetryApplicationUnderFence(
         scope,
         CODE.PROJECT_TRUST_DENIED,
         RULE.PROJECT_TRUST_DENIED,
-        'Project Trust is not granted; Project Runtime Application is unavailable',
+        uiText('journal.retry.trustDenied'),
       )],
       attachToChain: true,
     });
@@ -359,7 +366,7 @@ async function runRetryApplicationUnderFence(
           scope,
           CODE.GLOBAL_PENDING_BARRIER,
           RULE.GLOBAL_PENDING_BARRIER,
-          barrier.reason ?? 'Global recovery is required first',
+          barrier.reason ?? uiText('journal.retry.barrierRequired'),
         )],
         attachToChain: true,
       });
@@ -368,7 +375,7 @@ async function runRetryApplicationUnderFence(
   }
 
   const model = {
-    actionLabel: 'Retry Runtime Application',
+    actionLabel: uiText('ledger.action.retry-application'),
     authority: scope,
     target: receiptId,
     stateRevision: chain.stateRevision,
@@ -386,36 +393,38 @@ async function runRetryApplicationUnderFence(
   if (!await showTransactionStep(ctx, {
     ...model,
     step: 'Intent',
-    details: ['Retry only the selected active Pending Application chain; Bridge State is not rewritten'],
+    details: [uiText('journal.retry.intent.details')],
   })) return void await decline();
   if (!await showTransactionStep(ctx, {
     ...model,
     step: 'Validation',
     details: [
       ...fullValidationDisclosureLines(rootReceipt.findings),
-      `Active recovery root ${quote(receiptId)}`,
-      `Exact State Revision ${quote(chain.stateRevision)}`,
-      `Bound Validation Snapshot ${quote(rootReceipt.validationSnapshot ?? '(not recorded)')}`,
+      uiText('journal.retry.validation.root', { receiptId: quote(receiptId) }),
+      uiText('journal.retry.validation.revision', { revision: quote(chain.stateRevision) }),
+      uiText('journal.retry.validation.snapshot', {
+        snapshot: quote(rootReceipt.validationSnapshot ?? uiText('journal.retry.validation.snapshotMissing')),
+      }),
     ],
   })) return void await decline();
   if (!await showTransactionStep(ctx, {
     ...model,
     step: 'Consent',
-    details: ['Retry Application Confirmation is explicit and defaults to No'],
+    details: [uiText('journal.retry.consent.details')],
   })) return void await decline();
   if (!await ctx.ui.confirm(
-    'Retry Application Confirmation — 預設 No',
-    `重新載入 Bridge resources 並驗證 ${scope} State Revision ${quote(chain.stateRevision)}？`,
+    uiText('journal.retry.consent.title'),
+    uiText('journal.retry.consent.body', { scope, revision: quote(chain.stateRevision) }),
   )) return void await decline();
   if (!await showTransactionStep(ctx, {
     ...model,
     step: 'Plan',
-    details: ['Ask the Pi host to reload, then verify Bridge re-entry at the exact bound State Revision'],
+    details: [uiText('journal.retry.plan.details')],
   })) return void await decline();
   if (!await showTransactionStep(ctx, {
     ...model,
     step: 'Commit',
-    details: ['No Bridge State write; append a resolving Receipt only after exact post-reload verification'],
+    details: [uiText('journal.retry.commit.details')],
   })) return void await decline();
 
   // Consent can remain open while either Bridge State or live source material changes.
@@ -432,7 +441,7 @@ async function runRetryApplicationUnderFence(
         scope,
         CODE.PERSISTENCE_INDETERMINATE,
         RULE.STATE_CORRUPT,
-        preReloadState.error ?? 'Bridge State became unreadable before Runtime Application',
+        preReloadState.error ?? uiText('journal.retry.persistenceBeforeReload'),
         'persistence',
       )],
       attachToChain: true,
@@ -450,7 +459,10 @@ async function runRetryApplicationUnderFence(
         scope,
         CODE.REJECTED_AS_STALE,
         RULE.REJECTED_AS_STALE,
-        `State Revision changed during confirmation (${chain.stateRevision} → ${preReloadState.state!.stateRevision}); Runtime Application was not requested`,
+        uiText('journal.retry.staleDuringConfirm', {
+          expected: chain.stateRevision,
+          observed: preReloadState.state!.stateRevision,
+        }),
         'persistence',
       )],
       attachToChain: true,
@@ -468,7 +480,7 @@ async function runRetryApplicationUnderFence(
         scope,
         CODE.REJECTED_AS_STALE,
         RULE.REJECTED_AS_STALE_SNAPSHOT,
-        'The bound Validation Snapshot changed during confirmation; Runtime Application was not requested',
+        uiText('journal.retry.staleDuringConfirmSnapshot'),
         'validation',
       )],
       attachToChain: true,
@@ -486,7 +498,7 @@ async function runRetryApplicationUnderFence(
         scope,
         CODE.PROJECT_TRUST_DENIED,
         RULE.PROJECT_TRUST_DENIED,
-        'Project Trust was revoked during confirmation; Runtime Application was not requested',
+        uiText('journal.retry.trustRevoked'),
       )],
       attachToChain: true,
     });
@@ -505,7 +517,7 @@ async function runRetryApplicationUnderFence(
           scope,
           CODE.GLOBAL_PENDING_BARRIER,
           RULE.GLOBAL_PENDING_BARRIER,
-          barrier.reason ?? 'Global recovery became required during confirmation',
+          barrier.reason ?? uiText('journal.retry.barrierDuringConfirm'),
         )],
         attachToChain: true,
       });
@@ -532,7 +544,7 @@ async function runRetryApplicationUnderFence(
           scope,
           CODE.PROJECT_TRUST_DENIED,
           RULE.PROJECT_TRUST_DENIED,
-          'Project Trust was revoked during host reload; Project Runtime Application remains blocked',
+          uiText('journal.retry.trustRevokedReload'),
         );
         throw postReloadGuardBlocked;
       }
@@ -543,7 +555,7 @@ async function runRetryApplicationUnderFence(
             scope,
             CODE.GLOBAL_PENDING_BARRIER,
             RULE.GLOBAL_PENDING_BARRIER,
-            barrier.reason ?? 'Global recovery became required during host reload',
+            barrier.reason ?? uiText('journal.retry.barrierDuringReload'),
           );
           throw postReloadGuardBlocked;
         }
@@ -577,14 +589,14 @@ export async function runReceiptJournalView(
   target: ReceiptJournalViewTarget = {},
 ): Promise<void> {
   const ui: ExtensionUIContext = ctx.ui;
-  const scope = await pickScope(ui, 'Receipt Journal — 選擇 Scope', target.scope);
+  const scope = await pickScope(ui, uiText('journal.pick.scope'), target.scope);
   if (!scope) return;
 
   const journal = await readReceiptJournal(scope, { cwd: ctx.cwd });
   if (target.receiptId) {
     const receipt = journal.receipts.find((item) => item.id === target.receiptId);
     if (!receipt) {
-      ui.notify(`Receipt Journal 找不到精確 Receipt ID ${quote(target.receiptId)}。`, 'warning');
+      ui.notify(uiText('journal.notFound', { receiptId: quote(target.receiptId) }), 'warning');
       return;
     }
     await reportOutcome(ctx, { receipt });
@@ -592,31 +604,48 @@ export async function runReceiptJournalView(
   }
 
   const lines: string[] = [
-    `=== ${scope === 'global' ? 'Global' : 'Project'} Receipt Journal ===`,
-    `Total Receipts: ${journal.receipts.length}`,
-    `Degraded: ${journal.isDegraded ? `Yes (${journal.corruptedLineCount} corrupted lines)` : 'No'}`,
-    `Active Recovery Chains: ${journal.activeChains.length === 0 ? 'None' : ''}`,
+    uiText('journal.view.header', { scopeWord: scope === 'global' ? uiText('common.scope.word.global') : uiText('common.scope.word.project') }),
+    uiText('journal.view.total', { count: journal.receipts.length }),
+    journal.isDegraded
+      ? uiText('journal.view.degraded.yes', { count: journal.corruptedLineCount })
+      : uiText('journal.view.degraded.no'),
+    uiText('journal.view.chains.header', {
+      value: journal.activeChains.length === 0 ? uiText('journal.view.chains.none') : '',
+    }),
   ];
 
   for (const chain of journal.activeChains) {
-    lines.push(`  Chain ${quote(chain.rootReceiptId)} condition: ${quote(chain.condition)} (length: ${chain.receipts.length})`);
+    lines.push('  ' + uiText('journal.view.chain.line', {
+      receiptId: quote(chain.rootReceiptId),
+      condition: quote(chain.condition),
+      length: chain.receipts.length,
+    }));
   }
 
   lines.push('');
-  lines.push('--- Recent Receipts ---');
+  lines.push(uiText('journal.view.recent.header'));
   const recent = journal.receipts.slice(-10).reverse();
   if (recent.length === 0) {
-    lines.push('  (Journal is empty)');
+    lines.push('  ' + uiText('journal.view.recent.empty'));
   } else {
     for (const rc of recent) {
       lines.push(`${quote(rc.id)} ${quote(rc.completedAt)} · ${quote(rc.operation)} (${rc.scope})`);
-      lines.push(`  Summary: ${quote(rc.summary)} | Durable: ${quote(rc.durableOutcome)} | Runtime: ${quote(rc.runtimeOutcome)}`);
-      lines.push(`  Revision: ${quote(rc.expectedStateRevision)} → ${quote(rc.observedStateRevision ?? rc.targetStateRevision ?? '?')}`);
+      lines.push('  ' + uiText('journal.view.receipt.summary', {
+        summary: attemptSummaryText(rc.summary),
+        durable: quote(rc.durableOutcome),
+        runtime: quote(rc.runtimeOutcome),
+      }));
+      lines.push('  ' + uiText('journal.view.receipt.revision', {
+        expected: quote(rc.expectedStateRevision),
+        observed: quote(rc.observedStateRevision ?? rc.targetStateRevision ?? '?'),
+      }));
       if (rc.recoversReceiptId) {
-        lines.push(`  Recovers: ${quote(rc.recoversReceiptId)}`);
+        lines.push('  ' + uiText('journal.view.receipt.recovers', { receiptId: quote(rc.recoversReceiptId) }));
       }
       if (rc.findings.length > 0) {
-        lines.push(`  Findings: ${rc.findings.map((finding) => `${finding.classification} ${quote(finding.code)}`).join(', ')}`);
+        lines.push('  ' + uiText('journal.view.receipt.findings', {
+          findings: rc.findings.map((finding) => `${finding.classification} ${quote(finding.code)}`).join(', '),
+        }));
       }
       lines.push('');
     }
@@ -635,7 +664,7 @@ export async function runRepairStateFlow(
   target: RepairStateTarget = {},
 ): Promise<void> {
   const ui: ExtensionUIContext = ctx.ui;
-  const scope = await pickScope(ui, 'Repair State — 選擇 Scope', target.scope);
+  const scope = await pickScope(ui, uiText('journal.repair.pick.scope'), target.scope);
   if (!scope) return;
 
   const [initial, initialJournal] = await Promise.all([
@@ -649,7 +678,7 @@ export async function runRepairStateFlow(
     stateRevision: selectedStateRevision,
   };
   const model = {
-    actionLabel: 'Repair State',
+    actionLabel: uiText('ledger.action.repair-state'),
     authority: scope,
     target: `${scope} Bridge State`,
     stateRevision: selectedStateRevision,
@@ -660,7 +689,7 @@ export async function runRepairStateFlow(
         scope,
         initial.status === 'incompatible' ? CODE.PERSISTENCE_INDETERMINATE : CODE.PERSISTENCE_INDETERMINATE,
         initial.status === 'incompatible' ? RULE.STATE_SCHEMA_UNKNOWN : RULE.STATE_CORRUPT,
-        initial.error ?? `Bridge State is ${initial.status}`,
+        initial.error ?? uiText('journal.repair.stateError', { status: initial.status }),
         'persistence',
       )];
   const repairFindings = [...stateFindings, ...initialJournal.findings];
@@ -672,30 +701,34 @@ export async function runRepairStateFlow(
   if (!await showTransactionStep(ctx, {
     ...model,
     step: 'Intent',
-    details: ['Verify the exact authoritative Bridge State and reconstruct degraded Receipt Journal lines when eligible'],
+    details: [uiText('journal.repair.intent.details')],
   })) return void await decline();
   if (!await showTransactionStep(ctx, {
     ...model,
     step: 'Validation',
     details: [
       ...fullValidationDisclosureLines(repairFindings),
-      `Current read status: ${initial.status}`,
-      `Current diagnostic: ${quote(initial.error ?? 'none')}`,
-      `Receipt Journal: ${initialJournal.isDegraded ? `${initialJournal.corruptedLineCount} corrupted line(s)` : 'healthy'}`,
-      `Receipt Journal revision: ${initialJournal.revision}`,
-      `Receipt Journal repair eligibility: ${expected.journalEligibility}`,
-      'The domain Recovery Action will revalidate under the Attempt Fence; this presentation result does not authorize repair',
+      uiText('journal.repair.validation.status', { status: initial.status }),
+      uiText('journal.repair.validation.diagnostic', { error: quote(initial.error ?? uiText('journal.repair.validation.diagnosticNone')) }),
+      initialJournal.isDegraded
+        ? uiText('journal.repair.validation.journalDegraded', { count: initialJournal.corruptedLineCount })
+        : uiText('journal.repair.validation.journalHealthy'),
+      uiText('journal.repair.validation.journalRevision', { revision: initialJournal.revision }),
+      uiText('journal.repair.validation.eligibility', { eligibility: expected.journalEligibility }),
+      uiText('journal.repair.validation.domainGuard'),
     ],
   })) return void await decline();
   if (!await showTransactionStep(ctx, {
     ...model,
     step: 'Consent',
-    details: ['Repair State Confirmation remains a separate Default No decision'],
+    details: [uiText('journal.repair.consent.details')],
   })) return void await decline();
 
   const confirmed = await ui.confirm(
-    'Repair State Confirmation — 預設 No',
-    `執行 ${scope === 'global' ? 'Global' : 'Project'} Scope 的 State Repair？\n將在 Attempt Fence 保護下驗證 Bridge State，重建可辨識的 Receipt Journal，並解除相應的 Indeterminate/Degraded recovery chain。`,
+    uiText('journal.repair.consent.title'),
+    uiText('journal.repair.consent.body', {
+      scopeWord: scope === 'global' ? uiText('common.scope.word.global') : uiText('common.scope.word.project'),
+    }),
   );
   if (!confirmed) {
     return void await decline();
@@ -704,12 +737,12 @@ export async function runRepairStateFlow(
   if (!await showTransactionStep(ctx, {
     ...model,
     step: 'Plan',
-    details: ['Validate state readability/schema and atomically retain only verified Receipt lines; do not retry a lifecycle operation or roll state back'],
+    details: [uiText('journal.repair.plan.details')],
   })) return void await decline();
   if (!await showTransactionStep(ctx, {
     ...model,
     step: 'Commit',
-    details: ['The domain guard will acquire the scope Attempt Fence and append the resulting immutable Receipt'],
+    details: [uiText('journal.repair.commit.details')],
   })) return void await decline();
 
   const res = await repairBridgeState(scope, {

--- a/extensions/pi/lifecycle.ts
+++ b/extensions/pi/lifecycle.ts
@@ -4,7 +4,8 @@
  *
  * All consent surfaces Default No and are bound to Validation Snapshot + State Revision by the
  * underlying src/lifecycle seams; this layer only collects explicit user outcomes and reports
- * Attempt Summary receipts.
+ * Attempt Summary receipts. All user-visible strings come from the centralized ui-strings
+ * module (Issue #41).
  */
 
 import type { ExtensionCommandContext, ExtensionUIContext } from '@earendil-works/pi-coding-agent';
@@ -16,8 +17,6 @@ import {
   applyUpdate,
   preflightRebind,
   refreshRegistration,
-  registrationRemovalDisclosure,
-  installationRemovalDisclosure,
   confirmRegistrationRemoval,
   confirmInstallationRemoval,
   preflightRegistrationRemoval,
@@ -25,6 +24,8 @@ import {
   type LifecycleFlowOptions,
   type RebindTarget,
   type UpdateCandidate,
+  type RegistrationRemovalPreflight,
+  type InstallationRemovalPreflight,
 } from '../../src/lifecycle/index.js';
 import { buildUpdatePlan, compatibleCandidateIds, type InstallationChoice } from '../../src/lifecycle/update-plan.js';
 import { createReceipt, type AttemptReceipt } from '../../src/registration/receipt.js';
@@ -33,6 +34,7 @@ import {
   reportOutcome,
   validationDisclosureLines,
 } from './registration.js';
+import { attemptSummaryText, uiText } from './ui-strings.js';
 import { quoteTerminalText } from './terminal-presentation.js';
 import { openTransactionSheet, type TransactionSheetModel } from './transaction-sheet.js';
 
@@ -49,9 +51,17 @@ export function planChoicesFor(
   return installations.map((installation) => ({
     installation,
     options: [
-      { label: `update — 套用新快照（${compatible.has(installation.pluginId) ? '有 Compatible candidate' : '無 candidate → 不可選'}）`, value: 'update', enabled: compatible.has(installation.pluginId) },
-      { label: 'disable — 停用並保留 Installation ID', value: 'disable', enabled: true },
-      { label: 'remove — 移除此 Installation', value: 'remove', enabled: true },
+      {
+        label: uiText('life.plan.choice.update', {
+          detail: compatible.has(installation.pluginId)
+            ? uiText('life.plan.choice.update.compatible')
+            : uiText('life.plan.choice.update.incompatible'),
+        }),
+        value: 'update',
+        enabled: compatible.has(installation.pluginId),
+      },
+      { label: uiText('life.plan.choice.disable'), value: 'disable', enabled: true },
+      { label: uiText('life.plan.choice.remove'), value: 'remove', enabled: true },
     ],
   }));
 }
@@ -77,20 +87,27 @@ export function candidateSummary(candidate: UpdateCandidate): string {
     ]),
   ).values()];
   const lines = [
-    `Scope: ${candidate.scope}`,
-    `Registration: ${candidate.registrationId.slice(0, 8)}…`,
-    `Marketplace: ${quote(candidate.marketplaceName || '(unchanged name)')}`,
-    `New Validation Snapshot: ${candidate.snapshot.fingerprint.slice(0, 16)}…`,
-    `Recorded Snapshot: ${(candidate.recordedFingerprint ?? '(none)').slice(0, 16)}…`,
+    uiText('life.candidate.scope', { scope: candidate.scope }),
+    uiText('life.candidate.registration', { id: `${candidate.registrationId.slice(0, 8)}…` }),
+    uiText('reg.detail.marketplace', { name: quote(candidate.marketplaceName || `(${uiText('common.none')})`) }),
+    uiText('life.candidate.newSnapshot', { snapshot: candidate.snapshot.fingerprint.slice(0, 16) }),
+    uiText('life.candidate.recordedSnapshot', { snapshot: (candidate.recordedFingerprint ?? uiText('common.none')).slice(0, 16) }),
   ];
   if (candidate.resolvedRevision) {
-    lines.push(`Resolved Revision: ${candidate.recordedResolvedRevision ?? '(none)'.slice(0, 12)} → ${candidate.resolvedRevision}`);
+    lines.push(uiText('life.candidate.resolvedRevision', {
+      from: candidate.recordedResolvedRevision ?? uiText('common.none'),
+      to: candidate.resolvedRevision,
+    }));
   }
   const available = candidate.inspection.entries.filter((item) => item.plugin && !item.unavailableReason).length;
-  lines.push(`Entries: ${candidate.inspection.entries.length}（${available} 可安裝）`);
+  lines.push(uiText('life.candidate.entries', { total: candidate.inspection.entries.length, available }));
   lines.push(...fullValidationDisclosureLines(findings));
   for (const entry of candidate.inspection.entries) {
-    lines.push(`  ${quote(entry.entry.entryId)} ${entry.plugin ? `· ${quote(entry.plugin.manifestName)} ` : ''}— ${entry.unavailableReason ? `unavailable (${quote(entry.unavailableReason)})` : '可安裝'}`);
+    lines.push(`  ${quote(entry.entry.entryId)} ${entry.plugin ? `· ${quote(entry.plugin.manifestName)} ` : ''}— ${
+      entry.unavailableReason
+        ? uiText('common.unavailable') + `（${quote(entry.unavailableReason)}）`
+        : uiText('inst.entry.available')
+    }`);
   }
   return lines.join('\n');
 }
@@ -102,7 +119,7 @@ export async function attemptReport(
   const journal = await appendReceipt(outcome.receipt.scope, outcome.receipt, { cwd: ctx.cwd });
   await reportOutcome(ctx, outcome);
   if (!journal.success) {
-    ctx.ui.notify(`Receipt Journal 寫入失敗：${quote(journal.error ?? 'unknown error')}`, 'warning');
+    ctx.ui.notify(uiText('journal.appendFailed', { error: quote(journal.error ?? uiText('common.unknown')) }), 'warning');
   }
 }
 
@@ -116,10 +133,10 @@ function lifecycleOptions(ctx: ExtensionCommandContext): LifecycleFlowOptions {
 
 async function pickScope(ui: ExtensionUIContext): Promise<Scope | undefined> {
   const labels = new Map<string, Scope>([
-    ['Global Scope', 'global'],
-    ['Project Scope', 'project'],
+    [uiText('common.scope.global'), 'global'],
+    [uiText('common.scope.project'), 'project'],
   ]);
-  const choice = await ui.select('選擇 Scope', [...labels.keys()]);
+  const choice = await ui.select(uiText('life.pick.scope'), [...labels.keys()]);
   return choice ? labels.get(choice) : undefined;
 }
 
@@ -137,7 +154,7 @@ async function pickRegistration(
   const opts = lifecycleOptions(ctx);
   const state = await readBridgeState(scope, opts);
   if (state.status !== 'ok' && state.status !== 'missing') {
-    ui.notify(`Bridge State 不可讀：${quote(state.error ?? 'Persistence Indeterminate')}`, 'error');
+    ui.notify(uiText('common.bridgeState.unreadable', { error: quote(state.error ?? 'Persistence Indeterminate') }), 'error');
     return undefined;
   }
   const registrations = state.state?.registrations ?? [];
@@ -150,11 +167,11 @@ async function pickRegistration(
     };
   }
   if (registrations.length === 0) {
-    ui.notify('此 Scope 尚無 Marketplace Registration。', 'info');
+    ui.notify(uiText('common.registration.none'), 'info');
     return undefined;
   }
   const labels = registrations.map((r) => `${quote(r.alias ?? r.marketplaceName ?? r.id)} · ${r.sourceKind ?? '?'} · ${r.id}`);
-  const chosen = await ui.select('選擇 Marketplace Registration', labels);
+  const chosen = await ui.select(uiText('life.pick.registration'), labels);
   if (!chosen) return undefined;
   const registration = registrations[labels.indexOf(chosen)]!;
   return {
@@ -163,6 +180,55 @@ async function pickRegistration(
     validationSnapshot: registration.validationSnapshot,
     opts,
   };
+}
+
+/**
+ * Localized presentation of the Registration Removal cascade disclosure.
+ * Mirrors src/lifecycle/removal.ts disclosure content in the presentation language.
+ */
+export function localizedRegistrationRemovalDisclosure(pf: RegistrationRemovalPreflight): string {
+  const lines = [
+    uiText('life.removal.disclosure.scope', { scope: pf.scope }),
+    pf.registrationSource
+      ? uiText('life.removal.disclosure.registration', {
+          id: `${pf.registrationId.slice(0, 8)}…`,
+          source: quote(JSON.stringify(pf.registrationSource)),
+        })
+      : uiText('life.removal.disclosure.registration.noSource', { id: `${pf.registrationId.slice(0, 8)}…` }),
+    uiText('life.removal.disclosure.revision', { revision: pf.stateRevision }),
+    uiText('life.removal.disclosure.cascade', { count: pf.affectedInstallations.length }),
+  ];
+  for (const installation of pf.affectedInstallations) {
+    lines.push('  ' + quote(JSON.stringify(installation.id)) + ' · ' +
+      quote(JSON.stringify(installation.pluginId)) + ' · ' + installation.installationState);
+  }
+  lines.push(uiText('life.removal.disclosure.otherScopes'));
+  return lines.join('\n');
+}
+
+/** Localized presentation of the Installation Removal disclosure. */
+export function localizedInstallationRemovalDisclosure(pf: InstallationRemovalPreflight): string {
+  const lines = [
+    uiText('life.removal.disclosure.scope', { scope: pf.scope }),
+    uiText('life.removal.disclosure.installationLine', {
+      id: quote(JSON.stringify(pf.installation.id)),
+      pluginId: quote(JSON.stringify(pf.installation.pluginId)),
+      state: pf.installation.installationState,
+    }),
+    pf.registrationId
+      ? uiText('life.removal.disclosure.retainedRegistration', { id: pf.registrationId.slice(0, 8) + '…' })
+      : uiText('life.removal.disclosure.retainedNone'),
+    uiText('life.removal.disclosure.revision', { revision: pf.stateRevision }),
+  ];
+  if (pf.resumingInheritedInstallations.length > 0) {
+    lines.push(uiText('life.removal.disclosure.resuming.header'));
+    for (const inherited of pf.resumingInheritedInstallations) {
+      lines.push('  ' + quote(JSON.stringify(inherited.id)) + ' · ' + quote(JSON.stringify(inherited.pluginId)));
+    }
+  } else {
+    lines.push(uiText('life.removal.disclosure.resuming.none'));
+  }
+  return lines.join('\n');
 }
 
 /**
@@ -182,13 +248,17 @@ export async function runUpdatePlanChecklist(
   const ui = ctx.ui;
   const opts = lifecycleOptions(ctx);
   const state = await readBridgeState(scope, opts);
-  if (state.status !== 'ok' && state.status !== 'missing') return void ui.notify(`Bridge State 不可讀：${quote(state.error ?? 'Persistence Indeterminate')}`, 'error');
+  if (state.status !== 'ok' && state.status !== 'missing') {
+    return void ui.notify(uiText('common.bridgeState.unreadable', { error: quote(state.error ?? 'Persistence Indeterminate') }), 'error');
+  }
 
   // Strictly this Registration's own scope-local Installations — independent Registrations and
   // Installations are never combined into a batch (CONTEXT.md: Lifecycle Operation).
   const installations = (state.state?.installations ?? []).filter((i) => i.registrationId === candidate.registrationId);
 
-  const actionLabel = kind === 'rebind' ? 'Registration Rebind' : 'Apply Update';
+  const actionLabel = kind === 'rebind' ? uiText('life.actionLabel.rebind') : uiText('life.actionLabel.applyUpdate');
+  // Receipts store the canonical operation identity; display labels stay presentation-local.
+  const operation = kind === 'rebind' ? 'Registration Rebind' : 'Apply Update';
   const commonModel = {
     actionLabel,
     authority: scope,
@@ -203,7 +273,7 @@ export async function runUpdatePlanChecklist(
   ): Promise<void> => {
     await attemptReport(ctx, {
       receipt: createReceipt({
-        operation: actionLabel,
+        operation,
         scope,
         trigger: `${kind} ${candidate.registrationId}`,
         expectedStateRevision: stateRevision,
@@ -218,7 +288,9 @@ export async function runUpdatePlanChecklist(
   if (!transaction.intentShown && !await showTransactionStep(ctx, {
     ...commonModel,
     step: 'Intent',
-    details: [kind === 'rebind' ? 'Replace the Registration source while preserving its canonical ID' : 'Apply the exact Update Candidate in one Lifecycle Operation'],
+    details: [kind === 'rebind'
+      ? uiText('life.updatePlan.intent.rebind')
+      : uiText('life.updatePlan.intent.apply')],
   })) {
     await concludeWithoutCommit('Declined');
     return;
@@ -233,12 +305,12 @@ export async function runUpdatePlanChecklist(
     return;
   }
 
-  ui.notify(`Validation Disclosure（新快照）：\n${candidateSummary(candidate)}`, 'info');
+  ui.notify(uiText('life.updatePlan.notifyDisclosure', { summary: candidateSummary(candidate) }), 'info');
 
   if (!await showTransactionStep(ctx, {
     ...commonModel,
     step: 'Consent',
-    details: ['Registration Confirmation and every required Activation Confirmation remain separate Default No decisions'],
+    details: [uiText('life.updatePlan.consent.details')],
   })) {
     await concludeWithoutCommit('Declined');
     return;
@@ -246,8 +318,8 @@ export async function runUpdatePlanChecklist(
 
   // Fresh Registration Confirmation — Default No, bound to the candidate snapshot + revision.
   const registrationConfirmed = await ui.confirm(
-    'Registration Confirmation — 預設 No（綁定新 Validation Snapshot + State Revision）',
-    `接受此新的 Validation Snapshot 作為 Registration ${candidate.registrationId.slice(0, 8)}… 的授權來源？`,
+    uiText('life.updatePlan.confirmRegistration.title'),
+    uiText('life.updatePlan.confirmRegistration.body', { id: candidate.registrationId.slice(0, 8) }),
   );
   if (!registrationConfirmed) {
     await concludeWithoutCommit('Declined');
@@ -257,7 +329,7 @@ export async function runUpdatePlanChecklist(
   if (!await showTransactionStep(ctx, {
     ...commonModel,
     step: 'Plan',
-    details: [`Installations requiring an explicit outcome: ${installations.length}`],
+    details: [uiText('life.updatePlan.plan.details', { count: installations.length })],
   })) {
     await concludeWithoutCommit('Declined');
     return;
@@ -269,7 +341,10 @@ export async function runUpdatePlanChecklist(
   for (const { installation, options } of planChoicesFor(installations, candidate)) {
     const selectable = options.filter((o) => o.enabled);
     const picked = await ui.select(
-      `Installation ${quote(installation.manifestName ?? installation.pluginId)}（${installation.installationState}）— 選擇更新結果`,
+      uiText('life.updatePlan.pick.title', {
+        name: quote(installation.manifestName ?? installation.pluginId),
+        state: installation.installationState,
+      }),
       selectable.map((o) => o.label),
     );
     if (!picked) {
@@ -284,8 +359,8 @@ export async function runUpdatePlanChecklist(
     const willStayEnabled = installation.installationState === 'enabled' && choices[installation.id] === 'update';
     if (!willStayEnabled) continue;
     const confirmed = await ui.confirm(
-      'Activation Confirmation — 預設 No（舊同意不沿用）',
-      `啟用的 ${quote(installation.manifestName ?? installation.pluginId)} 將在新快照下保持啟用。確認其 Activation？`,
+      uiText('life.updatePlan.activation.title'),
+      uiText('life.updatePlan.activation.body', { name: quote(installation.manifestName ?? installation.pluginId) }),
     );
     activationConfirmations[installation.id] = confirmed;
     if (!confirmed) {
@@ -308,15 +383,19 @@ export async function runUpdatePlanChecklist(
 
   // Final checklist review before the single atomic commit.
   const checklist = plan.plan.entries
-    .map((entry) => `· ${entry.installationId.slice(0, 16)}… → ${entry.choice}${entry.choice === 'update' ? `（${entry.installationState}）` : ''}`)
+    .map((entry) => uiText('life.updatePlan.checklist.entry', {
+      installationId: `${entry.installationId.slice(0, 16)}…`,
+      choice: entry.choice,
+      state: entry.choice === 'update' ? `（${entry.installationState}）` : '',
+    }))
     .join('\n');
 
   if (!await showTransactionStep(ctx, {
     ...commonModel,
     step: 'Commit',
     details: [
-      'The complete Update Plan will commit atomically after the final Default No confirmation',
-      ...(checklist ? checklist.split('\n') : ['No existing Installation consequences']),
+      uiText('life.updatePlan.commit.details'),
+      ...(checklist ? checklist.split('\n') : [uiText('life.updatePlan.commit.noConsequences')]),
     ],
   })) {
     await concludeWithoutCommit('Declined');
@@ -324,8 +403,10 @@ export async function runUpdatePlanChecklist(
   }
 
   const proceed = await ui.confirm(
-    kind === 'rebind' ? 'Apply Rebind — 單次原子提交' : 'Apply Update — 單次原子提交',
-    `將以單一 Lifecycle Operation 原子替換快照並套用所有披露後果：\n${checklist || '（無既有 Installation）'}\n\n確認提交？`,
+    kind === 'rebind' ? uiText('life.updatePlan.commit.confirm.rebind.title') : uiText('life.updatePlan.commit.confirm.apply.title'),
+    uiText('life.updatePlan.commit.confirm.body', {
+      checklist: checklist || uiText('life.updatePlan.commit.confirm.empty'),
+    }),
   );
   if (!proceed) {
     await concludeWithoutCommit('Declined');
@@ -347,7 +428,7 @@ export async function runRefreshFlow(
   if (!picked) return;
 
   const model = {
-    actionLabel: 'Marketplace Refresh',
+    actionLabel: uiText('life.actionLabel.refresh'),
     authority: scope,
     target: picked.registrationId,
     stateRevision: picked.stateRevision,
@@ -357,8 +438,8 @@ export async function runRefreshFlow(
     ...model,
     step: 'Intent',
     details: [
-      'Run an explicit non-mutating inspection for this Registration only',
-      'Bridge State will not be written by Marketplace Refresh',
+      uiText('life.refresh.intent.inspectionOnly'),
+      uiText('life.refresh.intent.noWrite'),
     ],
   })) return;
 
@@ -366,7 +447,7 @@ export async function runRefreshFlow(
   const validationDetails = outcome.status === 'update-candidate'
     ? candidateSummary(outcome.candidate).split('\n')
     : [
-        `Refresh outcome: ${outcome.status}`,
+        uiText('life.refresh.outcome', { status: outcome.status }),
         ...fullValidationDisclosureLines(outcome.receipt.findings),
       ];
   const validationContinued = await showTransactionStep(ctx, {
@@ -384,7 +465,7 @@ export async function runRefreshFlow(
   if (outcome.status === 'blocked') {
     return;
   }
-  ui.notify('Update Candidate 已產生（非變異檢查，Bridge State 未寫入）。', 'info');
+  ui.notify(uiText('life.refresh.candidateReady'), 'info');
   // Bind the plan to the exact State Revision the candidate was validated against.
   await runUpdatePlanChecklist(ctx, scope, outcome.candidate, outcome.candidate.stateRevision, 'apply-update');
 }
@@ -402,36 +483,38 @@ export async function runRebindFlow(
 
   if (!await showTransactionStep(ctx, {
     step: 'Intent',
-    actionLabel: 'Registration Rebind',
+    actionLabel: uiText('life.actionLabel.rebind'),
     authority: scope,
     target: picked.registrationId,
-    details: ['Replace the source locator or Git selector while preserving the canonical Registration ID'],
+    details: [uiText('life.rebind.intent.details')],
   })) return;
 
   const sourceKinds = new Map<string, RebindTarget['kind']>([
-    ['本地目錄（local path）', 'local'],
-    ['Git 倉庫（locator + selector）', 'git'],
+    [uiText('life.rebind.sourceKind.local'), 'local'],
+    [uiText('life.rebind.sourceKind.git'), 'git'],
   ]);
-  const kindChoice = await ui.select('新來源型別', [...sourceKinds.keys()]);
+  const kindChoice = await ui.select(uiText('life.rebind.sourceKind.prompt'), [...sourceKinds.keys()]);
   if (!kindChoice) return;
   const sourceKind = sourceKinds.get(kindChoice);
   if (!sourceKind) return;
 
   let target: RebindTarget;
   if (sourceKind === 'local') {
-    const rootPath = await ui.input('新的本地 Marketplace Root 路徑', '/path/to/marketplace');
-    if (!rootPath) return void ui.notify('已取消 Rebind。', 'info');
+    const rootPath = await ui.input(uiText('life.rebind.localRoot.prompt'), '/path/to/marketplace');
+    if (!rootPath) return void ui.notify(uiText('life.rebind.cancelled'), 'info');
     target = { kind: 'local', rootPath };
   } else {
-    const locator = await ui.input('Git Locator（https:// 或 ssh，無憑證、無 query/fragment）', 'https://github.com/owner/repo.git');
-    if (!locator) return void ui.notify('已取消 Rebind。', 'info');
-    const selectorKind = await ui.select('Git Selector 型別', ['default', 'branch', 'tag', 'commit']);
-    if (!selectorKind) return void ui.notify('已取消 Rebind。', 'info');
+    const locator = await ui.input(uiText('life.rebind.locator.prompt'), 'https://github.com/owner/repo.git');
+    if (!locator) return void ui.notify(uiText('life.rebind.cancelled'), 'info');
+    const selectorKind = await ui.select(uiText('life.rebind.selectorKind.prompt'), ['default', 'branch', 'tag', 'commit']);
+    if (!selectorKind) return void ui.notify(uiText('life.rebind.cancelled'), 'info');
     let selector: Extract<RebindTarget, { kind: 'git' }>['selector'] = 'default';
     if (selectorKind === 'branch' || selectorKind === 'tag' || selectorKind === 'commit') {
-      const placeholder = selectorKind === 'commit' ? '完整 40/64 hex commit' : selectorKind === 'tag' ? 'v1.2.3' : 'main';
-      const value = await ui.input(`${selectorKind} 值（例：${placeholder}）`, placeholder);
-      if (!value) return void ui.notify('已取消 Rebind。', 'info');
+      const placeholder = selectorKind === 'commit'
+        ? uiText('life.rebind.selectorPlaceholder.commit')
+        : selectorKind === 'tag' ? uiText('life.rebind.selectorPlaceholder.tag') : uiText('life.rebind.selectorPlaceholder.branch');
+      const value = await ui.input(uiText('life.rebind.selectorValue.prompt', { kind: selectorKind, placeholder }), placeholder);
+      if (!value) return void ui.notify(uiText('life.rebind.cancelled'), 'info');
       selector = { kind: selectorKind, value };
     }
     target = { kind: 'git', locator, selector };
@@ -441,7 +524,7 @@ export async function runRebindFlow(
   if (!pf.ok) {
     await showTransactionStep(ctx, {
       step: 'Validation',
-      actionLabel: 'Registration Rebind',
+      actionLabel: uiText('life.actionLabel.rebind'),
       authority: scope,
       target: picked.registrationId,
       stateRevision: pf.outcome.receipt.expectedStateRevision,
@@ -451,7 +534,7 @@ export async function runRebindFlow(
     await attemptReport(ctx, pf.outcome);
     return;
   }
-  ui.notify('替代來源已完成完整重驗證；需重新收集全部確認（舊 Activation 同意不沿用）。', 'info');
+  ui.notify(uiText('life.rebind.revalidated'), 'info');
   // Rebind binds to the revision observed while validating the replacement source.
   await runUpdatePlanChecklist(
     ctx,
@@ -481,18 +564,20 @@ export async function runRemovalFlow(
 
   if (!targetKind && target.targetId) {
     const state = await readBridgeState(scope, opts);
-    if (state.status !== 'ok' && state.status !== 'missing') return void ui.notify(`Bridge State 不可讀：${quote(state.error ?? 'Persistence Indeterminate')}`, 'error');
+    if (state.status !== 'ok' && state.status !== 'missing') {
+      return void ui.notify(uiText('common.bridgeState.unreadable', { error: quote(state.error ?? 'Persistence Indeterminate') }), 'error');
+    }
     if (state.state?.registrations.some((registration) => registration.id === target.targetId)) targetKind = 'registration';
     if (state.state?.installations.some((installation) => installation.id === target.targetId)) targetKind = 'installation';
-    if (!targetKind) return void ui.notify(`找不到 canonical removal target ${quote(target.targetId)}。`, 'warning');
+    if (!targetKind) return void ui.notify(uiText('life.removal.notFound', { targetId: quote(target.targetId) }), 'warning');
   }
 
   if (!targetKind) {
     const removalKinds = new Map<string, 'registration' | 'installation'>([
-      ['整個 Registration（原子刪除同範圍所有 Installations）', 'registration'],
-      ['單一 Installation（保留 Registration）', 'installation'],
+      [uiText('life.removal.kind.registration'), 'registration'],
+      [uiText('life.removal.kind.installation'), 'installation'],
     ]);
-    const what = await ui.select('移除目標', [...removalKinds.keys()]);
+    const what = await ui.select(uiText('life.removal.pick.kind'), [...removalKinds.keys()]);
     if (!what) return;
     targetKind = removalKinds.get(what);
     if (!targetKind) return;
@@ -503,14 +588,14 @@ export async function runRemovalFlow(
     if (!picked) return;
 
     const model = {
-      actionLabel: 'Registration Removal',
+      actionLabel: uiText('life.actionLabel.registrationRemoval'),
       authority: scope,
       target: picked.registrationId,
     } satisfies Omit<TransactionSheetModel, 'step'>;
     if (!await showTransactionStep(ctx, {
       ...model,
       step: 'Intent',
-      details: ['Remove the Registration and all of its same-scope Installations atomically'],
+      details: [uiText('life.removal.reg.intent')],
     })) return;
 
     const pf = await preflightRegistrationRemoval(scope, picked.registrationId, opts);
@@ -534,28 +619,28 @@ export async function runRemovalFlow(
       step: 'Validation',
       details: [
         ...validationDisclosureLines([]),
-        ...registrationRemovalDisclosure(pf.preflight).split('\n'),
+        ...localizedRegistrationRemovalDisclosure(pf.preflight).split('\n'),
       ],
     })) return decline();
     if (!await showTransactionStep(ctx, {
       ...boundModel,
       step: 'Consent',
-      details: ['Registration Removal confirmation remains a separate Default No decision'],
+      details: [uiText('life.removal.reg.consent.details')],
     })) return decline();
     const proceed = await ui.confirm(
-      'Registration Removal — 預設 No',
-      quote(registrationRemovalDisclosure(pf.preflight)),
+      uiText('life.removal.reg.consent.title'),
+      quote(localizedRegistrationRemovalDisclosure(pf.preflight)),
     );
     if (!proceed) return decline();
     if (!await showTransactionStep(ctx, {
       ...boundModel,
       step: 'Plan',
-      details: registrationRemovalDisclosure(pf.preflight).split('\n'),
+      details: localizedRegistrationRemovalDisclosure(pf.preflight).split('\n'),
     })) return decline();
     if (!await showTransactionStep(ctx, {
       ...boundModel,
       step: 'Commit',
-      details: ['Commit the disclosed cascade to this scope document under the held Attempt Fence'],
+      details: [uiText('life.removal.reg.commit')],
     })) return decline();
     await attemptReport(ctx, await confirmRegistrationRemoval(pf.preflight, true, opts));
     return;
@@ -564,24 +649,27 @@ export async function runRemovalFlow(
   let installationId = target.targetId;
   if (!installationId) {
     const state = await readBridgeState(scope, opts);
-    if (state.status !== 'ok' && state.status !== 'missing') return void ui.notify(`Bridge State 不可讀：${quote(state.error ?? 'Persistence Indeterminate')}`, 'error');
+    if (state.status !== 'ok' && state.status !== 'missing') {
+      return void ui.notify(uiText('common.bridgeState.unreadable', { error: quote(state.error ?? 'Persistence Indeterminate') }), 'error');
+    }
     const installations = state.state?.installations ?? [];
-    if (installations.length === 0) return void ui.notify('此 Scope 尚無 Installed Plugin。', 'info');
-    const labels = installations.map((installation) => `${quote(installation.manifestName ?? installation.pluginId)} · ${installation.installationState} · ${quote(installation.id)}`);
-    const chosen = await ui.select('選擇要移除的 Installation', labels);
+    if (installations.length === 0) return void ui.notify(uiText('common.installation.none'), 'info');
+    const labels = installations.map((installation) =>
+      `${quote(installation.manifestName ?? installation.pluginId)} · ${installation.installationState} · ${quote(installation.id)}`);
+    const chosen = await ui.select(uiText('life.removal.pick.installation'), labels);
     if (!chosen) return;
     installationId = installations[labels.indexOf(chosen)]!.id;
   }
 
   const model = {
-    actionLabel: 'Installation Removal',
+    actionLabel: uiText('life.actionLabel.installationRemoval'),
     authority: scope,
     target: installationId,
   } satisfies Omit<TransactionSheetModel, 'step'>;
   if (!await showTransactionStep(ctx, {
     ...model,
     step: 'Intent',
-    details: ['Remove exactly one scope-local Installation while retaining its Registration'],
+    details: [uiText('life.removal.inst.intent')],
   })) return;
 
   const pf = await preflightInstallationRemoval(scope, installationId, opts);
@@ -604,28 +692,28 @@ export async function runRemovalFlow(
     step: 'Validation',
     details: [
       ...validationDisclosureLines([]),
-      ...installationRemovalDisclosure(pf.preflight).split('\n'),
+      ...localizedInstallationRemovalDisclosure(pf.preflight).split('\n'),
     ],
   })) return decline();
   if (!await showTransactionStep(ctx, {
     ...boundModel,
     step: 'Consent',
-    details: ['Installation Removal confirmation remains a separate Default No decision'],
+    details: [uiText('life.removal.inst.consent.details')],
   })) return decline();
   const proceed = await ui.confirm(
-    'Installation Removal — 預設 No',
-    quote(installationRemovalDisclosure(pf.preflight)),
+    uiText('life.removal.inst.consent.title'),
+    quote(localizedInstallationRemovalDisclosure(pf.preflight)),
   );
   if (!proceed) return decline();
   if (!await showTransactionStep(ctx, {
     ...boundModel,
     step: 'Plan',
-    details: installationRemovalDisclosure(pf.preflight).split('\n'),
+    details: localizedInstallationRemovalDisclosure(pf.preflight).split('\n'),
   })) return decline();
   if (!await showTransactionStep(ctx, {
     ...boundModel,
     step: 'Commit',
-    details: ['Commit removal to this scope document under the held Attempt Fence'],
+    details: [uiText('life.removal.inst.commit')],
   })) return decline();
   await attemptReport(ctx, await confirmInstallationRemoval(pf.preflight, true, opts));
 }

--- a/extensions/pi/lifecycle.ts
+++ b/extensions/pi/lifecycle.ts
@@ -34,7 +34,8 @@ import {
   reportOutcome,
   validationDisclosureLines,
 } from './registration.js';
-import { attemptSummaryText, uiText } from './ui-strings.js';
+import { attemptSummaryText, uiText,
+  scopeOptions } from './ui-strings.js';
 import { quoteTerminalText } from './terminal-presentation.js';
 import { openTransactionSheet, type TransactionSheetModel } from './transaction-sheet.js';
 
@@ -132,10 +133,7 @@ function lifecycleOptions(ctx: ExtensionCommandContext): LifecycleFlowOptions {
 }
 
 async function pickScope(ui: ExtensionUIContext): Promise<Scope | undefined> {
-  const labels = new Map<string, Scope>([
-    [uiText('common.scope.global'), 'global'],
-    [uiText('common.scope.project'), 'project'],
-  ]);
+  const labels = scopeOptions();
   const choice = await ui.select(uiText('life.pick.scope'), [...labels.keys()]);
   return choice ? labels.get(choice) : undefined;
 }

--- a/extensions/pi/registration.ts
+++ b/extensions/pi/registration.ts
@@ -17,7 +17,8 @@ import {
 import type { Scope } from '../../src/bridge-state/types.js';
 import { sortFindings, type ValidationFinding } from '../../src/registration/findings.js';
 import type { AttemptReceipt } from '../../src/registration/receipt.js';
-import { attemptSummaryText, findingOutcomeText, uiText, verdictText } from './ui-strings.js';
+import { attemptSummaryText, findingOutcomeText, uiText, verdictText,
+  scopeOptions } from './ui-strings.js';
 import { quoteTerminalText } from './terminal-presentation.js';
 import { openTransactionSheet, type TransactionSheetModel } from './transaction-sheet.js';
 
@@ -77,10 +78,7 @@ export async function runLocalRegistrationFlow(
   const ui: ExtensionUIContext = ctx.ui;
   let scope = target.scope;
   if (!scope) {
-    const scopeLabels = new Map<string, Scope>([
-      [uiText('common.scope.global'), 'global'],
-      [uiText('common.scope.project'), 'project'],
-    ]);
+    const scopeLabels = scopeOptions();
     const scopeChoice = await ui.select(uiText('reg.select.scope'), [...scopeLabels.keys()]);
     if (!scopeChoice) {
       ui.notify(uiText('reg.cancelled'), 'info');

--- a/extensions/pi/registration.ts
+++ b/extensions/pi/registration.ts
@@ -5,6 +5,7 @@
  * commit → Attempt Summary + closed Recovery Action reporting.
  *
  * The flow logic itself lives in src/registration/flow.ts (the tested seam); this file renders it.
+ * All user-visible strings come from the centralized ui-strings module (Issue #41).
  */
 
 import type { ExtensionCommandContext, ExtensionUIContext } from '@earendil-works/pi-coding-agent';
@@ -16,16 +17,23 @@ import {
 import type { Scope } from '../../src/bridge-state/types.js';
 import { sortFindings, type ValidationFinding } from '../../src/registration/findings.js';
 import type { AttemptReceipt } from '../../src/registration/receipt.js';
+import { attemptSummaryText, findingOutcomeText, uiText, verdictText } from './ui-strings.js';
 import { quoteTerminalText } from './terminal-presentation.js';
 import { openTransactionSheet, type TransactionSheetModel } from './transaction-sheet.js';
 
 export function formatFindings(findings: ValidationFinding[]): string[] {
-  return sortFindings(findings).map((f) => {
-    return `Finding classification ${f.classification} | scope ${f.scope} | phase ${f.phase} | ` +
-      `target ${f.target} | pointer ${quoteTerminalText(f.pointer || '(none)')} | ` +
-      `code ${quoteTerminalText(f.code)} | rule ${quoteTerminalText(f.rule)} | ` +
-      `outcome ${quoteTerminalText(f.outcome)}`;
-  });
+  return sortFindings(findings).map((f) =>
+    uiText('finding.line', {
+      classification: f.classification,
+      scope: f.scope,
+      phase: f.phase,
+      target: f.target,
+      pointer: quoteTerminalText(f.pointer || `(${uiText('common.none')})`),
+      code: quoteTerminalText(f.code),
+      rule: quoteTerminalText(f.rule),
+      outcome: quoteTerminalText(findingOutcomeText(f)),
+    }),
+  );
 }
 
 export function validationDisclosureLines(findings: ValidationFinding[]): string[] {
@@ -34,14 +42,11 @@ export function validationDisclosureLines(findings: ValidationFinding[]): string
     warning: findings.filter((finding) => finding.classification === 'warning').length,
     notice: findings.filter((finding) => finding.classification === 'notice').length,
   };
-  const verdict = counts.blocking > 0
-    ? 'Blocked'
-    : counts.warning > 0 || counts.notice > 0
-      ? 'Passed with diagnostics'
-      : 'Passed';
+  const verdict = counts.blocking > 0 ? 'Blocked'
+    : counts.warning > 0 || counts.notice > 0 ? 'Passed with diagnostics' : 'Passed';
   return [
-    `Verdict ${verdict}`,
-    `Findings ${counts.blocking} blocking · ${counts.warning} warning · ${counts.notice} notice`,
+    `${uiText('verdict.label')}：${verdictText(verdict)}`,
+    `${uiText('findings.count.label')}：${uiText('findings.count.line', counts)}`,
   ];
 }
 
@@ -60,7 +65,7 @@ async function transactionStep(
 ): Promise<boolean> {
   if (await openTransactionSheet(ctx, model) === 'continue') return true;
   if (cancel) await cancel();
-  else ctx.ui.notify('已取消 Transaction；Bridge State 未變更。', 'info');
+  else ctx.ui.notify(uiText('common.cancelled.transaction'), 'info');
   return false;
 }
 
@@ -73,21 +78,21 @@ export async function runLocalRegistrationFlow(
   let scope = target.scope;
   if (!scope) {
     const scopeLabels = new Map<string, Scope>([
-      ['Global Scope', 'global'],
-      ['Project Scope', 'project'],
+      [uiText('common.scope.global'), 'global'],
+      [uiText('common.scope.project'), 'project'],
     ]);
-    const scopeChoice = await ui.select('Marketplace Registration — 選擇 Scope', [...scopeLabels.keys()]);
+    const scopeChoice = await ui.select(uiText('reg.select.scope'), [...scopeLabels.keys()]);
     if (!scopeChoice) {
-      ui.notify('已取消 Registration', 'info');
+      ui.notify(uiText('reg.cancelled'), 'info');
       return;
     }
     scope = scopeLabels.get(scopeChoice);
     if (!scope) return;
   }
 
-  const rootPath = await ui.input('本地 Marketplace Root（需含 .agents/plugins/marketplace.json）', '.');
+  const rootPath = await ui.input(uiText('reg.input.localRoot'), '.');
   if (!rootPath) {
-    ui.notify('已取消 Registration', 'info');
+    ui.notify(uiText('reg.cancelled'), 'info');
     return;
   }
 
@@ -97,7 +102,7 @@ export async function runLocalRegistrationFlow(
     actionLabel,
     authority: scope,
     target: rootPath,
-    details: [`Source ${quoteTerminalText(rootPath)}`],
+    details: [uiText('reg.detail.source', { source: quoteTerminalText(rootPath) })],
   })) return;
 
   const opts = { cwd: ctx.cwd, projectTrusted: ctx.isProjectTrusted() };
@@ -109,18 +114,26 @@ export async function runLocalRegistrationFlow(
 
   const pf = res.preflight;
   const validationDetails = [
-    `Registration ID ${quoteTerminalText(pf.registrationId)}`,
-    `Source ${quoteTerminalText(pf.canonicalPath)}`,
-    `Marketplace ${quoteTerminalText(pf.marketplaceName)}`,
-    `Entries ${pf.catalog.entries.length} (` +
-      `${pf.catalog.entries.filter((entry) => entry.available).length} locatable / ` +
-      `${pf.catalog.entries.filter((entry) => !entry.available).length} unavailable)`,
-    `Compatibility Profile ${quoteTerminalText(pf.snapshot.profile)}`,
-    `Ruleset ${quoteTerminalText(pf.snapshot.ruleset)}`,
-    `Validation Budget ${quoteTerminalText(pf.snapshot.budget)}`,
+    uiText('reg.detail.registrationId', { id: quoteTerminalText(pf.registrationId) }),
+    uiText('reg.detail.source', { source: quoteTerminalText(pf.canonicalPath) }),
+    uiText('reg.detail.marketplace', { name: quoteTerminalText(pf.marketplaceName) }),
+    uiText('reg.detail.entries', {
+      total: pf.catalog.entries.length,
+      locatable: pf.catalog.entries.filter((entry) => entry.available).length,
+      unavailable: pf.catalog.entries.filter((entry) => !entry.available).length,
+    }),
+    uiText('reg.detail.profile', { profile: quoteTerminalText(pf.snapshot.profile) }),
+    uiText('reg.detail.ruleset', { ruleset: quoteTerminalText(pf.snapshot.ruleset) }),
+    uiText('reg.detail.budget', { budget: quoteTerminalText(pf.snapshot.budget) }),
     ...fullValidationDisclosureLines(pf.findings),
     ...pf.catalog.entries.map((entry) =>
-      `Entry ${quoteTerminalText(entry.entryId)} ${quoteTerminalText(entry.name ?? '(unnamed)')} ${quoteTerminalText(entry.available ? 'locatable' : entry.unavailableReason ?? 'unavailable')}`,
+      uiText('reg.detail.entry', {
+        entryId: quoteTerminalText(entry.entryId),
+        name: quoteTerminalText(entry.name ?? `(${uiText('common.none')})`),
+        status: entry.available
+          ? uiText('reg.entry.locatable')
+          : uiText('reg.entry.unavailable', { reason: quoteTerminalText(entry.unavailableReason ?? uiText('common.unavailable')) }),
+      }),
     ),
   ];
   const boundModel = {
@@ -141,28 +154,31 @@ export async function runLocalRegistrationFlow(
   if (!await transactionStep(ctx, {
     ...boundModel,
     step: 'Consent',
-    details: ['Registration Confirmation: separate Default No host gate'],
+    details: [uiText('reg.consent.details')],
   }, cancel)) return;
 
   const yes = await ui.confirm(
-    'Registration Confirmation — 預設 No（綁定 State Revision + Validation Snapshot，不可記憶、不可批次）',
-    `確認 Registration ID ${quoteTerminalText(pf.registrationId)}：` +
-      `${quoteTerminalText(pf.canonicalPath)} 至 ${scope}？\n` +
-      `Validation Disclosure:\n${validationDetails.join('\n')}`,
+    uiText('reg.consent.title'),
+    uiText('reg.local.consent.body', {
+      registrationId: quoteTerminalText(pf.registrationId),
+      source: quoteTerminalText(pf.canonicalPath),
+      scope,
+      disclosure: validationDetails.join('\n'),
+    }),
   );
 
   if (yes) {
     if (!await transactionStep(ctx, {
       ...boundModel,
       step: 'Plan',
-      details: ['Update Plan: N/A — new Registration has no replacement plan'],
+      details: [uiText('reg.plan.details')],
     }, cancel)) return;
     if (!await transactionStep(ctx, {
       ...boundModel,
       step: 'Commit',
       details: [
-        `Persist Registration ID ${quoteTerminalText(pf.registrationId)}`,
-        `Write authority ${scope} at State Revision ${quoteTerminalText(pf.stateRevision)}`,
+        uiText('reg.commit.persist', { id: quoteTerminalText(pf.registrationId) }),
+        uiText('reg.commit.authority', { scope, revision: quoteTerminalText(pf.stateRevision) }),
       ],
     }, cancel)) return;
   }
@@ -210,5 +226,8 @@ export async function reportOutcome(
     validationSnapshot: rc.validationSnapshot,
     receipt: rc,
   });
-  ctx.ui.notify(`Attempt Summary: ${rc.summary} · Receipt ${quoteTerminalText(rc.id)}`, notifyType);
+  ctx.ui.notify(
+    uiText('reg.outcome.notify', { summary: attemptSummaryText(rc.summary), receiptId: quoteTerminalText(rc.id) }),
+    notifyType,
+  );
 }

--- a/extensions/pi/scope-overrides.ts
+++ b/extensions/pi/scope-overrides.ts
@@ -6,6 +6,8 @@
  * suppresses only that single Plugin, and removing either reveals the inherited record again.
  * The Effective State view marks every record's participating source and suppression reason,
  * and lists Projected Skills with their collision outcome and Skill Availability.
+ *
+ * All user-visible strings come from the centralized ui-strings module (Issue #41).
  */
 
 import type { ExtensionCommandContext, ExtensionUIContext } from '@earendil-works/pi-coding-agent';
@@ -18,6 +20,7 @@ import { projectEffectiveState } from '../../src/projection/project.js';
 import { createReceipt } from '../../src/registration/receipt.js';
 import { reportOutcome, validationDisclosureLines } from './registration.js';
 import { appendAndReportReceipt } from './journal.js';
+import { uiText } from './ui-strings.js';
 import { quoteTerminalText } from './terminal-presentation.js';
 import { openTransactionSheet, type TransactionSheetModel } from './transaction-sheet.js';
 
@@ -54,7 +57,9 @@ export function inheritedRecordRows(
     rows.push({
       kind: 'registration',
       targetId: registration.id,
-      label: `${quote(registration.alias ?? registration.marketplaceName ?? registration.id)} · Registration ${registration.id.slice(0, 8)}…${reason === 'scope-override-registration' ? ' — 已抑制（子樹）' : ''}`,
+      label: `${quote(registration.alias ?? registration.marketplaceName ?? registration.id)} · Registration ${registration.id.slice(0, 8)}…${
+        reason === 'scope-override-registration' ? uiText('ovr.suppressed.subtree') : ''
+      }`,
       suppressedByOverride: reason === 'scope-override-registration',
       supersededByProject: false,
       selectable: true,
@@ -67,9 +72,9 @@ export function inheritedRecordRows(
       kind: 'installation',
       targetId: installation.id,
       label: `${quote(installation.manifestName ?? installation.pluginId)} · Installation ${installation.id.slice(0, 8)}…${
-        reason === 'scope-override-installation' ? ' — 已抑制（單一 Plugin）'
-          : reason === 'scope-override-registration' ? ' — 已抑制（隸屬被覆蓋的 Registration 子樹）'
-            : reason === 'project-precedence' ? ' — 由 Project 同名 Plugin 優先取代' : ''
+        reason === 'scope-override-installation' ? uiText('ovr.suppressed.single')
+          : reason === 'scope-override-registration' ? uiText('ovr.suppressed.byRegistration')
+            : reason === 'project-precedence' ? uiText('ovr.supersededByProject') : ''
       }`,
       suppressedByOverride: reason === 'scope-override-installation' || reason === 'scope-override-registration',
       supersededByProject: reason === 'project-precedence',
@@ -82,19 +87,33 @@ export function inheritedRecordRows(
 /** Compact multi-line summary of one projection result for disclosure / notification. */
 export function formatProjectionSummary(state: EffectiveState, plugins: ReturnType<typeof projectEffectiveState>['plugins'], findings: ReturnType<typeof projectEffectiveState>['findings']): string {
   const lines = [
-    `Effective State: ${state.registrations.length} registrations · ${state.installations.length} installations 參與`,
-    ...state.suppressed.map((item) => `⊘ suppressed ${item.kind} ${item.targetId.slice(0, 8)}… (${item.reason})`),
+    uiText('ovr.projection.header', {
+      registrations: state.registrations.length,
+      installations: state.installations.length,
+    }),
+    ...state.suppressed.map((item) => uiText('ovr.projection.suppressed', {
+      kind: item.kind,
+      targetId: `${item.targetId.slice(0, 8)}…`,
+      reason: item.reason,
+    })),
   ];
-  if (plugins.length === 0) lines.push('Projected Plugins: none');
+  if (plugins.length === 0) lines.push(uiText('ovr.projection.noPlugins'));
   for (const plugin of plugins) {
     lines.push(`▸ ${quote(plugin.pluginId)} · ${plugin.sourceScope}`);
     for (const skill of plugin.skills) {
-      const status = skill.status === 'projected' ? 'projected' : 'unavailable（碰撞）';
-      lines.push(`    ${quote(skill.name)} · ${status} · availability: ${skill.availability}`);
+      lines.push('    ' + uiText('ovr.projection.skill', {
+        name: quote(skill.name),
+        status: skill.status === 'projected'
+          ? uiText('ovr.projection.skillProjected')
+          : uiText('ovr.projection.skillUnavailable'),
+        availability: skill.availability,
+      }));
     }
   }
   if (findings.length > 0) {
-    lines.push(`Findings: ${findings.map((f) => `${f.classification} ${f.code}`).join(' | ')}`);
+    lines.push(uiText('ovr.projection.findings', {
+      findings: findings.map((f) => `${f.classification} ${f.code}`).join(' | '),
+    }));
   }
   return lines.join('\n');
 }
@@ -143,7 +162,7 @@ async function pickInheritedRow(
   }
   const candidates = target.targetKind ? rows.filter((row) => row.kind === target.targetKind) : rows;
   const labels = candidates.map((row) => `${row.label} · ${quote(row.targetId)}`);
-  const chosen = await ui.select('建立 Scope Override — 選擇要抑制的繼承全域紀錄', labels);
+  const chosen = await ui.select(uiText('ovr.select.create'), labels);
   if (!chosen) return undefined;
   return candidates[labels.indexOf(chosen)];
 }
@@ -158,8 +177,8 @@ async function pickExistingOverride(
       item.targetId === target.targetId && (!target.targetKind || item.kind === target.targetKind));
   }
   const candidates = target.targetKind ? overrides.filter((item) => item.kind === target.targetKind) : overrides;
-  const labels = candidates.map((item) => `${item.kind} Override → ${quote(item.targetId)}`);
-  const chosen = await ui.select('移除 Scope Override — 移除後立即還原繼承（不改寫全域文件）', labels);
+  const labels = candidates.map((item) => uiText('ovr.pick.existing', { kind: item.kind, targetId: quote(item.targetId) }));
+  const chosen = await ui.select(uiText('ovr.select.remove'), labels);
   if (!chosen) return undefined;
   return candidates[labels.indexOf(chosen)];
 }
@@ -171,7 +190,9 @@ export async function runScopeOverrideFlow(
 ): Promise<void> {
   const ui: ExtensionUIContext = ctx.ui;
   const docs = await readBoth({ cwd: ctx.cwd });
-  if (!docs.ok) return void ui.notify(`Bridge State 不可讀：${quote(docs.error ?? 'Persistence Indeterminate')}`, 'error');
+  if (!docs.ok) {
+    return void ui.notify(uiText('common.bridgeState.unreadable', { error: quote(docs.error ?? 'Persistence Indeterminate') }), 'error');
+  }
   const expectedStateRevision = target.expectedStateRevision ?? docs.project!.stateRevision;
   const opts = {
     cwd: ctx.cwd,
@@ -182,10 +203,10 @@ export async function runScopeOverrideFlow(
 
   const rows = inheritedRecordRows(docs.global!, docs.project!, ctx.isProjectTrusted());
   const row = await pickInheritedRow(ui, rows, target);
-  if (!row) return void ui.notify('找不到指定的繼承全域紀錄。', 'warning');
+  if (!row) return void ui.notify(uiText('ovr.notFound.inherited'), 'warning');
 
   const model = {
-    actionLabel: 'Scope Override Creation',
+    actionLabel: uiText('ovr.create.actionLabel'),
     authority: 'project' as const,
     target: row.targetId,
     stateRevision: expectedStateRevision,
@@ -193,7 +214,7 @@ export async function runScopeOverrideFlow(
   if (!await showTransactionStep(ctx, {
     ...model,
     step: 'Intent',
-    details: [`Create a Project Scope ${row.kind} override without modifying Global Bridge State`],
+    details: [uiText('ovr.create.intent', { kind: row.kind })],
   })) return void await reportDeclinedOverride(ctx, model);
 
   if (!await showTransactionStep(ctx, {
@@ -201,36 +222,44 @@ export async function runScopeOverrideFlow(
     step: 'Validation',
     details: [
       ...validationDisclosureLines([]),
-      `Target kind: ${row.kind}`,
-      `Target ID: ${quote(row.targetId)}`,
-      `Already suppressed: ${row.suppressedByOverride ? 'yes' : 'no'}`,
-      `Project Trust observed from Pi host: ${ctx.isProjectTrusted() ? 'granted' : 'not granted; domain admission will block'}`,
+      uiText('ovr.create.targetKind', { kind: row.kind }),
+      uiText('ovr.create.targetId', { targetId: quote(row.targetId) }),
+      uiText('ovr.create.alreadySuppressed', {
+        value: row.suppressedByOverride ? uiText('common.yes') : uiText('common.no'),
+      }),
+      uiText('ovr.create.trustObserved', {
+        value: ctx.isProjectTrusted() ? uiText('ovr.create.trust.granted') : uiText('ovr.create.trust.notGranted'),
+      }),
     ],
   })) return void await reportDeclinedOverride(ctx, model);
 
   const cascade = row.kind === 'registration'
-    ? '\n\nRegistration Override 會抑制整顆 Marketplace 子樹（該 Registration 及其所有 Installations）。'
-    : '\n\nInstallation Override 僅抑制此單一 Plugin。';
+    ? uiText('ovr.create.cascade.registration')
+    : uiText('ovr.create.cascade.installation');
   if (!await showTransactionStep(ctx, {
     ...model,
     step: 'Consent',
-    details: ['Scope Override Disclosure remains a separate Default No decision'],
+    details: [uiText('ovr.create.consent.details')],
   })) return void await reportDeclinedOverride(ctx, model);
   const confirmed = await ui.confirm(
-    'Scope Override Disclosure — 預設 No',
-    `將於 Project Scope 建立 ${row.kind} Scope Override，抑制繼承的全域紀錄：\n${quote(row.targetId)}${cascade}\n\n不會修改全域文件；移除 Override 即可還原繼承。`,
+    uiText('ovr.create.consent.title'),
+    uiText('ovr.create.consent.body', {
+      kind: row.kind,
+      targetId: quote(row.targetId),
+      cascade,
+    }),
   );
   if (!confirmed) return void await reportDeclinedOverride(ctx, model);
 
   if (!await showTransactionStep(ctx, {
     ...model,
     step: 'Plan',
-    details: [row.kind === 'registration' ? 'Suppress the inherited Registration marketplace subtree' : 'Suppress only the inherited Installation'],
+    details: [uiText(row.kind === 'registration' ? 'ovr.create.plan.registration' : 'ovr.create.plan.installation')],
   })) return void await reportDeclinedOverride(ctx, model);
   if (!await showTransactionStep(ctx, {
     ...model,
     step: 'Commit',
-    details: ['The domain lifecycle guard will acquire the Project Attempt Fence, validate trust and barrier state, and commit atomically'],
+    details: [uiText('ovr.create.commit')],
   })) return void await reportDeclinedOverride(ctx, model);
 
   const outcome = await createScopeOverride(row.kind, row.targetId, opts);
@@ -244,7 +273,9 @@ export async function runRemoveScopeOverrideFlow(
 ): Promise<void> {
   const ui: ExtensionUIContext = ctx.ui;
   const docs = await readBoth({ cwd: ctx.cwd });
-  if (!docs.ok) return void ui.notify(`Bridge State 不可讀：${quote(docs.error ?? 'Persistence Indeterminate')}`, 'error');
+  if (!docs.ok) {
+    return void ui.notify(uiText('common.bridgeState.unreadable', { error: quote(docs.error ?? 'Persistence Indeterminate') }), 'error');
+  }
   const expectedStateRevision = targetOptions.expectedStateRevision ?? docs.project!.stateRevision;
   const opts = {
     cwd: ctx.cwd,
@@ -253,13 +284,13 @@ export async function runRemoveScopeOverrideFlow(
     expectedStateRevision,
   };
   const overrides = docs.project!.scopeOverrides;
-  if (overrides.length === 0) return void ui.notify('Project Scope 目前沒有任何 Scope Override。', 'info');
+  if (overrides.length === 0) return void ui.notify(uiText('ovr.none'), 'info');
 
   const target = await pickExistingOverride(ui, overrides, targetOptions);
-  if (!target) return void ui.notify('找不到指定的 Scope Override。', 'warning');
+  if (!target) return void ui.notify(uiText('ovr.notFound.override'), 'warning');
 
   const model = {
-    actionLabel: 'Scope Override Removal',
+    actionLabel: uiText('ovr.remove.actionLabel'),
     authority: 'project' as const,
     target: target.targetId,
     stateRevision: expectedStateRevision,
@@ -267,36 +298,41 @@ export async function runRemoveScopeOverrideFlow(
   if (!await showTransactionStep(ctx, {
     ...model,
     step: 'Intent',
-    details: [`Remove the Project Scope ${target.kind} override and reveal inherited state by recomputation`],
+    details: [uiText('ovr.remove.intent', { kind: target.kind })],
   })) return void await reportDeclinedOverride(ctx, model);
   if (!await showTransactionStep(ctx, {
     ...model,
     step: 'Validation',
     details: [
       ...validationDisclosureLines([]),
-      `Target kind: ${target.kind}`,
-      `Target ID: ${quote(target.targetId)}`,
-      `Project Trust observed from Pi host: ${ctx.isProjectTrusted() ? 'granted' : 'not granted; domain admission will block'}`,
+      uiText('ovr.create.targetKind', { kind: target.kind }),
+      uiText('ovr.create.targetId', { targetId: quote(target.targetId) }),
+      uiText('ovr.create.trustObserved', {
+        value: ctx.isProjectTrusted() ? uiText('ovr.create.trust.granted') : uiText('ovr.create.trust.notGranted'),
+      }),
     ],
   })) return void await reportDeclinedOverride(ctx, model);
 
   if (!await showTransactionStep(ctx, {
     ...model,
     step: 'Consent',
-    details: ['Override Removal remains a separate Default No decision'],
+    details: [uiText('ovr.remove.consent.details')],
   })) return void await reportDeclinedOverride(ctx, model);
-  const confirmed = await ui.confirm('Override Removal — 預設 No', `移除 ${target.kind} Scope Override？\n被抑制的繼承全域紀錄將立即在 Effective State 中恢復。`);
+  const confirmed = await ui.confirm(
+    uiText('ovr.remove.consent.title'),
+    uiText('ovr.remove.consent.body', { kind: target.kind }),
+  );
   if (!confirmed) return void await reportDeclinedOverride(ctx, model);
 
   if (!await showTransactionStep(ctx, {
     ...model,
     step: 'Plan',
-    details: ['Remove only the selected Project Scope Override; Global Bridge State remains unchanged'],
+    details: [uiText('ovr.remove.plan')],
   })) return void await reportDeclinedOverride(ctx, model);
   if (!await showTransactionStep(ctx, {
     ...model,
     step: 'Commit',
-    details: ['The domain lifecycle guard will acquire the Project Attempt Fence, validate trust and barrier state, and commit atomically'],
+    details: [uiText('ovr.create.commit')],
   })) return void await reportDeclinedOverride(ctx, model);
 
   const outcome = await removeScopeOverride(target.kind, target.targetId, opts);
@@ -308,12 +344,14 @@ export async function runEffectiveStateView(ctx: ExtensionCommandContext): Promi
   const ui: ExtensionUIContext = ctx.ui;
   const trusted = ctx.isProjectTrusted();
   const docs = await readBoth({ cwd: ctx.cwd });
-  if (!docs.ok) return void ui.notify(`Bridge State 不可讀：${quote(docs.error ?? 'Persistence Indeterminate')}`, 'error');
+  if (!docs.ok) {
+    return void ui.notify(uiText('common.bridgeState.unreadable', { error: quote(docs.error ?? 'Persistence Indeterminate') }), 'error');
+  }
   const effective = computeEffectiveState(docs.global!, docs.project!, { projectTrusted: trusted });
   const projection = projectEffectiveState(docs.global!, docs.project!, { projectTrusted: trusted });
-  const trustNote = trusted ? '' : '\n\n⚠ Project Trust 未授予——Project Scope 紀錄仍保存但不參與 Effective State。';
+  const trustNote = trusted ? '' : uiText('ovr.projection.trustNote');
   ui.notify(
-    `${formatProjectionSummary(effective, projection.plugins, projection.findings)}${trustNote}\n\nAvailable 僅由宿主獨立證據確立；碰撞僅影響技能粒度，不改變 Plugin 分類。`,
+    `${formatProjectionSummary(effective, projection.plugins, projection.findings)}${trustNote}${uiText('ovr.projection.availableNote')}`,
     projection.findings.length > 0 ? 'warning' : 'info',
   );
 }

--- a/extensions/pi/transaction-sheet.ts
+++ b/extensions/pi/transaction-sheet.ts
@@ -9,7 +9,15 @@ import {
 
 import type { Scope } from '../../src/bridge-state/types.js';
 import { sortFindings } from '../../src/registration/findings.js';
-import type { AttemptReceipt, AttemptSummary } from '../../src/registration/receipt.js';
+import type { AttemptReceipt, AttemptSummary, RecoveryAction } from '../../src/registration/receipt.js';
+import {
+  attemptSummaryGloss,
+  closedValue,
+  findingOutcomeText,
+  recoveryActionGloss,
+  transactionStepLabel,
+  uiText,
+} from './ui-strings.js';
 import {
   padTerminalLine,
   quoteTerminalText,
@@ -41,7 +49,15 @@ function field(theme: TransactionSheetTheme, label: string, value: unknown): str
 }
 
 function authorityLabel(scope: Scope): string {
-  return scope === 'global' ? '[G] GLOBAL' : '[P] PROJECT';
+  return scope === 'global' ? '[G] Global Scope' : '[P] Project Scope';
+}
+
+function findingLine(theme: TransactionSheetTheme, finding: AttemptReceipt['findings'][number]): string {
+  return (
+    `${theme.fg('warning', `[${finding.classification}]`)} ${quoteTerminalText(finding.code)} ` +
+    `${quoteTerminalText(finding.rule)}: ${quoteTerminalText(findingOutcomeText(finding))}` +
+    `${finding.pointer ? ` @${quoteTerminalText(finding.pointer)}` : ''}`
+  );
 }
 
 function receiptAxes(receipt: AttemptReceipt, theme: TransactionSheetTheme): [string[], string[], string[]] {
@@ -52,30 +68,36 @@ function receiptAxes(receipt: AttemptReceipt, theme: TransactionSheetTheme): [st
     notice: orderedFindings.filter((finding) => finding.classification === 'notice').length,
   };
   const durable = [
-    theme.fg('accent', theme.bold('Durable')),
-    field(theme, 'Outcome', receipt.durableOutcome),
-    field(theme, 'Expected revision', receipt.expectedStateRevision),
-    ...(receipt.targetStateRevision === undefined ? [] : [field(theme, 'Target revision', receipt.targetStateRevision)]),
-    ...(receipt.observedStateRevision === undefined ? [] : [field(theme, 'Observed revision', receipt.observedStateRevision)]),
-    field(theme, 'State changed', receipt.stateChanged ? 'yes' : 'no'),
+    theme.fg('accent', theme.bold(uiText('sheet.axis.durable'))),
+    field(theme, uiText('sheet.field.outcome'), receipt.durableOutcome),
+    field(theme, uiText('sheet.field.expectedRevision'), receipt.expectedStateRevision),
+    ...(receipt.targetStateRevision === undefined
+      ? []
+      : [field(theme, uiText('sheet.field.targetRevision'), receipt.targetStateRevision)]),
+    ...(receipt.observedStateRevision === undefined
+      ? []
+      : [field(theme, uiText('sheet.field.observedRevision'), receipt.observedStateRevision)]),
+    field(
+      theme,
+      uiText('sheet.field.stateChanged'),
+      receipt.stateChanged ? uiText('common.yes') : uiText('common.no'),
+    ),
   ];
   const findings = [
-    theme.fg('accent', theme.bold('Findings')),
-    field(theme, 'Count', orderedFindings.length),
+    theme.fg('accent', theme.bold(uiText('sheet.axis.findings'))),
+    field(theme, uiText('sheet.field.count'), orderedFindings.length),
     field(theme, 'Blocking', classifications.blocking),
     field(theme, 'Warning', classifications.warning),
     field(theme, 'Notice', classifications.notice),
-    ...orderedFindings.map((finding) =>
-      `${theme.fg('warning', `[${finding.classification}]`)} ${quoteTerminalText(finding.code)} ${quoteTerminalText(finding.rule)}: ${quoteTerminalText(finding.outcome)}${finding.pointer ? ` @${quoteTerminalText(finding.pointer)}` : ''}`,
-    ),
+    ...orderedFindings.map((finding) => findingLine(theme, finding)),
   ];
   const runtime = [
-    theme.fg('accent', theme.bold('Runtime')),
-    field(theme, 'Outcome', receipt.runtimeOutcome),
-    field(theme, 'Receipt', receipt.id),
-    field(theme, 'Kind', receipt.kind),
-    field(theme, 'Operation', receipt.operation),
-    field(theme, 'Trigger', receipt.trigger),
+    theme.fg('accent', theme.bold(uiText('sheet.axis.runtime'))),
+    field(theme, uiText('sheet.field.outcome'), receipt.runtimeOutcome),
+    field(theme, uiText('sheet.field.receipt'), receipt.id),
+    field(theme, uiText('sheet.field.kind'), receipt.kind),
+    field(theme, uiText('sheet.field.operation'), receipt.operation),
+    field(theme, uiText('sheet.field.trigger'), receipt.trigger),
   ];
   return [durable, findings, runtime];
 }
@@ -109,15 +131,16 @@ function renderStackedAxes(axes: [string[], string[], string[]], width: number):
   return lines;
 }
 
-/** Stage indicator cells: done ✓, active ▸ … ACTIVE, pending numbered. */
+/** Stage indicator cells: done ✓, active ▸ …（進行中）, pending numbered. Labels are zh_TW. */
 function stageSegments(theme: TransactionSheetTheme, step: TransactionStep): string[] {
   const activeIndex = TRANSACTION_STEPS.indexOf(step);
   return TRANSACTION_STEPS.map((name, index) => {
-    if (index < activeIndex) return theme.fg('success', `✓ ${index + 1} ${name}`);
+    const label = transactionStepLabel(name);
+    if (index < activeIndex) return theme.fg('success', `✓ ${index + 1} ${label}`);
     if (index === activeIndex) {
-      return theme.fg('accent', theme.bold(`▸ ${index + 1} ${name} ACTIVE`));
+      return theme.fg('accent', theme.bold(`▸ ${index + 1} ${label}（${uiText('step.activeSuffix')}）`));
     }
-    return theme.fg('muted', `${index + 1} ${name}`);
+    return theme.fg('muted', `${index + 1} ${label}`);
   });
 }
 
@@ -128,16 +151,23 @@ function stageRows(theme: TransactionSheetTheme, step: TransactionStep, width: n
     wrapTextWithAnsi(row.join(connector), Math.max(1, width)));
 }
 
-const SUMMARY_TONES: Record<AttemptSummary, { tone: BadgeTone; label: string }> = {
-  'Completed': { tone: 'success', label: 'COMPLETED' },
-  'Completed with diagnostics': { tone: 'warning', label: 'DIAGNOSTICS' },
-  'Declined': { tone: 'warning', label: 'DECLINED' },
-  'Blocked': { tone: 'error', label: 'BLOCKED' },
-  'Rejected as Stale': { tone: 'warning', label: 'STALE' },
-  'Persistence Failed': { tone: 'error', label: 'PERSISTENCE FAILED' },
-  'Persistence Indeterminate': { tone: 'error', label: 'INDETERMINATE' },
-  'Pending Application': { tone: 'warning', label: 'PENDING' },
+const SUMMARY_TONES: Record<AttemptSummary, { tone: BadgeTone; labelId: Parameters<typeof uiText>[0] }> = {
+  'Completed': { tone: 'success', labelId: 'ledger.badge.healthy' },
+  'Completed with diagnostics': { tone: 'warning', labelId: 'summary.badge.diagnostics' },
+  'Declined': { tone: 'warning', labelId: 'summary.badge.declined' },
+  'Blocked': { tone: 'error', labelId: 'summary.badge.blocked' },
+  'Rejected as Stale': { tone: 'warning', labelId: 'summary.badge.stale' },
+  'Persistence Failed': { tone: 'error', labelId: 'summary.badge.persistenceFailed' },
+  'Persistence Indeterminate': { tone: 'error', labelId: 'ledger.badge.indeterminate' },
+  'Pending Application': { tone: 'warning', labelId: 'summary.badge.pending' },
 };
+
+/** Recovery Action closed values rendered quoted-canonical + zh_TW gloss outside the quotes. */
+function recoveryActionsText(actions: RecoveryAction[]): string {
+  return actions
+    .map((action) => closedValue(quoteTerminalText(action), recoveryActionGloss(action)))
+    .join(', ');
+}
 
 export function renderTransactionSheet(
   model: TransactionSheetModel,
@@ -153,12 +183,12 @@ export function renderTransactionSheet(
   const body: string[] = [
     ...stageRows(theme, model.step, innerWidth),
     '',
-    field(theme, 'Action', model.actionLabel),
-    ...(authority === undefined ? [] : [field(theme, 'Authority', authorityLabel(authority))]),
-    ...(model.target === undefined ? [] : [field(theme, 'Target', model.target)]),
+    field(theme, uiText('sheet.field.action'), model.actionLabel),
+    ...(authority === undefined ? [] : [field(theme, uiText('sheet.field.authority'), authorityLabel(authority))]),
+    ...(model.target === undefined ? [] : [field(theme, uiText('sheet.field.target'), model.target)]),
     ...(stateRevision === undefined ? [] : [field(theme, 'State Revision', stateRevision)]),
     ...(validationSnapshot === undefined ? [] : [field(theme, 'Validation Snapshot', validationSnapshot)]),
-    ...(model.details ?? []).map((detail) => field(theme, 'Detail', detail)),
+    ...(model.details ?? []).map((detail) => field(theme, uiText('sheet.field.detail'), detail)),
   ];
 
   if (receipt) {
@@ -168,23 +198,22 @@ export function renderTransactionSheet(
     body.push('');
     const summaryTone = SUMMARY_TONES[receipt.summary];
     body.push(
-      `${theme.fg('accent', theme.bold('Attempt Summary:'))} ${quoteTerminalText(receipt.summary)} ` +
-        renderBadge(theme, summaryTone.tone, summaryTone.label),
+      `${theme.fg('accent', theme.bold(`${uiText('sheet.attemptSummary')}:`))} ` +
+        `${closedValue(quoteTerminalText(receipt.summary), attemptSummaryGloss(receipt.summary))} ` +
+        renderBadge(theme, summaryTone.tone, uiText(summaryTone.labelId)),
     );
     body.push(
-      `${theme.fg('accent', theme.bold('Recovery Actions:'))} ${
-        receipt.recoveryActions.length > 0
-          ? receipt.recoveryActions.map((action) => quoteTerminalText(action)).join(', ')
-          : 'none'
+      `${theme.fg('accent', theme.bold(`${uiText('sheet.recoveryActions')}:`))} ${
+        receipt.recoveryActions.length > 0 ? recoveryActionsText(receipt.recoveryActions) : uiText('common.none')
       }`,
     );
   }
 
   body.push('');
-  body.push(theme.fg('dim', 'Enter: continue | Esc/q/Ctrl-C: cancel'));
+  body.push(theme.fg('dim', uiText('sheet.keys')));
   // Wrap every content line to the panel interior so no tail is lost inside the frame.
   const wrappedBody = body.flatMap((line) => wrapTextWithAnsi(line, Math.max(1, totalWidth - 3)));
-  return renderPanel(theme, { title: 'Transaction Sheet', lines: wrappedBody, width: totalWidth });
+  return renderPanel(theme, { title: uiText('sheet.title'), lines: wrappedBody, width: totalWidth });
 }
 
 export class TransactionSheetComponent implements Component {
@@ -230,7 +259,7 @@ export class TransactionSheetComponent implements Component {
   private validationPreview(): string[] {
     const details = this.model.details ?? [];
     const verdictAndCounts = details.filter((detail) =>
-      /^Verdict(?:\s|:)/.test(detail) || /^Findings(?:\s|:)/.test(detail));
+      detail.startsWith(uiText('verdict.label')) || detail.startsWith(uiText('findings.count.label')));
     return verdictAndCounts.length > 0 ? verdictAndCounts : details.slice(0, 2);
   }
 
@@ -245,10 +274,10 @@ export class TransactionSheetComponent implements Component {
     return {
       ...this.model,
       details: this.validationDetailsExpanded
-        ? [...details, 'Full Validation Disclosure expanded (press d to collapse)']
+        ? [...details, uiText('sheet.disclosure.expanded')]
         : [
             ...this.validationPreview(),
-            `Full Validation Disclosure collapsed (${details.length} lines; press d to expand)`,
+            uiText('sheet.disclosure.collapsed', { count: details.length }),
           ],
     };
   }

--- a/extensions/pi/ui-strings.ts
+++ b/extensions/pi/ui-strings.ts
@@ -1,10 +1,11 @@
 /**
  * Centralized presentation-string module for the /codex-marketplace TUI (Issue #41).
  *
- * Every user-visible TUI string is addressed by a stable message id and resolved from
- * the active locale dictionary (zh_TW). Components never hard-code display English;
+ * Every user-visible string on TUI surfaces is addressed by a stable message id and resolved
+ * from the active locale dictionary (zh_TW). Components never hard-code display English;
  * remaining Latin text on screen is limited to canonical glossary terms, closed values,
- * rule codes, and target identities, exactly as required by Issue #41.
+ * rule codes, and target identities, exactly as required by Issue #41. The non-TUI
+ * `list`/`inspect` plain-text output is explicitly out of scope and stays canonical English.
  *
  * Locale seam: switching dictionaries is intentionally out of scope, but the module
  * shape (locale-keyed dictionaries behind `uiText`) leaves that seam in place.
@@ -15,6 +16,7 @@
 
 import type { AttemptSummary, RecoveryAction } from '../../src/registration/receipt.js';
 import type { ValidationFinding } from '../../src/registration/findings.js';
+import type { Scope } from '../../src/bridge-state/types.js';
 import type { TransactionStep } from './transaction-sheet.js';
 
 /** Supported presentation locales. Only zh_TW ships today; the seam stays explicit. */
@@ -594,6 +596,14 @@ export function uiText(id: MessageId, params?: Record<string, string | number>):
 /** Canonical-first closed value rendering: `Canonical（中文釋義）`. */
 export function closedValue(canonical: string, gloss: string): string {
   return `${canonical}（${gloss}）`;
+}
+
+/** Localized scope-selection options bound to their structured Scope values. */
+export function scopeOptions(): Map<string, Scope> {
+  return new Map([
+    [uiText('common.scope.global'), 'global'],
+    [uiText('common.scope.project'), 'project'],
+  ]);
 }
 
 const ATTEMPT_SUMMARY_GLOSS: Record<AttemptSummary, MessageId> = {

--- a/extensions/pi/ui-strings.ts
+++ b/extensions/pi/ui-strings.ts
@@ -1,0 +1,684 @@
+/**
+ * Centralized presentation-string module for the /codex-marketplace TUI (Issue #41).
+ *
+ * Every user-visible TUI string is addressed by a stable message id and resolved from
+ * the active locale dictionary (zh_TW). Components never hard-code display English;
+ * remaining Latin text on screen is limited to canonical glossary terms, closed values,
+ * rule codes, and target identities, exactly as required by Issue #41.
+ *
+ * Locale seam: switching dictionaries is intentionally out of scope, but the module
+ * shape (locale-keyed dictionaries behind `uiText`) leaves that seam in place.
+ *
+ * Behavior rule: dispatch never matches on display strings. All intents remain
+ * structured (LedgerActionIntent), and closed values are compared canonically.
+ */
+
+import type { AttemptSummary, RecoveryAction } from '../../src/registration/receipt.js';
+import type { ValidationFinding } from '../../src/registration/findings.js';
+import type { TransactionStep } from './transaction-sheet.js';
+
+/** Supported presentation locales. Only zh_TW ships today; the seam stays explicit. */
+export type UiLocale = 'zh-TW';
+
+export const activeLocale: UiLocale = 'zh-TW';
+
+/**
+ * The zh_TW dictionary. Keys are stable message ids; values are zh_TW templates with
+ * optional `{param}` placeholders filled by `uiText`.
+ */
+const zhTW = {
+  // --- index.ts: command surface -------------------------------------------
+  'cmd.description': '於 Global / Project Bridge Ledger 工作區管理 Codex Marketplace',
+  'cmd.state.empty':
+    '{scope}：空白（初始狀態）· schema v{version} · State Revision {revision} · Registration 0 · Installation 0',
+  'cmd.state.ok':
+    '{scope}：State Revision {revision} · Registration {registrations} · 啟用 Installation {enabled} / 停用 {disabled}',
+  'cmd.state.ok.overrides': ' · Scope Override {overrides}',
+  'cmd.state.incompatible': '{scope}：不相容 — {error}（需更新 Bridge Package）',
+  'cmd.state.corrupted': '{scope}：Persistence Indeterminate（無法判定）— {error}（不自動回滾）',
+
+  // --- common ---------------------------------------------------------------
+  'common.yes': '是',
+  'common.no': '否',
+  'common.none': '無',
+  'common.notApplicable': '不適用',
+  'common.unavailable': 'unavailable（無法使用）',
+  'common.unknown': '未知',
+  'common.cancelled.transaction': '已取消 Transaction；Bridge State 未變更。',
+  'common.bridgeState.unreadable': 'Bridge State 不可讀：{error}',
+  'common.scope.global': 'Global Scope',
+  'common.scope.project': 'Project Scope',
+  'common.scope.word.global': 'Global',
+  'common.scope.word.project': 'Project',
+  'common.installation.none': '此 Scope 尚無 Installed Plugin。',
+  'common.registration.none': '此 Scope 尚無 Marketplace Registration。',
+
+  // --- closed-value glosses (canonical always rendered first) ---------------
+  'summary.gloss.Completed': '完成',
+  'summary.gloss.Completed with diagnostics': '完成但有診斷',
+  'summary.gloss.Declined': '已婉拒',
+  'summary.gloss.Blocked': '受阻',
+  'summary.gloss.Rejected as Stale': '已拒絕（過期）',
+  'summary.gloss.Persistence Failed': '持久化失敗',
+  'summary.gloss.Persistence Indeterminate': '持久化無法判定',
+  'summary.gloss.Pending Application': '待套用',
+  'summary.badge.diagnostics': '有診斷',
+  'summary.badge.declined': '已婉拒',
+  'summary.badge.blocked': '受阻',
+  'summary.badge.stale': '過期',
+  'summary.badge.persistenceFailed': '持久失敗',
+  'summary.badge.pending': '待套用',
+  'recovery.gloss.Retry': '重試',
+  'recovery.gloss.Revalidate': '重新驗證',
+  'recovery.gloss.Refresh': '重新整理（Marketplace Refresh）',
+  'recovery.gloss.Rebind': '重新綁定（Registration Rebind）',
+  'recovery.gloss.Retry Application': '重試運行時套用',
+  'recovery.gloss.Disable': '停用',
+  'recovery.gloss.Remove': '移除',
+  'recovery.gloss.Repair State': '修復 Bridge State',
+  'recovery.gloss.Inspect': '檢視',
+  'step.gloss.Intent': '意圖',
+  'step.gloss.Validation': '驗證',
+  'step.gloss.Consent': '同意確認',
+  'step.gloss.Plan': '計畫',
+  'step.gloss.Commit': '提交',
+  'step.gloss.Receipt': '收據',
+  'step.activeSuffix': '進行中',
+
+  // --- verdict (validation disclosure headline) ------------------------------
+  'verdict.label': '判定 Verdict',
+  'verdict.gloss.Passed': '通過',
+  'verdict.gloss.Passed with diagnostics': '通過但有診斷',
+  'verdict.gloss.Blocked': '受阻',
+  'findings.count.label': 'Findings',
+  'findings.count.line': '{blocking} blocking · {warning} warning · {notice} notice',
+
+  // --- finding rendering -----------------------------------------------------
+  'finding.line':
+    'finding 分類 {classification}｜Scope {scope}｜階段 {phase}｜目標 {target}｜指標 {pointer}｜代碼 {code}｜規則 {rule}｜結果 {outcome}',
+
+  // --- transaction-sheet.ts --------------------------------------------------
+  'sheet.title': 'Transaction Sheet 交易單',
+  'sheet.field.action': '動作',
+  'sheet.field.authority': '授權範圍',
+  'sheet.field.target': '目標',
+  'sheet.field.detail': '詳情',
+  'sheet.field.outcome': '結果',
+  'sheet.field.expectedRevision': '預期 State Revision',
+  'sheet.field.targetRevision': '目標 State Revision',
+  'sheet.field.observedRevision': '觀察 State Revision',
+  'sheet.field.stateChanged': 'State 是否變更',
+  'sheet.axis.durable': 'Durable（持久層）',
+  'sheet.axis.findings': 'Findings（診斷）',
+  'sheet.axis.runtime': 'Runtime（運行時）',
+  'sheet.field.count': '總數',
+  'sheet.field.receipt': 'Receipt',
+  'sheet.field.kind': '種類',
+  'sheet.field.operation': '操作',
+  'sheet.field.trigger': '觸發',
+  'sheet.attemptSummary': 'Attempt Summary',
+  'sheet.recoveryActions': 'Recovery Actions（復原動作）',
+  'sheet.keys': 'Enter：繼續｜Esc/q/Ctrl-C：取消',
+  'sheet.disclosure.expanded': '完整 Validation Disclosure 已展開（按 d 收合）',
+  'sheet.disclosure.collapsed': '完整 Validation Disclosure 已收合（共 {count} 行；按 d 展開）',
+
+  // --- bridge-ledger.ts: model ------------------------------------------------
+  'ledger.title': 'CODEX MARKETPLACE / BRIDGE LEDGER',
+  'ledger.section.observe.label': '總覽',
+  'ledger.section.observe.description': '檢視授權分割區與衍生的 Effective State',
+  'ledger.section.sources.label': '來源',
+  'ledger.section.sources.description': 'Marketplace Registration 與來源生命週期操作',
+  'ledger.section.plugins.label': 'Plugins',
+  'ledger.section.plugins.description': '相容候選與 scope-local Installation 狀態',
+  'ledger.section.scope-inheritance.label': 'Scope 與繼承',
+  'ledger.section.scope-inheritance.description': 'Project Scope Override 抑制繼承的全域紀錄，但不修改它們',
+  'ledger.section.recovery-receipts.label': '復原與收據',
+  'ledger.section.recovery-receipts.description': '非權威的 Attempt Receipt 歷史與明確的 State Repair',
+
+  'ledger.action.observe-partitions': '檢視授權分割區',
+  'ledger.action.observe-effective-state': '檢視 Effective State 與 Projected Skills',
+  'ledger.action.register-local': '註冊本地 Marketplace',
+  'ledger.action.register-git': '註冊 Git Marketplace',
+  'ledger.action.refresh-registration': 'Marketplace Refresh（重整來源）',
+  'ledger.action.rebind-registration': 'Registration Rebind（重綁來源）',
+  'ledger.action.remove-registration': '移除 Registration',
+  'ledger.action.install-disabled': 'Install Disabled（安裝但停用）',
+  'ledger.action.install-and-enable': 'Install and Enable（安裝並啟用）',
+  'ledger.action.enable-installation': '啟用 Installation',
+  'ledger.action.disable-installation': '停用 Installation',
+  'ledger.action.remove-installation': '移除 Installation',
+  'ledger.action.create-scope-override': '建立 Scope Override',
+  'ledger.action.remove-scope-override': '移除 Scope Override',
+  'ledger.action.view-receipt-journal': '檢視 Receipt Journal',
+  'ledger.action.repair-state': 'Repair State（修復 Bridge State）',
+  'ledger.action.retry-application': 'Retry Application（重試運行時套用）',
+  'ledger.action.inspect-receipt': '檢視 Attempt Receipt',
+
+  'ledger.rail.health.healthy': '健康',
+  'ledger.rail.health.healthyEmpty': '健康（空白初始狀態）',
+  'ledger.rail.health.incompatible': '不相容：{error}',
+  'ledger.rail.health.indeterminate': 'Persistence Indeterminate（無法判定）：{error}',
+  'ledger.rail.trust.notApplicable': 'Project Trust：不適用',
+  'ledger.rail.trust.granted': 'Project Trust：已授予',
+  'ledger.rail.trust.notGranted': 'Project Trust：未授予',
+  'ledger.badge.healthy': '健康',
+  'ledger.badge.incompatible': '不相容',
+  'ledger.badge.indeterminate': '無法判定',
+  'ledger.badge.trustGranted': '信任已授予',
+  'ledger.badge.noTrust': '未授予 Project Trust',
+  'ledger.badge.barrierActive': 'Barrier 作用中',
+  'ledger.badge.barrierClear': 'Barrier 暢通',
+  'ledger.rail.revision': '{marker} State Revision {revision}',
+  'ledger.rail.registrations': 'Registration {count}',
+  'ledger.rail.installations': 'Installation 啟用 {enabled} / 停用 {disabled}',
+  'ledger.rail.overrides': 'Scope Override {count}',
+  'ledger.rail.barrierReason': '↳ Barrier 原因：{reason}',
+  'ledger.barrier.clear': '無作用中 Barrier',
+  'ledger.barrier.defaultReason': '需要先進行全域復原',
+
+  'ledger.availability.ready': '可用',
+  'ledger.availability.blocked': '受阻',
+  'ledger.disabledReason.barrier':
+    'Global Pending Barrier 作用中：{reason}；請開啟「復原與收據」分區並完成可用的 Global Recovery Action',
+  'ledger.disabledReason.trust': '未授予 Project Trust；Project Scope 變異不可用',
+  'ledger.disabledReason.retryNoSnapshot':
+    'Pending Application 未綁定 Validation Snapshot；請改以全新的已驗證 Lifecycle Intent 開始，而非重放此嘗試',
+  'ledger.disabledReason.repairIneligible': 'State Repair 不適用於 {conditions}；請使用確切宣告的 Recovery Action',
+  'ledger.disabledReason.repairNothing': 'State Repair 沒有符合資格的 Persistence Indeterminate 復原鏈，也沒有不可讀狀態',
+  'ledger.disabledReason.incompatible': 'Bridge State schema 不相容：{error}；請更新 Bridge Package',
+  'ledger.disabledReason.incompatibleMutation': 'Bridge State 不相容：{error}；變更前請先更新 Bridge Package',
+  'ledger.disabledReason.corrupted': 'Persistence Indeterminate：{error}；請使用 Repair State',
+  'ledger.disabledReason.corruptState': 'Bridge State 無法讀取',
+  'ledger.condition.pending-application': 'Pending Application',
+  'ledger.condition.persistence-failed': 'Persistence Failed',
+
+  'ledger.row.registrationActions': '{scopeWord} Registration 操作',
+  'ledger.row.registration.sourceUnknown': '未知來源',
+  'ledger.row.registration.sourceUnavailable': '（來源不可讀）',
+  'ledger.row.diagnostic.unavailable': 'Unavailable（無法使用）· {findings}',
+  'ledger.row.diagnostic.noEntries': '未回報任何 Marketplace Entry',
+  'ledger.row.skills.resources': '{name} {policy} 資源 {resources}',
+  'ledger.row.skills.none': '技能：無',
+  'ledger.row.skills.noResources': '無',
+  'ledger.row.install.alreadyInstalled': '此 Marketplace Entry 在此 Scope 已有 Installation',
+  'ledger.row.install.snapshotMissing': 'Validation Snapshot 不可用；請在來源檢驗後重新開啟 Plugins 分區',
+  'ledger.row.install.classification': '{classification} Marketplace Entry',
+  'ledger.row.override.inherited': '繼承自 Global 的 {kind} · 正典目標 {targetId}',
+  'ledger.row.override.label': '{kind} Override',
+  'ledger.row.override.suppresses': '抑制繼承的 {targetId}',
+  'ledger.row.retry.label': '{scopeWord} Pending Application',
+  'ledger.row.retry.detail': '進行中的復原鏈 {receiptId} · State Revision {revision}',
+  'ledger.row.observe.partitions': 'Global / Project 授權分割區',
+  'ledger.row.observe.partitionsDetail': 'Global State Revision {global} · Project State Revision {project}',
+  'ledger.row.observe.effective': 'Effective State 與 Projected Skills',
+  'ledger.row.observe.effectiveDetail':
+    'Registration {registrations} · Installation {installations} · 已抑制 {suppressed} · 已排除 {excluded}',
+  'ledger.row.journal.label': '{scopeWord} Receipt Journal',
+  'ledger.row.journal.detail': 'Receipt {receipts} · 進行中復原鏈 {chains} · 降級 {degraded}',
+  'ledger.row.repair.label': '{scopeWord} State Repair',
+  'ledger.revision.unavailable': '無法讀取',
+
+  // --- bridge-ledger.ts: component chrome ------------------------------------
+  'ledger.panel.navigation': '導覽',
+  'ledger.panel.sections': '分區',
+  'ledger.panel.help': '說明',
+  'ledger.rows.empty': '此分區沒有任何列',
+  'ledger.entry.unavailableRow': 'Unavailable（無法使用）· {label}',
+  'ledger.entry.noFindings': '（未回報 findings）',
+  'ledger.entry.blocked': '受阻：{reason}',
+  'ledger.meta.target': '目標 {kind} {target}',
+  'ledger.meta.scope': 'Scope {scope}',
+  'ledger.meta.mode': '模式 {mode}',
+  'ledger.meta.detail': '詳情 {detail}',
+  'ledger.status.browsing': '狀態：瀏覽 {marker}｜{section}｜{pane}',
+  'ledger.status.pane.actions': '動作',
+  'ledger.status.pane.sections': '分區',
+  'ledger.keys.help': '按鍵：?/Esc 關閉說明｜q/Ctrl-C 離開｜Esc/q 取消情境',
+  'ledger.keys.drilldown': '按鍵：Esc/q 取消｜Enter 進入分區｜j/k 移動｜g/p 切換 Scope｜? 說明',
+  'ledger.keys.wide': '按鍵：Esc/q 取消｜Enter 執行｜j/k 或方向鍵移動｜i 詳情｜g/p 切換 Scope｜? 說明',
+  'ledger.help.move': 'Up/Down 或 j/k：移動選取',
+  'ledger.help.sections': 'Left/Right：切換分區（寬版面）或進入下層',
+  'ledger.help.enter': 'Enter：開啟分區或執行可用的結構化動作',
+  'ledger.help.metadata': 'i：展開或收合所選項目的中繼資料',
+  'ledger.help.browse': 'g/p：僅瀏覽 Global／Project；變異授權仍須明確選擇',
+  'ledger.help.close': 'Esc：返回/取消｜q 或 Ctrl-C：離開｜？：關閉說明',
+
+  // --- registration.ts / git-registration.ts ---------------------------------
+  'reg.select.scope': 'Marketplace Registration — 選擇 Scope',
+  'reg.select.scope.git': 'Marketplace Registration (Git) — 選擇 Scope',
+  'reg.cancelled': '已取消 Registration',
+  'reg.git.cancelled': '已取消 Git Registration',
+  'reg.input.localRoot': '本地 Marketplace Root（需含 .agents/plugins/marketplace.json）',
+  'reg.detail.registrationId': 'Registration ID {id}',
+  'reg.detail.source': '來源 {source}',
+  'reg.detail.marketplace': 'Marketplace {name}',
+  'reg.detail.entries': 'Entries {total}（可定位 {locatable} / 無法定位 {unavailable}）',
+  'reg.detail.profile': 'Compatibility Profile {profile}',
+  'reg.detail.ruleset': 'Validation Ruleset {ruleset}',
+  'reg.detail.budget': 'Validation Budget {budget}',
+  'reg.detail.snapshotShort': 'Validation Snapshot：{snapshot}…',
+  'reg.detail.entry': 'Entry {entryId} {name} {status}',
+  'reg.entry.locatable': '可定位',
+  'reg.entry.unavailable': '無法使用：{reason}',
+  'reg.git.locator.prompt': 'Git Marketplace Locator（https:// 或 ssh:// 或 scp-like user@host:path，無憑證、無 query/fragment）',
+  'reg.git.selector.prompt': 'Git Selector — 選擇型別',
+  'reg.git.selector.default': 'default（跟隨遠端預設分支 HEAD）',
+  'reg.git.selector.branch': 'branch（→ refs/heads/*）',
+  'reg.git.selector.tag': 'tag（→ refs/tags/*）',
+  'reg.git.selector.commit': 'commit（小寫完整 40/64 hex）',
+  'reg.git.branch.prompt': 'Branch 名稱（例：main / feature/foo，將正規化為 refs/heads/<name>）',
+  'reg.git.tag.prompt': 'Tag 名稱（例：v1.2.3，將正規化為 refs/tags/<name>）',
+  'reg.git.commit.prompt': 'Commit（完整 40 或 64 hex，將轉為小寫）',
+  'reg.git.detail.canonicalLocator': 'Canonical Git Locator {locator}',
+  'reg.git.detail.locator': 'Locator {locator}',
+  'reg.git.detail.selectorValue': 'Git Selector {selector}',
+  'reg.git.detail.transport': 'Locator 傳輸 {transport}',
+  'reg.git.detail.host': 'Locator 主機 {host}',
+  'reg.git.detail.port': 'Locator 連接埠 {port}',
+  'reg.git.detail.path': 'Locator 路徑 {path}',
+  'reg.git.detail.user': 'Locator 使用者 {user}',
+  'reg.git.detail.selector': 'Git Selector {kind} → {canonical}',
+  'reg.git.detail.resolvedRevision': 'Resolved Revision {revision}',
+  'reg.git.detail.acquisitionSafety':
+    '取得安全：隔離且無憑證的 Git Source Acquisition；遠端控制的 hooks 與 submodules 一律不執行。',
+  'reg.consent.details': 'Registration Confirmation：獨立的 Default No 宿主閘門',
+  'reg.consent.title': 'Registration Confirmation — 預設 No（綁定 State Revision + Validation Snapshot，不可記憶、不可批次）',
+  'reg.local.consent.body': '確認 Registration ID {registrationId}：{source} 至 {scope}？\nValidation Disclosure:\n{disclosure}',
+  'reg.git.consent.body':
+    '確認 Registration ID {registrationId}：{locator}#{selector}（{revision}…）至 {scope}？\nValidation Disclosure:\n{disclosure}',
+  'reg.plan.details': 'Update Plan：不適用——新 Registration 沒有替換計畫',
+  'reg.commit.persist': '寫入 Registration ID {id}',
+  'reg.commit.authority': '於 {scope} 以 State Revision {revision} 寫入授權文件',
+  'reg.outcome.notify': 'Attempt Summary：{summary} · Receipt {receiptId}',
+
+  // --- installation.ts ---------------------------------------------------------
+  'inst.select.scope': 'Plugin Installation — 選擇 Scope',
+  'inst.select.installedScope': 'Installed Plugin — 選擇 Scope',
+  'inst.select.registered': '選擇已註冊 Marketplace',
+  'inst.select.installed': '選擇 Installed Plugin',
+  'inst.select.entry': 'Marketplace Entries（顯示 Marketplace Entry ID 與可安裝/unavailable 原因）',
+  'inst.select.path': '安裝路徑（Installation path）',
+  'inst.path.disabled': 'Install Disabled（安裝但停用）',
+  'inst.path.enabled': 'Install and Enable（安裝並啟用）',
+  'inst.entry.unavailable': '此 Marketplace Entry 為 Unavailable，無法安裝。',
+  'inst.choice.unavailable': '{name} — Unavailable（{reason}）',
+  'inst.choice.available': '{id} · {name} — 可安裝',
+  'inst.choice.readFailure': 'Marketplace Catalog 無法讀取',
+  'inst.entry.available': '可安裝',
+  'inst.entry.unavailableNotice': '此 Marketplace Entry 為 Unavailable，無法安裝。',
+  'inst.actionLabel.disabled': 'Install Disabled（安裝但停用）',
+  'inst.actionLabel.enabled': 'Install and Enable（安裝並啟用）',
+  'inst.actionLabel.enablement': 'Plugin Enablement（啟用 Plugin）',
+  'inst.actionLabel.disablement': 'Plugin Disablement（停用 Plugin）',
+  'inst.disclosure.scope': 'Scope：{scope}',
+  'inst.detail.registration': 'Registration {id}',
+  'inst.detail.entryPointer': 'Marketplace Entry {pointer}',
+  'inst.detail.targetState': '目標狀態 {state}',
+  'inst.detail.requestedState': '要求狀態 {state}',
+  'inst.detail.currentState': '目前狀態 {state}',
+  'inst.detail.installation': 'Installation {id}',
+  'inst.notFound.registration': '找不到 Marketplace Registration {id}。',
+  'inst.notFound.installation': '找不到 Installed Plugin {id}。',
+  'inst.disclosure.plugin': 'Plugin：{name}（{id}）',
+  'inst.disclosure.source': '來源 {source}',
+  'inst.disclosure.marketplaceEntry': 'Marketplace Entry：{entryId}',
+  'inst.disclosure.classification': '分類：Compatible',
+  'inst.disclosure.precedence': '投影優先序：Pi → Project Scope → Global Scope',
+  'inst.disclosure.skills': 'Skills：{count}',
+  'inst.disclosure.skill': '{name} · {policy} · resources：{resources}',
+  'inst.disclosure.findings': 'Findings：{findings}',
+  'inst.activation.confirmTitle': 'Activation Confirmation — 預設 No（獨立於 Registration Confirmation）',
+  'inst.activation.confirmBody': 'Validation Disclosure:\n{disclosure}\n\n確認安裝並啟用 {name}？',
+  'inst.activation.reenableTitle': 'Activation Confirmation — 預設 No（重新驗證後才可 re-enable）',
+  'inst.commit.authority': '於 {scope} 以 State Revision {revision} 寫入授權文件',
+  'inst.plan.notApplicable': 'Update Plan：不適用——Plugin Installation 不會替換 Registration 快照',
+  'inst.plan.stateOnly': 'Update Plan：不適用——僅變更 Installation 狀態的操作',
+  'inst.consent.activationGate': 'Activation Confirmation：獨立的 Default No 宿主閘門',
+  'inst.consent.na.disabled': 'Activation Confirmation：不適用——Install Disabled 不會啟用',
+  'inst.consent.na.disablement': 'Activation Confirmation：不適用——disablement 不會啟用 Plugin',
+  'inst.validation.noSnapshot': 'Validation Snapshot：不適用——disablement 移除運行時參與',
+
+  // --- lifecycle.ts -------------------------------------------------------------
+  'life.pick.scope': '選擇 Scope',
+  'life.pick.registration': '選擇 Marketplace Registration',
+  'life.plan.choice.update': 'update — 套用新快照（{detail}）',
+  'life.plan.choice.update.compatible': '有 Compatible candidate',
+  'life.plan.choice.update.incompatible': '無 candidate → 不可選',
+  'life.plan.choice.disable': 'disable — 停用並保留 Installation ID',
+  'life.plan.choice.remove': 'remove — 移除此 Installation',
+  'life.candidate.scope': 'Scope：{scope}',
+  'life.candidate.registration': 'Registration：{id}',
+  'life.candidate.newSnapshot': '新 Validation Snapshot：{snapshot}…',
+  'life.candidate.recordedSnapshot': '既有 Recorded Snapshot：{snapshot}…',
+  'life.candidate.resolvedRevision': 'Resolved Revision：{from} → {to}',
+  'life.candidate.entries': 'Entries：{total}（可安裝 {available}）',
+  'life.actionLabel.refresh': 'Marketplace Refresh（重整來源）',
+  'life.actionLabel.rebind': 'Registration Rebind（重綁來源）',
+  'life.actionLabel.applyUpdate': 'Apply Update（套用更新）',
+  'life.actionLabel.registrationRemoval': 'Registration Removal（移除 Registration）',
+  'life.actionLabel.installationRemoval': 'Installation Removal（移除 Installation）',
+  'life.rebind.selectorPlaceholder.branch': 'main',
+  'life.rebind.selectorPlaceholder.tag': 'v1.2.3',
+  'life.rebind.selectorPlaceholder.commit': '完整 40/64 hex commit',
+  'life.updatePlan.intent.rebind': '在保留正典 Registration ID 的前提下替換其來源',
+  'life.updatePlan.intent.apply': '於單一 Lifecycle Operation 中套用此 Update Candidate',
+  'life.updatePlan.notifyDisclosure': 'Validation Disclosure（新快照）：\n{summary}',
+  'life.updatePlan.consent.details': 'Registration Confirmation 與每項必要的 Activation Confirmation 皆是獨立的 Default No 決策',
+  'life.updatePlan.confirmRegistration.title': 'Registration Confirmation — 預設 No（綁定新 Validation Snapshot + State Revision）',
+  'life.updatePlan.confirmRegistration.body': '接受此新的 Validation Snapshot 作為 Registration {id}… 的授權來源？',
+  'life.updatePlan.plan.details': '需要明確結果的 Installation 數量：{count}',
+  'life.updatePlan.pick.title': 'Installation {name}（{state}）— 選擇更新結果',
+  'life.updatePlan.activation.title': 'Activation Confirmation — 預設 No（舊同意不沿用）',
+  'life.updatePlan.activation.body': '啟用的 {name} 將在新快照下保持啟用。確認其 Activation？',
+  'life.updatePlan.checklist.entry': '· {installationId} → {choice}{state}',
+  'life.updatePlan.commit.details': '最終 Default No 確認後，完整 Update Plan 將原子提交',
+  'life.updatePlan.commit.noConsequences': '（無既有 Installation 後果）',
+  'life.updatePlan.commit.confirm.apply.title': 'Apply Update — 單次原子提交',
+  'life.updatePlan.commit.confirm.rebind.title': 'Apply Rebind — 單次原子提交',
+  'life.updatePlan.commit.confirm.body': '將以單一 Lifecycle Operation 原子替換快照並套用所有披露後果：\n{checklist}\n\n確認提交？',
+  'life.updatePlan.commit.confirm.empty': '（無既有 Installation）',
+  'life.refresh.intent.inspectionOnly': '僅對此 Registration 執行明確的非變異檢查',
+  'life.refresh.intent.noWrite': 'Marketplace Refresh 不會寫入 Bridge State',
+  'life.refresh.outcome': 'Refresh 結果：{status}',
+  'life.refresh.candidateReady': 'Update Candidate 已產生（非變異檢查，Bridge State 未寫入）。',
+  'life.rebind.intent.details': '在保留正典 Registration ID 的前提下，替換來源 locator 或 Git Selector',
+  'life.rebind.sourceKind.prompt': '新來源型別',
+  'life.rebind.sourceKind.local': '本地目錄（local path）',
+  'life.rebind.sourceKind.git': 'Git 倉庫（locator + selector）',
+  'life.rebind.localRoot.prompt': '新的本地 Marketplace Root 路徑',
+  'life.rebind.locator.prompt': 'Git Locator（https:// 或 ssh，無憑證、無 query/fragment）',
+  'life.rebind.selectorKind.prompt': 'Git Selector 型別',
+  'life.rebind.selectorValue.prompt': '{kind} 值（例：{placeholder}）',
+  'life.rebind.cancelled': '已取消 Rebind。',
+  'life.rebind.revalidated': '替代來源已完成完整重驗證；需重新收集全部確認（舊 Activation 同意不沿用）。',
+  'life.removal.pick.kind': '移除目標',
+  'life.removal.kind.registration': '整個 Registration（原子刪除同範圍所有 Installations）',
+  'life.removal.kind.installation': '單一 Installation（保留 Registration）',
+  'life.removal.pick.installation': '選擇要移除的 Installation',
+  'life.removal.notFound': '找不到正典 removal 目標 {targetId}。',
+  'life.removal.reg.intent': '原子移除此 Registration 與其全部同範圍 Installations',
+  'life.removal.reg.consent.details': 'Registration Removal 確認仍是獨立的 Default No 決策',
+  'life.removal.reg.consent.title': 'Registration Removal — 預設 No',
+  'life.removal.reg.commit': '於持有的 Attempt Fence 保護下，將已披露的連鎖後果提交至此 scope 文件',
+  'life.removal.inst.intent': '僅移除此 scope-local Installation，保留其所屬 Registration',
+  'life.removal.inst.consent.details': 'Installation Removal 確認仍是獨立的 Default No 決策',
+  'life.removal.inst.consent.title': 'Installation Removal — 預設 No',
+  'life.removal.inst.commit': '於持有的 Attempt Fence 保護下，將移除提交至此 scope 文件',
+  'life.removal.disclosure.scope': 'Scope：{scope}',
+  'life.removal.disclosure.registration': 'Registration：{id} · {source}',
+  'life.removal.disclosure.registration.noSource': 'Registration：{id}',
+  'life.removal.disclosure.revision': 'State Revision：{revision}',
+  'life.removal.disclosure.cascade': '原子移除的同範圍 Installations：{count}',
+  'life.removal.disclosure.installation': '{id} · {pluginId} · {state}',
+  'life.removal.disclosure.otherScopes': '永不變更其他 scope；殘留參照將 fail closed 顯示為 unavailable，直到修復或移除。',
+  'life.removal.disclosure.installationLine': 'Installation：{id} · {pluginId} · {state}',
+  'life.removal.disclosure.retainedRegistration': '保留 Registration：{id}',
+  'life.removal.disclosure.retainedNone': '保留 Registration：（無）',
+  'life.removal.disclosure.resuming.header': '之後恢復生效的繼承 Installations：',
+  'life.removal.disclosure.resuming.none': '沒有繼承 Installation 會在此之後恢復生效。',
+
+  // --- journal.ts -----------------------------------------------------------------
+  'journal.pick.scope': 'Receipt Journal — 選擇 Scope',
+  'journal.repair.pick.scope': 'Repair State — 選擇 Scope',
+  'journal.view.header': '=== {scopeWord} Receipt Journal ===',
+  'journal.view.total': 'Receipt 總數：{count}',
+  'journal.view.degraded.yes': 'Journal 降級：是（{count} 行損毀）',
+  'journal.view.degraded.no': 'Journal 降級：否',
+  'journal.view.chains.header': '進行中復原鏈：{value}',
+  'journal.view.chains.none': '無',
+  'journal.view.chain.line': 'Chain {receiptId} 條件：{condition}（長度：{length}）',
+  'journal.view.recent.header': '── 最近 Receipt ──',
+  'journal.view.recent.empty': '（Journal 為空）',
+  'journal.view.receipt.summary': '摘要：{summary}｜持久：{durable}｜運行時：{runtime}',
+  'journal.view.receipt.revision': 'State Revision：{expected} → {observed}',
+  'journal.view.receipt.recovers': '復原對象：{receiptId}',
+  'journal.view.receipt.findings': 'Findings：{findings}',
+  'journal.notFound': 'Receipt Journal 找不到精確 Receipt ID {receiptId}。',
+  'journal.appendFailed': 'Receipt Journal 寫入失敗：{error}',
+  'journal.finding.persistFailed': 'Attempt Receipt 寫入 Journal 失敗：{error}',
+  'journal.retry.chainStale': '所選的 Pending Application 復原鏈已不再進行中；請重新開啟 Bridge Ledger',
+  'journal.retry.staleDuringConfirm': '確認期間 State Revision 已改變（{expected} → {observed}）；未要求 Runtime Application',
+  'journal.retry.staleDuringConfirmSnapshot': '確認期間所綁 Validation Snapshot 已改變；未要求 Runtime Application',
+  'journal.retry.noSnapshot': '進行中的 Pending Application 根 Receipt 未綁定 Validation Snapshot；fail closed，請從全新 Intent 重新驗證',
+  'journal.retry.snapshotMismatch': '所綁 Validation Snapshot 已不符合現行來源材料；請重新開啟 Bridge Ledger 並重新驗證',
+  'journal.retry.unreadable': 'Bridge State 不可讀；無法驗證 Runtime Application',
+  'journal.retry.trustDenied': '未授予 Project Trust；Project Runtime Application 不可用',
+  'journal.retry.trustRevoked': '確認期間 Project Trust 已被撤銷；未要求 Runtime Application',
+  'journal.retry.trustRevokedReload': '宿主重載期間 Project Trust 已被撤銷；Project Runtime Application 保持阻擋',
+  'journal.retry.barrierRequired': '需要先完成全域復原',
+  'journal.retry.barrierDuringConfirm': '確認期間出現全域復原需求；未要求 Runtime Application',
+  'journal.retry.barrierDuringReload': '宿主重載期間出現全域復原需求',
+  'journal.retry.intent.details': '僅重試所選的進行中 Pending Application 復原鏈；不會改寫 Bridge State',
+  'journal.retry.validation.root': '進行中的復原根 Receipt {receiptId}',
+  'journal.retry.validation.revision': '精確 State Revision {revision}',
+  'journal.retry.validation.snapshot': '所綁 Validation Snapshot {snapshot}',
+  'journal.retry.validation.snapshotMissing': '（未記錄）',
+  'journal.retry.consent.details': 'Retry Application Confirmation 為明確決策，預設為 No',
+  'journal.retry.consent.title': 'Retry Application Confirmation — 預設 No',
+  'journal.retry.consent.body': '重新載入 Bridge resources 並驗證 {scope} State Revision {revision}？',
+  'journal.retry.plan.details': '請求 Pi 宿主重載，然後在完全一致的所綁 State Revision 驗證 Bridge 重新進入',
+  'journal.retry.commit.details': '不寫入 Bridge State；僅在精確的重載後驗證通過後附加解題 Receipt',
+  'journal.retry.persistenceBeforeReload': 'Runtime Application 前橋接狀態變得不可讀',
+  'journal.repair.intent.details': '驗證確切的權威 Bridge State，並在合格時重建降級的 Receipt Journal 行',
+  'journal.repair.validation.status': '目前讀取狀態：{status}',
+  'journal.repair.validation.diagnostic': '目前診斷：{error}',
+  'journal.repair.validation.diagnosticNone': '無',
+  'journal.repair.validation.journalDegraded': 'Receipt Journal：{count} 行損毀',
+  'journal.repair.validation.journalHealthy': 'Receipt Journal：健康',
+  'journal.repair.validation.journalRevision': 'Receipt Journal revision：{revision}',
+  'journal.repair.validation.eligibility': 'Receipt Journal 修復資格：{eligibility}',
+  'journal.repair.validation.domainGuard': 'Domain Recovery Action 將於 Attempt Fence 下重新驗證；此呈現結果不授權修復',
+  'journal.repair.consent.details': 'Repair State Confirmation 仍是獨立的 Default No 決策',
+  'journal.repair.consent.title': 'Repair State Confirmation — 預設 No',
+  'journal.repair.consent.body': '執行 {scopeWord} Scope 的 State Repair？\n將在 Attempt Fence 保護下驗證 Bridge State，重建可辨識的 Receipt Journal，並解除相應的 Indeterminate/Degraded 復原鏈。',
+  'journal.repair.plan.details': '驗證狀態可讀性/schema，原子地僅保留已驗證的 Receipt 行；不重試生命週期操作、也不回滾狀態',
+  'journal.repair.commit.details': 'Domain guard 將取得該 scope 的 Attempt Fence，並附加產生的不可變 Receipt',
+  'journal.repair.stateError': 'Bridge State 為 {status}',
+
+  // --- scope-overrides.ts ------------------------------------------------------------
+  'ovr.select.create': '建立 Scope Override — 選擇要抑制的繼承全域紀錄',
+  'ovr.select.remove': '移除 Scope Override — 移除後立即還原繼承（不改寫全域文件）',
+  'ovr.pick.existing': '{kind} Override → {targetId}',
+  'ovr.notFound.inherited': '找不到指定的繼承全域紀錄。',
+  'ovr.notFound.override': '找不到指定的 Scope Override。',
+  'ovr.none': 'Project Scope 目前沒有任何 Scope Override。',
+  'ovr.suppressed.subtree': ' — 已抑制（子樹）',
+  'ovr.suppressed.single': ' — 已抑制（單一 Plugin）',
+  'ovr.suppressed.byRegistration': ' — 已抑制（隸屬被覆蓋的 Registration 子樹）',
+  'ovr.supersededByProject': ' — 由 Project 同名 Plugin 優先取代',
+  'ovr.projection.header': 'Effective State：參與 Registration {registrations} · Installation {installations}',
+  'ovr.projection.suppressed': '⊘ 已抑制 {kind} {targetId}（{reason}）',
+  'ovr.projection.noPlugins': 'Projected Plugins：無',
+  'ovr.projection.skillProjected': 'projected（已投影）',
+  'ovr.projection.skillUnavailable': 'unavailable（碰撞）',
+  'ovr.projection.skill': '{name} · {status} · availability: {availability}',
+  'ovr.projection.findings': 'Findings：{findings}',
+  'ovr.projection.trustNote': '\n\n⚠ Project Trust 未授予——Project Scope 紀錄仍保存但不參與 Effective State。',
+  'ovr.projection.availableNote': '\n\nAvailable 僅由宿主獨立證據確立；碰撞僅影響技能粒度，不改變 Plugin 分類。',
+  'ovr.create.actionLabel': 'Scope Override Creation',
+  'ovr.create.intent': '建立 Project Scope 的 {kind} Override，且不修改 Global Bridge State',
+  'ovr.create.targetKind': '目標種類：{kind}',
+  'ovr.create.targetId': '目標 ID：{targetId}',
+  'ovr.create.alreadySuppressed': '是否已抑制：{value}',
+  'ovr.create.trustObserved': 'Pi 宿主觀察到的 Project Trust：{value}',
+  'ovr.create.trust.granted': 'granted（已授予）',
+  'ovr.create.trust.notGranted': 'not granted（未授予；domain admission 將阻擋）',
+  'ovr.create.consent.details': 'Scope Override Disclosure 仍是獨立的 Default No 決策',
+  'ovr.create.consent.title': 'Scope Override Disclosure — 預設 No',
+  'ovr.create.consent.body': '將於 Project Scope 建立 {kind} Scope Override，抑制繼承的全域紀錄：\n{targetId}{cascade}\n\n不會修改全域文件；移除 Override 即可還原繼承。',
+  'ovr.create.cascade.registration': '\n\nRegistration Override 會抑制整顆 Marketplace 子樹（該 Registration 及其所有 Installations）。',
+  'ovr.create.cascade.installation': '\n\nInstallation Override 僅抑制此單一 Plugin。',
+  'ovr.create.plan.registration': '抑制繼承的 Registration marketplace 子樹',
+  'ovr.create.plan.installation': '僅抑制繼承的 Installation',
+  'ovr.create.commit': 'Domain lifecycle guard 將取得 Project Attempt Fence，驗證 trust 與 barrier 狀態，並原子提交',
+  'ovr.remove.actionLabel': 'Scope Override Removal',
+  'ovr.remove.intent': '移除 Project Scope 的 {kind} Override，透過重算立即還原繼承狀態',
+  'ovr.remove.consent.details': 'Override Removal 仍是獨立的 Default No 決策',
+  'ovr.remove.consent.title': 'Override Removal — 預設 No',
+  'ovr.remove.consent.body': '移除 {kind} Scope Override？\n被抑制的繼承全域紀錄將立即在 Effective State 中恢復。',
+  'ovr.remove.plan': '僅移除所選的 Project Scope Override；Global Bridge State 保持不變',
+
+  // --- finding outcome 文案, keyed by stable RULE code -------------------------------
+  'finding.FENCE-01': '另一個 Attempt 正在此 Scope 進行；每個 Scope 同時僅允許一個 Attempt（不排隊）',
+  'finding.STALE-01': 'State Revision 或所綁快照已不再是現行值；此嘗試依 Stale 規則拒絕，需重新 preflight 與確認（不自動合併）',
+  'finding.STALE-02': '所綁 Validation Snapshot 已不符合現行來源材料；需重新驗證',
+  'finding.TRUST-01': '未授予 Project Trust；Project Scope 操作不可用',
+  'finding.DUP-01': '相同 Source Key 的 Marketplace Source 已存在於此 Scope；不得重複註冊',
+  'finding.SRC-01': '指定的來源路徑不存在',
+  'finding.SRC-02': '指定的來源路徑不是目錄',
+  'finding.CAT-01': '找不到 Marketplace Catalog（.agents/plugins/marketplace.json）；舊式 marketplace 形狀不參與 Bridge 讀取',
+  'finding.CAT-02': 'Marketplace Catalog 解析失敗或結構不符',
+  'finding.CAT-03': '宣告的 marketplace 名稱不是小寫 kebab-case',
+  'finding.CAT-04': 'Marketplace Entry 結構不符或無法解析',
+  'finding.CONT-01': '宣告路徑逸出其所屬根目錄（Contained Path 違規）',
+  'finding.CONT-02': 'Contained Symlink 違規：斷裂、迴圈、特殊檔案或指向所屬根之外',
+  'finding.BUDG-01': '超出 Validation Budget 上限',
+  'finding.GIT-01': 'Git Locator 格式無效',
+  'finding.GIT-02': 'Git Locator 不得使用明文或本機傳輸',
+  'finding.GIT-03': 'Git Locator 內嵌憑證，拒絕接受',
+  'finding.GIT-04': 'Git Locator 不得含 query 或 fragment',
+  'finding.GIT-05': 'Git Locator 含控制字元，拒絕接受',
+  'finding.GIT-06': 'Git Locator 含歧義編碼，拒絕接受',
+  'finding.GIT-10': 'Git Selector 無效',
+  'finding.GIT-11': 'branch 值不符合 Git ref-name 規則',
+  'finding.GIT-12': 'tag 值不符合 Git ref-name 規則',
+  'finding.GIT-13': 'commit 值須為完整 40/64 hex 物件名',
+  'finding.GIT-20': 'Resolved Revision 無效',
+  'finding.GIT-30': 'Git Source Acquisition 失敗',
+  'finding.GIT-31': 'SSH host key 未知或已變更，拒絕信任',
+  'finding.GIT-32': '偵測到改變 Canonical Git Locator 的重新導向，拒絕',
+  'finding.GIT-33': '憑證 helper／SSH agent 設定超出 Acquisition Trust Base，拒絕',
+  'finding.COMP-01': 'Plugin manifest 無效或結構不符',
+  'finding.COMP-02': 'Skill descriptor 無效或結構不符',
+  'finding.COMP-03': '不支援的作用中元件；Bridge 僅接受慣性（inert）元件',
+  'finding.COMP-04': 'Plugin ID 碰撞：多個候選宣稱同一 Plugin ID',
+  'finding.COMP-05': 'Skill Agent Profile 無效',
+  'finding.REG-01': '指定的 Registration 不在此 Scope 的 Bridge State',
+  'finding.UPD-01': 'Update Plan 不完整或有衝突；請為每個 Installation 提供明確結果',
+  'finding.INSTALL-01': '指定的 Installation 不存在',
+  'finding.INSTALL-02': '此 Marketplace Entry 在此 Scope 已有 Installation',
+  'finding.INSTALL-03': '缺少必要的 Activation Confirmation（Default No）',
+  'finding.INSTALL-04': '來源材料不再符合所綁快照；需要 Source Reacquisition',
+  'finding.COLLISION-01': 'Runtime 技能碰撞：同名 Skill Descriptor 由另一候選宣告，此 Skill 不可用',
+  'finding.DRIFT-01': 'Source Drift：來源樹與登記的 Validation Snapshot 不符；須先執行 Marketplace Refresh 產生 Update Candidate',
+  'finding.OVR-01': '找不到 Scope Override 目標的繼承紀錄',
+  'finding.OVR-02': '此目標已有 Scope Override',
+  'finding.BARRIER-01': 'Global Pending Barrier 作用中：全域復原完成前，Project 變異與運行時套用皆已阻擋（檢視與 Marketplace Refresh 仍可用）',
+  'finding.JOURNAL-01': 'Attempt Receipt 寫入 Journal 失敗',
+  'finding.JOURNAL-02': 'Receipt Journal 有損毀行；已降級保留',
+  'finding.PERSIST-01': 'Bridge State 不可讀或已損毀（Persistence Indeterminate）',
+  'finding.SCHEMA-01': 'Bridge State schema 版本未知（不相容）；請更新 Bridge Package',
+  'finding.RECON-01': '需要 Startup Reconciliation',
+} as const;
+
+export type MessageId = keyof typeof zhTW;
+
+type Dictionary = Record<MessageId, string>;
+
+const dictionaries: Record<UiLocale, Dictionary> = {
+  [activeLocale]: zhTW,
+};
+
+/**
+ * Resolve a message id from the active locale dictionary, interpolating `{param}`
+ * placeholders. Unknown params render verbatim so gaps are loud instead of silent.
+ */
+export function uiText(id: MessageId, params?: Record<string, string | number>): string {
+  const template = dictionaries[activeLocale][id];
+  if (params === undefined) return template;
+  return (template as string).replace(/\{(\w+)\}/g, (match, key: string) =>
+    Object.prototype.hasOwnProperty.call(params, key) ? String(params[key]) : match,
+  );
+}
+
+/** Canonical-first closed value rendering: `Canonical（中文釋義）`. */
+export function closedValue(canonical: string, gloss: string): string {
+  return `${canonical}（${gloss}）`;
+}
+
+const ATTEMPT_SUMMARY_GLOSS: Record<AttemptSummary, MessageId> = {
+  Completed: 'summary.gloss.Completed',
+  'Completed with diagnostics': 'summary.gloss.Completed with diagnostics',
+  Declined: 'summary.gloss.Declined',
+  Blocked: 'summary.gloss.Blocked',
+  'Rejected as Stale': 'summary.gloss.Rejected as Stale',
+  'Persistence Failed': 'summary.gloss.Persistence Failed',
+  'Persistence Indeterminate': 'summary.gloss.Persistence Indeterminate',
+  'Pending Application': 'summary.gloss.Pending Application',
+} as const;
+
+/** Attempt Summary closed value presented canonical-first with its zh_TW gloss.
+ * Unknown values (e.g. forged journal content) fall back to their quoted canonical form. */
+export function attemptSummaryText(summary: AttemptSummary): string {
+  const glossId = (ATTEMPT_SUMMARY_GLOSS as Record<string, MessageId>)[summary];
+  return glossId ? closedValue(summary, uiText(glossId)) : summary;
+}
+
+/** zh_TW gloss only, for callers that own canonical-value escaping themselves. */
+export function attemptSummaryGloss(summary: AttemptSummary): string {
+  const glossId = (ATTEMPT_SUMMARY_GLOSS as Record<string, MessageId>)[summary];
+  return glossId ? uiText(glossId) : '';
+}
+
+const RECOVERY_ACTION_GLOSS: Record<RecoveryAction, MessageId> = {
+  Retry: 'recovery.gloss.Retry',
+  Revalidate: 'recovery.gloss.Revalidate',
+  Refresh: 'recovery.gloss.Refresh',
+  Rebind: 'recovery.gloss.Rebind',
+  'Retry Application': 'recovery.gloss.Retry Application',
+  Disable: 'recovery.gloss.Disable',
+  Remove: 'recovery.gloss.Remove',
+  'Repair State': 'recovery.gloss.Repair State',
+  Inspect: 'recovery.gloss.Inspect',
+};
+
+/** Recovery Action closed value presented canonical-first with its zh_TW gloss. */
+export function recoveryActionText(action: RecoveryAction): string {
+  const glossId = RECOVERY_ACTION_GLOSS[action];
+  return glossId ? closedValue(action, uiText(glossId)) : action;
+}
+
+/** zh_TW gloss only, for callers that own canonical-value escaping themselves. */
+export function recoveryActionGloss(action: RecoveryAction): string {
+  const glossId = RECOVERY_ACTION_GLOSS[action];
+  return glossId ? uiText(glossId) : '';
+}
+
+const STEP_GLOSS: Record<TransactionStep, MessageId> = {
+  Intent: 'step.gloss.Intent',
+  Validation: 'step.gloss.Validation',
+  Consent: 'step.gloss.Consent',
+  Plan: 'step.gloss.Plan',
+  Commit: 'step.gloss.Commit',
+  Receipt: 'step.gloss.Receipt',
+};
+
+/** Transaction stage label in the active presentation language. */
+export function transactionStepLabel(step: TransactionStep): string {
+  return uiText(STEP_GLOSS[step]);
+}
+
+const VERDICT_GLOSS = {
+  Passed: 'verdict.gloss.Passed',
+  'Passed with diagnostics': 'verdict.gloss.Passed with diagnostics',
+  Blocked: 'verdict.gloss.Blocked',
+} as const;
+
+export type ValidationVerdict = keyof typeof VERDICT_GLOSS;
+
+/** Validation verdict closed value presented canonical-first with its zh_TW gloss. */
+export function verdictText(verdict: ValidationVerdict): string {
+  return closedValue(verdict, uiText(VERDICT_GLOSS[verdict]));
+}
+
+/**
+ * zh_TW operational copy for a domain finding, selected by its stable rule code at the
+ * presentation boundary. Rule codes, classifications, and finding order are unchanged;
+ * unknown rules fall back to the canonical outcome text rather than inventing copy.
+ */
+export function findingOutcomeText(finding: Pick<ValidationFinding, 'rule' | 'outcome'>): string {
+  const id = `finding.${finding.rule}` as MessageId;
+  return Object.prototype.hasOwnProperty.call(dictionaries[activeLocale], id)
+    ? uiText(id)
+    : finding.outcome;
+}

--- a/tests/e2e/bridge-ledger-command.test.ts
+++ b/tests/e2e/bridge-ledger-command.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import registerBridgeExtension from '../../extensions/pi/index.js';
+import { uiText } from '../../extensions/pi/ui-strings.js';
 import { commitBridgeState } from '../../src/bridge-state/store.js';
 import { appendReceipt } from '../../src/journal/journal.js';
 import { createReceipt } from '../../src/registration/receipt.js';
@@ -96,7 +97,7 @@ describe('/codex-marketplace Bridge Ledger command seam', () => {
       expect(screen).toMatch(/GLOBAL|\bG\b/);
       expect(screen).toMatch(/PROJECT|\bP\b/);
       expect(screen).toMatch(/rev(?:ision)?\s+"?0"?/i);
-      expect(screen).toMatch(/Project Trust.*(?:granted|trusted)/i);
+      expect(screen).toContain(uiText('ledger.rail.trust.granted'));
       expect(screen).toMatch(/Esc.*q|q.*Esc/i);
     }
   });
@@ -158,9 +159,9 @@ describe('/codex-marketplace Bridge Ledger command seam', () => {
     });
 
     expect(customCalls).toBe(2);
-    expect(screens[0]!.join('\n')).toMatch(/G rev "0"/);
-    expect(screens[1]!.join('\n')).toMatch(/G rev "1"/);
-    expect(screens[1]!.join('\n')).toMatch(/reg(?:istrations)? 1/);
+    expect(screens[0]!.join('\n')).toContain(uiText('ledger.rail.revision', { marker: 'G', revision: '"0"' }));
+    expect(screens[1]!.join('\n')).toContain(uiText('ledger.rail.revision', { marker: 'G', revision: '"1"' }));
+    expect(screens[1]!.join('\n')).toContain(uiText('ledger.rail.registrations', { count: 1 }));
   });
 
   it('keeps the Global Pending Barrier visible while disabling Project mutations', async () => {
@@ -214,12 +215,12 @@ describe('/codex-marketplace Bridge Ledger command seam', () => {
       },
     });
 
-    expect(screen).toMatch(/BARRIER ACTIVE/);
+    expect(screen).toContain(uiText('ledger.badge.barrierActive'));
     // Blocked Project mutation: availability is icon+word, and its reason is visible on selection.
-    expect(screen).toMatch(/○ Blocked Register local Marketplace/);
+    expect(screen).toContain(`○ ${uiText('ledger.availability.blocked')} ${uiText('ledger.action.register-local')}`);
     expect(screen).toMatch(/Global Pending Barrier/);
     expect(screen).not.toMatch(/\[available\]|\[Unavailable\]|disabled:/);
-    expect(screen).toMatch(/● Ready Register local Marketplace/);
+    expect(screen).toContain(`● ${uiText('ledger.availability.ready')} ${uiText('ledger.action.register-local')}`);
   });
 
   it.each([

--- a/tests/unit/extensions/bridge-ledger.test.ts
+++ b/tests/unit/extensions/bridge-ledger.test.ts
@@ -13,6 +13,7 @@ import {
   type BridgeLedgerSnapshot,
   type LedgerActionId,
 } from '../../../extensions/pi/bridge-ledger.js';
+import { attemptSummaryText, findingOutcomeText, uiText } from '../../../extensions/pi/ui-strings.js';
 
 const identityTheme = {
   fg: (_token: string, text: string) => text,
@@ -219,11 +220,11 @@ describe('Bridge Ledger presentation model', () => {
     ]));
 
     const recovery = model.sections.find((section) => section.id === 'recovery-receipts')!;
-    expect(recovery.rows.find((row) => row.id === 'journal:global')?.detail).toContain(
-      '1 receipt',
+    expect(recovery.rows.find((row) => row.id === 'journal:global')?.detail).toBe(
+      uiText('ledger.row.journal.detail', { receipts: 1, chains: 0, degraded: uiText('common.no') }),
     );
-    expect(recovery.rows.find((row) => row.id === 'journal:project')?.detail).toContain(
-      '0 active recovery chains',
+    expect(recovery.rows.find((row) => row.id === 'journal:project')?.detail).toBe(
+      uiText('ledger.row.journal.detail', { receipts: 0, chains: 0, degraded: uiText('common.no') }),
     );
   });
 
@@ -383,7 +384,7 @@ describe('Bridge Ledger presentation model', () => {
       expect(unavailable.marketplaceEntries.global[0]?.findings).toEqual([finding]);
       expect(diagnostic).toMatchObject({
         label: 'global-market',
-        detail: `Unavailable · ${code} · ${rule} · ${outcome}`,
+        detail: `Unavailable（無法使用）· ${code} · ${rule} · ${findingOutcomeText({ rule, outcome })}`,
         scope: 'global',
         targetKind: 'registration',
         targetId: registration.id,
@@ -440,23 +441,17 @@ describe('Bridge Ledger presentation model', () => {
     rendered.instance.handleInput('\x1b[C'); // Plugins
 
     const globalScreen = rendered.instance.render(240).join('\n');
-    expect(globalScreen).toContain(
-      'SOURCE_DRIFT · DRIFT-01 · Source Drift requires Marketplace Refresh',
-    );
-    expect(globalScreen).not.toContain(
-      'CATALOG_MALFORMED · CAT-02 · marketplace.json is not an object',
-    );
+    const driftOutcome = findingOutcomeText({ rule: 'DRIFT-01', outcome: 'Source Drift requires Marketplace Refresh' });
+    const catalogOutcome = findingOutcomeText({ rule: 'CAT-02', outcome: 'marketplace.json is not an object' });
+    expect(globalScreen).toContain(`SOURCE_DRIFT · DRIFT-01 · ${driftOutcome}`);
+    expect(globalScreen).not.toContain(`CATALOG_MALFORMED · CAT-02 · ${catalogOutcome}`);
     rendered.instance.handleInput('\r');
     expect(rendered.results).toEqual([]);
 
     rendered.instance.handleInput('p');
     const projectScreen = rendered.instance.render(240).join('\n');
-    expect(projectScreen).toContain(
-      'CATALOG_MALFORMED · CAT-02 · marketplace.json is not an object',
-    );
-    expect(projectScreen).not.toContain(
-      'SOURCE_DRIFT · DRIFT-01 · Source Drift requires Marketplace Refresh',
-    );
+    expect(projectScreen).toContain(`CATALOG_MALFORMED · CAT-02 · ${catalogOutcome}`);
+    expect(projectScreen).not.toContain(`SOURCE_DRIFT · DRIFT-01 · ${driftOutcome}`);
     rendered.instance.handleInput('\r');
     expect(rendered.results).toEqual([]);
   });
@@ -479,7 +474,7 @@ describe('Bridge Ledger presentation model', () => {
 
     const movedRow = findMarketplaceRow(moved, movedEntry.marketplaceEntryId);
     expect(movedRow?.actions.every((entry) => !entry.enabled)).toBe(true);
-    expect(movedRow?.actions[0]?.disabledReason).toContain('scope-local Installation');
+    expect(movedRow?.actions[0]?.disabledReason).toContain('Installation');
 
     const replacement = snapshot();
     const replacementEntry = replacement.marketplaceEntries.global[0]!;
@@ -596,7 +591,7 @@ describe('Bridge Ledger presentation model', () => {
 
     expect(retry?.actions[0]).toMatchObject({
       enabled: false,
-      disabledReason: expect.stringContaining('no bound Validation Snapshot'),
+      disabledReason: expect.stringContaining(uiText('ledger.disabledReason.retryNoSnapshot')),
     });
   });
 
@@ -608,14 +603,14 @@ describe('Bridge Ledger presentation model', () => {
     expect(lines.length).toBeGreaterThan(8);
     expect(screen).toContain('CODEX MARKETPLACE / BRIDGE LEDGER');
     expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
-    expect(screen).toContain('G rev "12"');
-    expect(screen).toContain('P rev "7"');
-    expect(screen.match(/HEALTHY/g)).toHaveLength(2);
-    expect(screen).toContain('Project Trust: granted');
-    expect(screen).toContain('BARRIER CLEAR');
-    expect(screen).toContain('Status:');
+    expect(screen).toContain(uiText('ledger.rail.revision', { marker: 'G', revision: '"12"' }));
+    expect(screen).toContain(uiText('ledger.rail.revision', { marker: 'P', revision: '"7"' }));
+    expect(screen.match(new RegExp(uiText('ledger.badge.healthy'), 'g'))).toHaveLength(2);
+    expect(screen).toContain(uiText('ledger.rail.trust.granted'));
+    expect(screen).toContain(uiText('ledger.badge.barrierClear'));
+    expect(screen).toContain('狀態：');
     expect(screen).toContain('Esc/q');
-    expect(screen).toContain(width >= 96 ? 'Navigation' : 'Sections');
+    expect(screen).toContain(width >= 96 ? uiText('ledger.panel.navigation') : uiText('ledger.panel.sections'));
   });
 
   it.each([120, 80, 60])('presents both authority rails as bordered panels at every width %i', (width) => {
@@ -656,7 +651,7 @@ describe('Bridge Ledger presentation model', () => {
     instance.handleInput('\x1b[C'); // Sources
     const idle = instance.render(120);
     const baselineWashes = backgrounds.filter((token) => token === 'selectedBg').length;
-    expect(idle.some((line) => line.includes('● Ready Register local Marketplace'))).toBe(true);
+    expect(idle.some((line) => line.includes(`● ${uiText('ledger.availability.ready')} ${uiText('ledger.action.register-local')}`))).toBe(true);
 
     instance.handleInput('j'); // move onto the registration row's actions
     instance.render(120);
@@ -667,6 +662,31 @@ describe('Bridge Ledger presentation model', () => {
     expect(screen).not.toContain('[Unavailable]');
   });
 
+  it.each([120, 80, 60])('keeps CJK double-width content within %i columns without overflow or frame damage', (width) => {
+    const cjk = snapshot();
+    cjk.global.state!.registrations[0]!.alias = '全球市集（相當長的雙寬字元名稱測試）';
+    cjk.project.state!.registrations[0]!.alias = '專案市集——CJK 寬度安全檢查';
+    cjk.barrier = { active: true, reason: '需要先進行全域復原：一段很長的中文診斷訊息，用來壓迫寬度計算' };
+    const { instance } = component(buildBridgeLedgerModel(cjk));
+    instance.render(width);
+    if (width >= 96) {
+      instance.handleInput('\x1b[C'); // 寬版：右切到「來源」
+    } else {
+      instance.handleInput('j'); // 窄版：選到「來源」分區
+      instance.handleInput('\r'); // 進入分區詳情
+    }
+    const lines = instance.render(width);
+    const screen = lines.join('\n');
+
+    // No line exceeds the terminal width even with double-width characters.
+    expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
+    // Panel frames stay intact: every framed content row still closes with a right border.
+    for (const line of lines.filter((candidate) => candidate.includes('│'))) {
+      expect(line.trimEnd().endsWith('│')).toBe(true);
+    }
+    expect(screen).toContain('全球市集');
+  });
+
   it('changes g/p browsing focus while keeping the visible action authority explicit', () => {
     const { instance, requests, results } = component();
     instance.render(120);
@@ -674,9 +694,9 @@ describe('Bridge Ledger presentation model', () => {
     instance.handleInput('\x1b[C'); // Sources
     instance.handleInput('p');
     const projectScreen = instance.render(120).join('\n');
-    expect(projectScreen).toContain('Status: browsing P');
-    expect(projectScreen).toContain('Project registration actions');
-    expect(projectScreen).not.toContain('Global registration actions');
+    expect(projectScreen).toContain('瀏覽 P');
+    expect(projectScreen).toContain(uiText('ledger.row.registrationActions', { scopeWord: 'Project' }));
+    expect(projectScreen).not.toContain(uiText('ledger.row.registrationActions', { scopeWord: 'Global' }));
     instance.handleInput('\r');
 
     expect(results).toEqual([{
@@ -742,7 +762,7 @@ describe('Bridge Ledger presentation model', () => {
     expect(findAction(clear, 'register-local', 'project').enabled).toBe(true);
     expect(findAction(clear, 'repair-state', 'project')).toMatchObject({
       enabled: false,
-      disabledReason: expect.stringContaining('no eligible Persistence Indeterminate'),
+      disabledReason: expect.stringContaining(uiText('ledger.disabledReason.repairNothing')),
     });
 
     const barrierSnapshot = snapshot();
@@ -757,7 +777,7 @@ describe('Bridge Ledger presentation model', () => {
     expect(findAction(barrier, 'view-receipt-journal', 'project').enabled).toBe(true);
     expect(findAction(barrier, 'repair-state', 'global')).toMatchObject({
       enabled: false,
-      disabledReason: expect.stringContaining('no eligible Persistence Indeterminate'),
+      disabledReason: expect.stringContaining(uiText('ledger.disabledReason.repairNothing')),
     });
 
     const untrustedSnapshot = snapshot();
@@ -923,27 +943,27 @@ describe('Bridge Ledger presentation model', () => {
     const wide = component();
     wide.instance.render(120);
     wide.instance.handleInput('\x1b[57418u'); // Kitty right
-    expect(wide.instance.render(120).join('\n')).toContain('> Sources');
+    expect(wide.instance.render(120).join('\n')).toContain(`> ${uiText('ledger.section.sources.label')}`);
     wide.instance.handleInput('j');
     wide.instance.handleInput('\x1b[57420u'); // Kitty down
     wide.instance.handleInput('\x1b[57419u'); // Kitty up
     wide.instance.handleInput('k');
     wide.instance.handleInput('?');
-    expect(wide.instance.render(120).join('\n')).toContain('Help');
+    expect(wide.instance.render(120).join('\n')).toContain(uiText('ledger.panel.help'));
     wide.instance.handleInput('\x1b[27u'); // Kitty Escape closes help
     expect(wide.results).toEqual([]);
 
     // The structured dump is hidden until expanded, then fully retrievable.
     const collapsed = wide.instance.render(120).join('\n');
-    expect(collapsed).not.toContain('| mode ');
-    expect(collapsed).not.toContain('detail ');
+    expect(collapsed).not.toContain('模式 ');
+    expect(collapsed).not.toContain('詳情 ');
     wide.instance.handleInput('i');
     const expanded = wide.instance.render(120).join('\n');
-    expect(expanded).toContain('mode mutation');
-    expect(expanded).toContain('scope global');
-    expect(expanded).toContain('target scope "global"');
+    expect(expanded).toContain('模式 mutation');
+    expect(expanded).toContain('Scope global');
+    expect(expanded).toContain('目標 scope "global"');
     wide.instance.handleInput('i');
-    expect(wide.instance.render(120).join('\n')).not.toContain('mode mutation');
+    expect(wide.instance.render(120).join('\n')).not.toContain('模式 mutation');
 
     wide.instance.handleInput('\x1b[13u'); // Kitty Enter activates first Global action
     expect(wide.results[0]).toMatchObject({ actionId: 'register-local', scope: 'global' });
@@ -960,15 +980,15 @@ describe('Bridge Ledger presentation model', () => {
   it.each([80, 60])('drills down through single-column sections at %i columns', (width) => {
     const narrow = component();
     narrow.instance.render(width);
-    expect(narrow.instance.render(width).join('\n')).toContain('Sections');
+    expect(narrow.instance.render(width).join('\n')).toContain(uiText('ledger.panel.sections'));
 
     narrow.instance.handleInput('\r');
     const detail = narrow.instance.render(width).join('\n');
-    expect(detail).toContain('Observe');
-    expect(detail).toContain('● Ready Inspect authority partitions');
+    expect(detail).toContain(uiText('ledger.section.observe.label'));
+    expect(detail).toContain(`● ${uiText('ledger.availability.ready')} ${uiText('ledger.action.observe-partitions')}`);
 
     narrow.instance.handleInput('\x1b');
-    expect(narrow.instance.render(width).join('\n')).toContain('Sections');
+    expect(narrow.instance.render(width).join('\n')).toContain(uiText('ledger.panel.sections'));
 
     narrow.instance.handleInput('q');
     expect(narrow.results).toEqual([undefined]);
@@ -987,7 +1007,7 @@ describe('Bridge Ledger presentation model', () => {
     blocked.instance.handleInput('p'); // Project register-local
     const screen = blocked.instance.render(120).join('\n');
 
-    expect(screen).toContain('○ Blocked Register local Marketplace');
+    expect(screen).toContain(`○ ${uiText('ledger.availability.blocked')} ${uiText('ledger.action.register-local')}`);
     expect(screen).toContain('Global Pending Barrier');
     expect(screen).not.toContain('[available]');
     expect(screen).not.toContain('[Unavailable]');

--- a/tests/unit/extensions/ledger-flow-adapters.test.ts
+++ b/tests/unit/extensions/ledger-flow-adapters.test.ts
@@ -20,8 +20,13 @@ import {
   runRepairStateFlow,
   runRetryApplicationFlow,
 } from '../../../extensions/pi/journal.js';
+import {
+  TRANSACTION_STEPS,
+  type TransactionStep,
+} from '../../../extensions/pi/transaction-sheet.js';
 import { runRefreshFlow, runRemovalFlow, runUpdatePlanChecklist } from '../../../extensions/pi/lifecycle.js';
 import { runScopeOverrideFlow } from '../../../extensions/pi/scope-overrides.js';
+import { transactionStepLabel, uiText, verdictText } from '../../../extensions/pi/ui-strings.js';
 
 const FIRST_REGISTRATION_ID = '11111111-1111-4111-8111-111111111111';
 const SECOND_REGISTRATION_ID = '22222222-2222-4222-8222-222222222222';
@@ -66,8 +71,9 @@ function makeUiHarness(options: UiHarnessOptions = {}) {
       const component = factory({ requestRender: () => {} }, identityTheme, {}, resolveSheet);
       const rendered = component.render(options.width ?? 120).join('\n');
       renders.push(rendered);
-      const active = ['Intent', 'Validation', 'Consent', 'Plan', 'Commit', 'Receipt']
-        .find((step) => rendered.includes(`${step} ACTIVE`));
+      // Canonical step ids are detected through their localized presentation markers.
+      const active = TRANSACTION_STEPS.find((step: TransactionStep, index: number) =>
+        rendered.includes(`▸ ${index + 1} ${transactionStepLabel(step)}（${uiText('step.activeSuffix')}）`));
       if (active) {
         sheets.push(active);
         await options.onStep?.(active);
@@ -429,7 +435,7 @@ describe('Bridge Ledger lifecycle flow adapters', () => {
       await flow;
 
       const receiptSheet = harness.renders.at(-1) ?? '';
-      expect(harness.notifications.at(-1)).toContain('Attempt Summary: Persistence Failed');
+      expect(harness.notifications.at(-1)).toContain('Attempt Summary：Persistence Failed（持久化失敗）');
       expect(receiptSheet).toMatch(/Attempt Summary:\s*"Persistence Failed"/s);
       expect(receiptSheet).toMatch(/RECEIPT_PERSISTENCE_FAILED.*JOURNAL-01/s);
       expect(receiptSheet).toContain('Scope Override Creation');
@@ -577,8 +583,8 @@ describe('Bridge Ledger lifecycle flow adapters', () => {
     await runRepairStateFlow(ctx as never, { scope: 'global' });
 
     expect(harness.sheets).toEqual(['Intent', 'Validation', 'Consent', 'Receipt']);
-    expect(harness.renders.find((rendered) => rendered.includes('Validation ACTIVE'))).toMatch(
-      /Verdict Passed.*Findings 0 blocking/s,
+    expect(harness.renders.find((rendered) => rendered.includes(`▸ 2 ${transactionStepLabel('Validation')}（${uiText('step.activeSuffix')}）`))).toMatch(
+      new RegExp(`${uiText('verdict.label')}：${verdictText('Passed')}.*${uiText('findings.count.label')}：${uiText('findings.count.line', { blocking: 0, warning: 0, notice: 0 })}`, 's'),
     );
     expect((await readReceiptJournal('global', { cwd, agentDir })).receipts.at(-1)).toEqual(
       expect.objectContaining({ kind: 'State Repair', operation: 'Repair State', summary: 'Declined' }),
@@ -605,7 +611,7 @@ describe('Bridge Ledger lifecycle flow adapters', () => {
       await flow;
 
       const receiptSheet = harness.renders.at(-1) ?? '';
-      expect(harness.notifications.at(-1)).toContain('Attempt Summary: Persistence Failed');
+      expect(harness.notifications.at(-1)).toContain('Attempt Summary：Persistence Failed（持久化失敗）');
       expect(receiptSheet).toMatch(/Attempt Summary:\s*"Persistence Failed"/s);
       expect(receiptSheet).toMatch(/RECEIPT_PERSISTENCE_FAILED.*JOURNAL-01/s);
       expect(receiptSheet).toContain('Repair State');
@@ -641,7 +647,7 @@ describe('Bridge Ledger lifecycle flow adapters', () => {
       await flow;
 
       const receiptSheet = harness.renders.at(-1) ?? '';
-      expect(harness.notifications.at(-1)).toContain('Attempt Summary: Persistence Failed');
+      expect(harness.notifications.at(-1)).toContain('Attempt Summary：Persistence Failed（持久化失敗）');
       expect(receiptSheet).toMatch(/Attempt Summary:\s*"Persistence Failed"/s);
       expect(receiptSheet).toMatch(/REJECTED_AS_STALE.*STALE-01/s);
       expect(receiptSheet).toMatch(/RECEIPT_PERSISTENCE_FAILED.*JOURNAL-01/s);
@@ -1153,9 +1159,10 @@ describe('Bridge Ledger lifecycle flow adapters', () => {
     });
 
     const disclosure = harness.renders.join('\n');
-    expect(disclosure).toContain('Verdict Blocked');
-    expect(disclosure).toContain('Findings 1 blocking');
-    expect(disclosure).toMatch(/classification blocking.*scope global.*phase post-commit.*target plugin.*pointer.*plugins\/0.*code.*WHOLE_PLUGIN_BLOCKED.*rule.*RUNTIME-01.*host cannot apply this plugin/s);
+    expect(disclosure).toContain(`${uiText('verdict.label')}：${verdictText('Blocked')}`);
+    expect(disclosure).toContain(uiText('findings.count.line', { blocking: 1, warning: 0, notice: 0 }));
+    // Detail lines pass through quoteTerminalText, so embedded quotes surface as \".
+    expect(disclosure).toMatch(/分類 blocking.*Scope global.*階段 post-commit.*目標 plugin.*指標.*plugins\/0.*代碼.*WHOLE_PLUGIN_BLOCKED.*規則.*RUNTIME-01.*結果 \\\"host cannot apply this plugin\\\"/s);
     expect(reloads).toBe(0);
     expect((await readReceiptJournal('global', { cwd, agentDir })).activeChains).toHaveLength(1);
   });
@@ -1179,7 +1186,7 @@ describe('Bridge Ledger lifecycle flow adapters', () => {
     expect(harness.sheets).toEqual(['Intent', 'Validation', 'Receipt']);
     expect(harness.renders.join('\n')).toContain('Marketplace Refresh');
     expect(harness.renders.join('\n')).toContain('Blocked');
-    expect(harness.renders.join('\n')).toContain('Verdict Blocked');
+    expect(harness.renders.join('\n')).toContain(`${uiText('verdict.label')}：${verdictText('Blocked')}`);
     const state = await readBridgeState('global', { cwd, agentDir });
     expect(state.status).toBe('missing');
     expect(state.state?.stateRevision).toBe('0');

--- a/tests/unit/extensions/lifecycle-tui.test.ts
+++ b/tests/unit/extensions/lifecycle-tui.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest';
 import type { Scope } from '../../../src/bridge-state/types.js';
 import type { UpdateCandidate } from '../../../src/lifecycle/refresh.js';
 import { candidateSummary, planChoicesFor } from '../../../extensions/pi/lifecycle.js';
+import { findingOutcomeText, uiText, verdictText } from '../../../extensions/pi/ui-strings.js';
+import { quoteTerminalText } from '../../../extensions/pi/terminal-presentation.js';
 import type { CompatiblePlugin } from '../../../src/compatibility/profile.js';
 
 const SCOPE: Scope = 'global';
@@ -73,12 +75,12 @@ describe('Update Plan Checklist TUI helpers', () => {
     candidate.resolvedRevision = 'c'.repeat(40);
     candidate.recordedResolvedRevision = 'd'.repeat(40);
     const summary = candidateSummary(candidate);
-    expect(summary).toContain('Scope: global');
+    expect(summary).toContain(uiText('life.candidate.scope', { scope: SCOPE }));
     expect(summary).toContain('b'.repeat(16));
     expect(summary).toContain('aaaa');
     expect(summary).toContain('cccc');
     expect(summary).toContain('/plugins/0');
-    expect(summary).toContain('unavailable ("invalid manifest")');
+    expect(summary).toContain(`（"invalid manifest"）`);
     // Marketplace-controlled text is quoted so values cannot forge disclosure lines.
     expect(summary).toContain('"kept"');
   });
@@ -109,14 +111,30 @@ describe('Update Plan Checklist TUI helpers', () => {
     ];
 
     const summary = candidateSummary(candidate);
-    expect(summary).toContain(
-      'Finding classification blocking | scope global | phase validation | target catalog | ' +
-        'pointer "/a" | code "BLOCKING_CODE" | rule "BLOCK-01" | outcome "blocking outcome"',
-    );
-    expect(summary).toContain(
-      'Finding classification notice | scope global | phase post-commit | target entry | ' +
-        'pointer "/z" | code "NOTICE_CODE" | rule "NOTICE-01" | outcome "notice outcome"',
-    );
+    const expectedBlocking = uiText('finding.line', {
+      classification: 'blocking',
+      scope: 'global',
+      phase: 'validation',
+      target: 'catalog',
+      pointer: '"/a"',
+      code: '"BLOCKING_CODE"',
+      rule: '"BLOCK-01"',
+      outcome: quoteTerminalText(findingOutcomeText({ rule: 'BLOCK-01', outcome: 'blocking outcome' })),
+    });
+    const expectedNotice = uiText('finding.line', {
+      classification: 'notice',
+      scope: 'global',
+      phase: 'post-commit',
+      target: 'entry',
+      pointer: '"/z"',
+      code: '"NOTICE_CODE"',
+      rule: '"NOTICE-01"',
+      outcome: quoteTerminalText(findingOutcomeText({ rule: 'NOTICE-01', outcome: 'notice outcome' })),
+    });
+    expect(summary).toContain(expectedBlocking);
+    expect(summary).toContain(expectedNotice);
+    // Canonical order is unchanged by presentation language; the verdict headline leads.
+    expect(summary.indexOf(verdictText('Blocked'))).toBeGreaterThan(-1);
     expect(summary.indexOf('BLOCKING_CODE')).toBeLessThan(summary.indexOf('NOTICE_CODE'));
   });
 });

--- a/tests/unit/extensions/transaction-flows.test.ts
+++ b/tests/unit/extensions/transaction-flows.test.ts
@@ -9,6 +9,9 @@ import { declinePluginDisable, preflightPluginDisable } from '../../../src/insta
 import { inspectMarketplaceEntries } from '../../../src/installation/inspection.js';
 import { appendReceipt, readReceiptJournal } from '../../../src/journal/journal.js';
 import { dispatchLedgerAction, formatStartupReceipt } from '../../../extensions/pi/index.js';
+import { TRANSACTION_STEPS } from '../../../extensions/pi/transaction-sheet.js';
+import { transactionStepLabel, uiText, verdictText, findingOutcomeText } from '../../../extensions/pi/ui-strings.js';
+import { quoteTerminalText } from '../../../extensions/pi/terminal-presentation.js';
 import {
   fullValidationDisclosureLines,
   reportOutcome,
@@ -31,7 +34,8 @@ function sheetCustom(
   return async (factory: any): Promise<unknown> => new Promise((resolve) => {
     const component = factory({}, theme, {}, resolve);
     const rendered = component.render(120).join('\n');
-    const active = rendered.match(/\b(Intent|Validation|Consent|Plan|Commit|Receipt) ACTIVE\b/)?.[1];
+    const active = TRANSACTION_STEPS.find((step, index) =>
+      rendered.includes(`▸ ${index + 1} ${transactionStepLabel(step)}（${uiText('step.activeSuffix')}）`));
     if (active) events.push(active);
     component.handleInput?.(active && decide(active) === 'cancel' ? '\u001b' : '\r');
   });
@@ -45,7 +49,8 @@ function terminalPreflightSheetCustom(
   return async (factory: any): Promise<unknown> => new Promise((resolve) => {
     const component = factory({ requestRender: () => {} }, theme, {}, resolve);
     let rendered = component.render(120).join('\n');
-    const active = rendered.match(/\b(Intent|Validation|Consent|Plan|Commit|Receipt) ACTIVE\b/)?.[1];
+    const active = TRANSACTION_STEPS.find((step, index) =>
+      rendered.includes(`▸ ${index + 1} ${transactionStepLabel(step)}（${uiText('step.activeSuffix')}）`));
     if (active) {
       events.push(active);
       if (active === 'Validation') {
@@ -110,10 +115,19 @@ describe('Bridge Ledger transaction flow adapters', () => {
       rule: 'RULE-01',
       outcome: 'blocked by policy',
     }])).toEqual([
-      'Verdict Blocked',
-      'Findings 1 blocking · 0 warning · 0 notice',
-      'Finding classification blocking | scope project | phase validation | target skill | ' +
-        'pointer "/skills/build" | code "RULE_CODE" | rule "RULE-01" | outcome "blocked by policy"',
+      `${uiText('verdict.label')}：${verdictText('Blocked')}`,
+      `${uiText('findings.count.label')}：${uiText('findings.count.line', { blocking: 1, warning: 0, notice: 0 })}`,
+      // Unknown rule codes (RULE-01 is test-local) fall back to the canonical outcome text.
+      uiText('finding.line', {
+        classification: 'blocking',
+        scope: 'project',
+        phase: 'validation',
+        target: 'skill',
+        pointer: '"/skills/build"',
+        code: '"RULE_CODE"',
+        rule: '"RULE-01"',
+        outcome: quoteTerminalText(findingOutcomeText({ rule: 'RULE-01', outcome: 'blocked by policy' })),
+      }),
     ]);
   });
 
@@ -284,8 +298,8 @@ describe('Bridge Ledger transaction flow adapters', () => {
       ui: {
         select: async (prompt: string, options: string[]) => {
           selectPrompts.push(prompt);
-          if (prompt.startsWith('Marketplace Entries')) return options[0];
-          if (prompt === 'Installation path') return 'Install Disabled';
+          if (prompt.startsWith(uiText('inst.select.entry'))) return options[0];
+          if (prompt === uiText('inst.select.path')) return uiText('inst.path.disabled');
           return undefined;
         },
         input: async () => undefined,
@@ -301,8 +315,8 @@ describe('Bridge Ledger transaction flow adapters', () => {
     await runPluginInstallationFlow(ctx as never, { scope: 'global', registrationId: secondId });
 
     expect(selectPrompts).toEqual([
-      'Marketplace Entries（顯示 Marketplace Entry ID 與可安裝/Unavailable 原因）',
-      'Installation path',
+      uiText('inst.select.entry'),
+      uiText('inst.select.path'),
     ]);
     expect(confirms).toEqual([]);
     const state = await readBridgeState('global', { cwd, agentDir });
@@ -341,7 +355,8 @@ describe('Bridge Ledger transaction flow adapters', () => {
         custom: async (factory: any): Promise<unknown> => new Promise((resolve) => {
           const component = factory({ requestRender: () => {} }, theme, {}, resolve);
           const rendered = component.render(120).join('\n');
-          const active = rendered.match(/\b(Intent|Validation|Consent|Plan|Commit|Receipt) ACTIVE\b/)?.[1];
+          const active = TRANSACTION_STEPS.find((step, index) =>
+      rendered.includes(`▸ ${index + 1} ${transactionStepLabel(step)}（${uiText('step.activeSuffix')}）`));
           if (active) events.push(active);
           void (async () => {
             if (active === 'Intent' && !revisionAdvanced) {
@@ -482,7 +497,7 @@ describe('Bridge Ledger transaction flow adapters', () => {
 
     expect(events).toEqual(['Intent', 'Validation', 'Receipt']);
     expect(renderedByStep.get('Intent')).toMatch(
-      new RegExp(`Target:.*${registrationId}/acme-marketplace/plugins/0.*State Revision:.*${selected.newRevision}`, 's'),
+      new RegExp(`目標:.*${registrationId}/acme-marketplace/plugins/0.*State Revision:.*${selected.newRevision}`, 's'),
     );
     expect(renderedByStep.get('Validation')).toMatch(/Verdict.*Blocked.*REJECTED_AS_STALE/s);
     expect((await readReceiptJournal('global', { cwd, agentDir })).receipts.at(-1)).toEqual(
@@ -686,7 +701,7 @@ describe('Bridge Ledger transaction flow adapters', () => {
 
     expect(events).toEqual(['Intent', 'Validation', 'Receipt']);
     expect(renderedByStep.get('Validation')).toMatch(
-      /Verdict.*Blocked.*INSTALLATION_NOT_FOUND.*INSTALL-01.*unsupported\s+source kind/s,
+      new RegExp(`Verdict.*Blocked.*INSTALLATION_NOT_FOUND.*INSTALL-01.*${findingOutcomeText({ rule: 'INSTALL-01', outcome: 'unsupported source kind' })}`, 's'),
     );
     expect((await readReceiptJournal('global', { cwd, agentDir })).receipts.at(-1)).toEqual(
       expect.objectContaining({
@@ -707,7 +722,7 @@ describe('Bridge Ledger transaction flow adapters', () => {
       ui: {
         select: async (prompt: string) => {
           selectPrompts.push(prompt);
-          if (prompt.startsWith('Git Selector')) return 'default (跟隨遠端預設分支 HEAD)';
+          if (prompt.startsWith(uiText('reg.git.selector.prompt').split(' — ')[0]!)) return uiText('reg.git.selector.default');
           return undefined;
         },
         input: async () => 'not-a-git-locator',
@@ -734,7 +749,7 @@ describe('Bridge Ledger transaction flow adapters', () => {
       isProjectTrusted: () => true,
       ui: {
         select: async (prompt: string) => {
-          if (prompt.startsWith('Git Selector')) return 'default (跟隨遠端預設分支 HEAD)';
+          if (prompt.startsWith(uiText('reg.git.selector.prompt').split(' — ')[0]!)) return uiText('reg.git.selector.default');
           throw new Error('explicit scope must not open another selector');
         },
         input: async () => 'not-a-git-locator',
@@ -874,7 +889,7 @@ describe('Bridge Ledger transaction flow adapters', () => {
 
     expect(events).toEqual(['Intent', 'Validation', 'Receipt']);
     expect(renderedByStep.get('Intent')).toMatch(
-      /Action:.*Plugin Enablement.*Target:.*global\/acme-market\/missing-plugin.*State Revision:.*0/s,
+      /動作:.*Plugin Enablement.*目標:.*global\/acme-market\/missing-plugin.*State Revision:.*0/s,
     );
     expect(renderedByStep.get('Validation')).toMatch(/INSTALLATION_NOT_FOUND.*INSTALL-01/s);
     expect((await readReceiptJournal('global', { cwd, agentDir })).receipts).toEqual([
@@ -915,7 +930,7 @@ describe('Bridge Ledger transaction flow adapters', () => {
 
     expect(events).toEqual(['Intent', 'Validation', 'Receipt']);
     expect(renderedByStep.get('Intent')).toMatch(
-      /Action:.*Plugin Disablement.*Target:.*global\/acme-market\/missing-plugin.*State Revision:.*0/s,
+      /動作:.*Plugin Disablement.*目標:.*global\/acme-market\/missing-plugin.*State Revision:.*0/s,
     );
     expect(renderedByStep.get('Validation')).toMatch(/INSTALLATION_NOT_FOUND.*INSTALL-01/s);
     expect((await readReceiptJournal('global', { cwd, agentDir })).receipts).toEqual([
@@ -1073,7 +1088,7 @@ describe('Bridge Ledger transaction flow adapters', () => {
 
     expect(events).toEqual(['Intent', 'Validation', 'Consent', 'Plan', 'Commit', 'Receipt']);
     expect(renderedByStep.get('Intent')).toMatch(
-      new RegExp(`Target:.*${registrationId}.*State Revision:.*${selected.newRevision}`, 's'),
+      new RegExp(`目標:.*${registrationId}.*State Revision:.*${selected.newRevision}`, 's'),
     );
     expect((await readBridgeState('project', { cwd, agentDir })).state?.scopeOverrides).toEqual([]);
     expect((await readReceiptJournal('project', { cwd, agentDir })).receipts.at(-1)).toEqual(
@@ -1116,7 +1131,7 @@ describe('Bridge Ledger transaction flow adapters', () => {
 
     expect(events).toEqual(['Intent', 'Validation', 'Consent', 'Plan', 'Commit', 'Receipt']);
     expect(renderedByStep.get('Intent')).toMatch(
-      new RegExp(`Target:.*project Bridge State.*State Revision:.*${selected.newRevision}`, 's'),
+      new RegExp(`目標:.*project Bridge State.*State Revision:.*${selected.newRevision}`, 's'),
     );
     expect((await readBridgeState('project', { cwd, agentDir })).state?.stateRevision).toBe('2');
     expect((await readReceiptJournal('project', { cwd, agentDir })).receipts.at(-1)).toEqual(
@@ -1204,7 +1219,8 @@ describe('Bridge Ledger transaction flow adapters', () => {
           const result = new Promise<unknown>((resolve) => { finish = resolve; });
           const component = factory({}, theme, {}, finish);
           const rendered = component.render(120).join('\n');
-          const active = rendered.match(/\b(Intent|Validation|Consent|Plan|Commit|Receipt) ACTIVE\b/)?.[1];
+          const active = TRANSACTION_STEPS.find((step, index) =>
+      rendered.includes(`▸ ${index + 1} ${transactionStepLabel(step)}（${uiText('step.activeSuffix')}）`));
           if (active) events.push(active);
           if (active === 'Commit' && !drifted) {
             drifted = true;
@@ -1319,8 +1335,8 @@ describe('Bridge Ledger transaction flow adapters', () => {
       isProjectTrusted: () => true,
       ui: {
         select: async (prompt: string, options: string[]) => {
-          if (prompt.startsWith('Marketplace Entries')) return options[0];
-          if (prompt === 'Installation path') return 'Install Disabled';
+          if (prompt.startsWith(uiText('inst.select.entry'))) return options[0];
+          if (prompt === uiText('inst.select.path')) return uiText('inst.path.disabled');
           return undefined;
         },
         input: async () => undefined,
@@ -1349,10 +1365,10 @@ describe('Bridge Ledger transaction flow adapters', () => {
 
     expect(events).toEqual(['Intent', 'Validation', 'Consent', 'Plan', 'Commit', 'Receipt']);
     expect(confirms).toEqual([]);
-    expect(renderedSheets.find((sheet) => sheet.includes('Validation ACTIVE'))).toMatch(
+    expect(renderedSheets.find((sheet) => sheet.includes(`▸ 2 ${transactionStepLabel('Validation')}（${uiText('step.activeSuffix')}）`))).toMatch(
       /Verdict.*Passed.*Findings.*blocking.*warning.*notice/s,
     );
-    expect(renderedSheets.find((sheet) => sheet.includes('Consent ACTIVE'))).toMatch(/N\/A/);
+    expect(renderedSheets.find((sheet) => sheet.includes(`▸ 3 ${transactionStepLabel('Consent')}（${uiText('step.activeSuffix')}）`))).toMatch(new RegExp(uiText('common.notApplicable')));
   });
 
   it('expands the complete Plugin disclosure with source, precedence, skills, policy, and resources', async () => {
@@ -1383,7 +1399,7 @@ describe('Bridge Ledger transaction flow adapters', () => {
         custom: async (factory: any) => new Promise((resolve) => {
           const component = factory({ requestRender: () => {} }, theme, {}, resolve);
           const first = component.render(120).join('\n');
-          if (first.includes('Validation ACTIVE')) {
+          if (first.includes(`▸ 2 ${transactionStepLabel('Validation')}（${uiText('step.activeSuffix')}）`)) {
             component.handleInput('d');
             expandedValidation = component.render(120).join('\n');
             component.handleInput('\u001b');
@@ -1403,9 +1419,9 @@ describe('Bridge Ledger transaction flow adapters', () => {
       targetState: 'disabled',
     });
 
-    expect(expandedValidation).toMatch(/Source:.*marketplace/s);
-    expect(expandedValidation).toContain('Projected precedence: Pi');
-    expect(expandedValidation).toContain('Skills: 1');
+    expect(expandedValidation).toMatch(/來源 .*marketplace/s);
+    expect(expandedValidation).toContain('投影優先序：Pi');
+    expect(expandedValidation).toContain('Skills：1');
     expect(expandedValidation).toMatch(/release-notes.*implicit.*guide\.md/s);
   });
 
@@ -1510,8 +1526,8 @@ describe('Bridge Ledger transaction flow adapters', () => {
       isProjectTrusted: () => true,
       ui: {
         select: async (prompt: string, options: string[]) => {
-          if (prompt.startsWith('Marketplace Entries')) return options[0];
-          if (prompt === 'Installation path') return 'Install and Enable';
+          if (prompt.startsWith(uiText('inst.select.entry'))) return options[0];
+          if (prompt === uiText('inst.select.path')) return uiText('inst.path.enabled');
           return undefined;
         },
         input: async () => join(root, 'marketplace'),

--- a/tests/unit/extensions/transaction-sheet.test.ts
+++ b/tests/unit/extensions/transaction-sheet.test.ts
@@ -14,6 +14,7 @@ import {
   renderTransactionSheet,
   type TransactionSheetModel,
 } from '../../../extensions/pi/transaction-sheet.js';
+import { transactionStepLabel, uiText, verdictText } from '../../../extensions/pi/ui-strings.js';
 import type { AttemptReceipt, AttemptSummary } from '../../../src/registration/receipt.js';
 
 const identityTheme = {
@@ -67,13 +68,14 @@ describe('Transaction Sheet presentation', () => {
     const output = renderTransactionSheet(model, identityTheme, 80).join('\n');
     expect(TRANSACTION_STEPS).toEqual(['Intent', 'Validation', 'Consent', 'Plan', 'Commit', 'Receipt']);
 
-    const positions = TRANSACTION_STEPS.map((step, index) => output.indexOf(`${index + 1} ${step}`));
+    // Canonical step ids stay stable internally; presentation labels are zh_TW.
+    const positions = TRANSACTION_STEPS.map((step, index) => output.indexOf(`${index + 1} ${transactionStepLabel(step)}`));
     expect(positions.every((position) => position >= 0)).toBe(true);
     expect([...positions].sort((a, b) => a - b)).toEqual(positions);
-    expect(output).toContain('▸ 2 Validation ACTIVE');
-    expect(output).toContain('✓ 1 Intent');
-    expect(output).not.toContain('[1 Intent] ->');
-    expect(output).toContain('Authority: "[G] GLOBAL"');
+    expect(output).toContain(`▸ 2 ${transactionStepLabel('Validation')}（${uiText('step.activeSuffix')}）`);
+    expect(output).toContain(`✓ 1 ${transactionStepLabel('Intent')}`);
+    expect(output).not.toContain('[1 意圖] ->');
+    expect(output).toContain('授權範圍: "[G] Global Scope"');
     expect(output).toContain('State Revision: "18"');
     expect(output).toContain('Validation Snapshot: "snapshot-18"');
     expect(renderTransactionSheet(model, identityTheme, 80).every((line) => visibleWidth(line) <= 80)).toBe(true);
@@ -91,7 +93,7 @@ describe('Transaction Sheet presentation', () => {
       expect(lines[0]).toContain('┌─ Transaction Sheet');
       expect(lines.at(-1)).toContain('┘');
       expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
-      expect(lines.join('\n')).toContain('5 Commit ACTIVE');
+      expect(lines.join('\n')).toContain(`5 ${transactionStepLabel('Commit')}（${uiText('step.activeSuffix')}）`);
     }
   });
 
@@ -113,7 +115,7 @@ describe('Transaction Sheet presentation', () => {
       actionLabel: 'Lifecycle operation',
       receipt: { ...receipt(summary), recoveryActions: [] },
     }, spyingTheme, 60).join('\n');
-    expect(output).toContain(`Attempt Summary: "${summary}"`);
+    expect(output).toContain(`Attempt Summary: "${summary}"（`);
     expect(tokens).toContain(`tool${tone === 'success' ? 'Success' : tone === 'error' ? 'Error' : 'Pending'}Bg`);
     expect(renderTransactionSheet({
       step: 'Receipt',
@@ -147,12 +149,13 @@ describe('Transaction Sheet presentation', () => {
       receipt: receipt(),
     }, identityTheme, width);
 
-    const axisHeader = lines.find((line) => line.includes('Durable') && line.includes('Findings') && line.includes('Runtime'));
+    const axisHeader = lines.find((line) => line.includes(uiText('sheet.axis.durable')) && line.includes(uiText('sheet.axis.findings')) && line.includes(uiText('sheet.axis.runtime')));
     expect(axisHeader).toBeDefined();
-    expect(axisHeader!.indexOf('Durable')).toBeLessThan(axisHeader!.indexOf('Findings'));
-    expect(axisHeader!.indexOf('Findings')).toBeLessThan(axisHeader!.indexOf('Runtime'));
+    expect(axisHeader!.indexOf(uiText('sheet.axis.durable'))).toBeLessThan(axisHeader!.indexOf(uiText('sheet.axis.findings')));
+    expect(axisHeader!.indexOf(uiText('sheet.axis.findings'))).toBeLessThan(axisHeader!.indexOf(uiText('sheet.axis.runtime')));
     expect(lines.join('\n')).toContain('Attempt Summary: "Pending Application"');
-    expect(lines.join('\n')).toContain('Recovery Actions: "Retry Application", "Inspect"');
+    expect(lines.join('\n')).toContain('"Retry Application"（重試運行時套用）');
+    expect(lines.join('\n')).toContain('"Inspect"（檢視）');
     expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
   });
 
@@ -166,8 +169,9 @@ describe('Transaction Sheet presentation', () => {
       receipt: receipt(),
     }, identityTheme, 60);
     const axisLines = lines.map((line) => stripTerminalSequences(line));
-    const positions = ['Durable', 'Findings', 'Runtime'].map((header) =>
-      axisLines.findIndex((line) => line.trim().startsWith(`│ ${header}`) || line.trim() === header));
+    const headers = [uiText('sheet.axis.durable'), uiText('sheet.axis.findings'), uiText('sheet.axis.runtime')];
+    const positions = headers.map((header) =>
+      axisLines.findIndex((line) => line.includes(header)));
     expect(positions.every((position) => position >= 0)).toBe(true);
     expect([...positions].sort((a, b) => a - b)).toEqual(positions);
     expect(lines.every((line) => visibleWidth(line) <= 60)).toBe(true);
@@ -214,7 +218,7 @@ describe('Transaction Sheet presentation', () => {
       receipt: { ...receipt(summary), recoveryActions: [] },
     }, identityTheme, 60).join('\n');
     expect(output).toContain(`Attempt Summary: "${summary}"`);
-    expect(output).toContain('Recovery Actions: none');
+    expect(output).toContain(`${uiText('sheet.recoveryActions')}: ${uiText('common.none')}`);
   });
 
   it.each([120, 80, 60])('prevents malicious terminal text from forging rows or exceeding width %i', (width) => {
@@ -268,7 +272,7 @@ describe('Transaction Sheet presentation', () => {
     component.handleInput(input);
     component.handleInput(input);
     expect(results).toEqual([expected]);
-    expect(component.render(60).some((line) => line.includes('Intent ACTIVE'))).toBe(true);
+    expect(component.render(60).some((line) => line.includes(`1 ${transactionStepLabel('Intent')}`))).toBe(true);
   });
 
   it('starts Validation with verdict/counts and toggles the full disclosure with d', () => {
@@ -280,8 +284,8 @@ describe('Transaction Sheet presentation', () => {
         actionLabel: 'Inspect candidate',
         details: [
           'Source /marketplace',
-          'Verdict Passed with diagnostics',
-          'Findings 0 blocking · 1 warning · 0 notice',
+          `${uiText('verdict.label')}：${verdictText('Blocked')}`,
+          `${uiText('findings.count.label')}：${uiText('findings.count.line', { blocking: 0, warning: 1, notice: 0 })}`,
           'FULL-DISCLOSURE-TAIL',
         ],
       },
@@ -292,17 +296,16 @@ describe('Transaction Sheet presentation', () => {
     );
 
     const collapsed = component.render(60).join('\n');
-    expect(collapsed).toContain('Verdict Passed with diagnostics');
-    expect(collapsed).toContain('Findings 0 blocking');
-    expect(collapsed).toContain('press d to expand');
+    expect(collapsed).toContain(`${uiText('verdict.label')}：${verdictText('Blocked')}`);
+    expect(collapsed).toContain(uiText('findings.count.line', { blocking: 0, warning: 1, notice: 0 }));
+    expect(collapsed).toContain(uiText('sheet.disclosure.collapsed', { count: 4 }).split('；')[0]!);
     expect(collapsed).not.toContain('FULL-DISCLOSURE-TAIL');
 
     component.handleInput('d');
     const expanded = component.render(60).join('\n');
     expect(expanded).toContain('FULL-DISCLOSURE-TAIL');
     // At 60 columns the hint may wrap inside the panel frame; both fragments must survive.
-    expect(expanded).toMatch(/press d to/);
-    expect(expanded).toMatch(/collapse/);
+    expect(expanded).toContain(uiText('sheet.disclosure.expanded'));
     expect(results).toEqual([]);
     expect(renderRequests).toBe(1);
   });
@@ -327,7 +330,7 @@ describe('Transaction Sheet presentation', () => {
     );
 
     expect(result).toBe(expected);
-    expect(rendered.some((line) => line.includes('Consent ACTIVE'))).toBe(true);
+    expect(rendered.some((line) => line.includes(transactionStepLabel('Consent')))).toBe(true);
   });
 
   it('uses escaped notification text and continues when custom TUI is unavailable', async () => {

--- a/tests/unit/extensions/ui-strings.test.ts
+++ b/tests/unit/extensions/ui-strings.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  attemptSummaryGloss,
+  attemptSummaryText,
+  closedValue,
+  findingOutcomeText,
+  recoveryActionGloss,
+  recoveryActionText,
+  transactionStepLabel,
+  uiText,
+  verdictText,
+} from '../../../extensions/pi/ui-strings.js';
+
+describe('centralized zh_TW presentation strings', () => {
+  it('resolves message ids from the active locale dictionary', () => {
+    expect(uiText('common.yes')).toBe('是');
+    expect(uiText('common.no')).toBe('否');
+  });
+
+  it('interpolates {param} placeholders and keeps unknown placeholders loud', () => {
+    expect(uiText('ledger.rail.registrations', { count: 3 })).toBe('Registration 3');
+    expect(uiText('cmd.state.ok', {
+      scope: 'Global Scope',
+      revision: '12',
+      registrations: 1,
+      enabled: 2,
+      disabled: 0,
+    })).toBe('Global Scope：State Revision 12 · Registration 1 · 啟用 Installation 2 / 停用 0');
+    expect(uiText('ledger.rail.registrations', { unrelated: 1 })).toContain('{count}');
+  });
+
+  it('pairs closed Attempt Summary values canonical-first with zh_TW glosses', () => {
+    expect(attemptSummaryText('Blocked')).toBe('Blocked（受阻）');
+    expect(attemptSummaryText('Pending Application')).toBe('Pending Application（待套用）');
+    expect(attemptSummaryGloss('Declined')).toBe('已婉拒');
+  });
+
+  it('falls back to the canonical value when an unknown Attempt Summary arrives', () => {
+    const forged = 'Blocked\nFORGED-RECEIPT' as never;
+    expect(attemptSummaryText(forged)).toBe('Blocked\nFORGED-RECEIPT');
+    expect(attemptSummaryGloss(forged)).toBe('');
+  });
+
+  it('pairs Recovery Action closed values canonical-first with zh_TW glosses', () => {
+    expect(recoveryActionText('Retry Application')).toBe('Retry Application（重試運行時套用）');
+    expect(recoveryActionGloss('Repair State')).toBe('修復 Bridge State');
+  });
+
+  it('renders validation verdicts canonical-first and stage labels in zh_TW', () => {
+    expect(verdictText('Passed with diagnostics')).toBe('Passed with diagnostics（通過但有診斷）');
+    expect(transactionStepLabel('Intent')).toBe('意圖');
+    expect(transactionStepLabel('Receipt')).toBe('收據');
+  });
+
+  it('maps domain findings to zh_TW copy by stable rule code at the presentation boundary', () => {
+    expect(findingOutcomeText({
+      rule: 'BUDG-01',
+      outcome: 'Validation Budget exceeded: catalog 999999 bytes > 200000',
+    })).toBe('超出 Validation Budget 上限');
+    expect(findingOutcomeText({ rule: 'CONT-01', outcome: 'path escapes root' }))
+      .toBe('宣告路徑逸出其所屬根目錄（Contained Path 違規）');
+  });
+
+  it('falls back to the canonical outcome text for rules outside the dictionary', () => {
+    expect(findingOutcomeText({ rule: 'TEST-99', outcome: 'unmapped diagnostic' }))
+      .toBe('unmapped diagnostic');
+  });
+
+  it('composes canonical-first closed values through one helper', () => {
+    expect(closedValue('Enabled', '已啟用')).toBe('Enabled（已啟用）');
+  });
+});


### PR DESCRIPTION
Closes #41

## Summary

- 新增集中式呈現字串模組 `extensions/pi/ui-strings.ts`：以穩定訊息 ID 索引的 zh_TW 字典（保留 locale 切換模組縫），並提供封閉值正典/中文並列（`attemptSummaryText` → `Blocked（受阻）`）、Recovery Action／Verdict 對照、交易階段標籤，以及依 rule code 對應中文文案的 `findingOutcomeText`
- 各 TUI 元件改為消費字串模組：Bridge Ledger 面板／狀態列／help／按鍵提示、Transaction Sheet（階段指示器、欄位標、欄位標籤、軸線、徽章）、本地與 Git Registration、Plugin Installation、Lifecycle（Refresh／Rebind／Update Plan／Removal，含本地化移除披露建構器）、Receipt Journal 視圖與 State Repair、Scope Override；元件內不再有硬編碼的使用者可見英文字串
- findings 於呈現邊界依 rule code 對應中文文案：rule code／classification／排序原樣不動，未知 rule 退回正典 outcome；所有 outcome 文案一律經 `quoteTerminalText` 跳脫
- glossary 術語（Bridge State、State Revision、Receipt Journal…）在中文句子中維持英文；分派續用結構化 intent，嚴禁比對譯文——收據 `operation` 亦固定為正典識別，不隨顯示語言改變
- 非 TUI 的 `list`/`inspect` 純文字輸出依議題範圍維持原樣；TUI 的 observe-partitions 改用在地化摘要

## Test plan

- [x] `npm run check` 綠燈（typecheck + 578 tests）
- [x] 更新全部受影響測試至 zh_TW 表面（bridge-ledger／transaction-sheet／transaction-flows／ledger-flow-adapters／lifecycle-tui／e2e bridge-ledger-command）
- [x] 新增 `tests/unit/extensions/ui-strings.test.ts`：訊息 ID 解析、參數插值、封閉值正典+中文並列、未知 Attempt Summary／rule code 的防禦性退回
- [x] 新增 CJK 雙寬寬度安全測試：120/80/60 欄下無溢位、面板框線完整、截斷正確

## Review notes

- Standards 軸（code-review）：2 項 P2 已修（scope 選單 Map 六處重複收斂為 `scopeOptions()`；模組檔頭釐清集中化範圍為 TUI surfaces）；Speculative Generality（單語系 seam）為議題明示的模組縫，不處理
- Spec 軸（code-review）：驗收標準逐項對驗通過；finding 中文文案採 rule 層級模板（議題指定之呈現邊界取捨），pointer／識別碼完整保留