### PR TITLE
feat: Runtime Skill Exposure——已啟用 Installation 的 skills 接入 Pi runtime（#54）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `pi-codex-marketplace` are documented here. Format follows Keep a Changelog and SemVer (starting at `0.1.0`; Git tags `v*` mirror npm versions).
 
+## [Unreleased]
+
+### Added
+- **Runtime Skill Exposure** (#54)：Bridge Extension 實作 host 資源發現接縫（`pi.on("resources_discover")` 回傳 `skillPaths`，startup 與 reload 兩種 reason 皆支援），依當下 Effective State（enabled Installation 減去 Scope Override 與 Project Trust 排除）之 Runtime Skill Collision 存活者，動態貢獻 skill 目錄——Git Registration 直接指向 Source Cache 中其 Validation Snapshot fingerprint 對應 entry 內的個別 skill 目錄，Local Registration 指向 live Marketplace Root；路徑解析重用 retained catalog + Contained Path 解析。發現時僅做被動存在性檢查：不重算指紋、不改動 Bridge State、不產生任何 Attempt Receipt；快取 entry 遭外部刪除時逐項略過且 discovery 必定完成（`SOURCE_REACQUISITION_REQUIRED` / `SOURCE_DRIFT` 仍由 Lifecycle Operations 產生）。新增領域模組 `src/projection/exposure.ts`（ADR 0001）。
+
 ## [0.1.9] - 2026-08-24
 
 ### Added

--- a/extensions/pi/index.ts
+++ b/extensions/pi/index.ts
@@ -16,6 +16,7 @@ import { stripTerminalSequences } from '@earendil-works/pi-tui';
 
 import { readBridgeStateSync } from '../../src/bridge-state/store.js';
 import type { ReadResult } from '../../src/bridge-state/types.js';
+import { discoverProjectedSkillPaths } from '../../src/projection/exposure.js';
 import { runStartupReconciliation } from '../../src/reconciliation/startup.js';
 import type { AttemptReceipt } from '../../src/registration/receipt.js';
 import { checkGlobalPendingBarrier } from '../../src/barrier/global-barrier.js';
@@ -304,6 +305,24 @@ export default function (pi: ExtensionAPI) {
       }
     } catch {
       // Non-blocking in extension bootstrap
+    }
+  });
+
+  // Runtime Skill Exposure (ADR 0001): contribute Projected Skills through Pi's
+  // resource-discovery seam at every startup and reload. Passive existence inspection over the
+  // current Effective State only — no fingerprint validation, no Bridge State mutation, and no
+  // Attempt Receipt. Missing snapshot material is skipped individually; discovery never fails
+  // the host's resource pass.
+  pi.on('resources_discover', async (_event, ctx) => {
+    try {
+      return {
+        skillPaths: discoverProjectedSkillPaths({
+          cwd: ctx.cwd,
+          projectTrusted: ctx.isProjectTrusted(),
+        }).skillPaths,
+      };
+    } catch {
+      return {};
     }
   });
 

--- a/src/projection/exposure.ts
+++ b/src/projection/exposure.ts
@@ -1,0 +1,269 @@
+/**
+ * Runtime Skill Exposure — read-time discovery of Projected Skill directories contributed to Pi
+ * through the host resource-discovery seam (`resources_discover` → `skillPaths`).
+ * See CONTEXT.md: Runtime Skill Exposure, Projected Skill, Projected Plugin, Effective State,
+ * Runtime Skill Collision, Source Cache, Skill Availability.
+ *
+ * Exposure derives entirely from the current Effective State (enabled Installations minus Scope
+ * Overrides and Project Trust exclusions) and its collision survivors. It performs passive
+ * existence inspection only: no fingerprint recomputation, no Bridge State mutation, and no
+ * Attempt Receipt — snapshot-bound validation stays bound to Lifecycle Operations and Runtime
+ * Applications. Missing cache entries or unreadable snapshot material are skipped individually;
+ * discovery always completes. Exposure never establishes Skill Availability.
+ *
+ * Path resolution follows the retained Validation Snapshot locations:
+ * - Git Registrations resolve inside the Source Cache entry pinned by their recorded base-tree
+ *   fingerprint (the same addressing Marketplace Refresh and inspection reuse; both the
+ *   Registration's and Installation's snapshots are state-pinned against eviction).
+ * - Local Registrations resolve inside their live Marketplace Root at its canonical real path,
+ *   mirroring read-time inspection; drift remains a Lifecycle Operation concern, not discovery's.
+ */
+
+import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from 'node:fs';
+import { basename, join } from 'node:path';
+
+import { parseFrontmatter } from '@earendil-works/pi-coding-agent';
+
+import { getCacheEntriesDir, getCacheDir } from '../cache/paths.js';
+import { readBridgeStateSync } from '../bridge-state/store.js';
+import type { BridgeState } from '../bridge-state/types.js';
+import { parseCatalog, type Catalog } from '../registration/catalog.js';
+import { BUDGET } from '../registration/budget.js';
+import { resolveContained } from '../registration/contained.js';
+import {
+  computeEffectiveState,
+  type EffectiveInstallation,
+  type EffectiveState,
+} from './effective-state.js';
+import { resolveRuntimeSkillCollisions, type SkillCandidate } from './collision.js';
+
+export interface RuntimeSkillExposureOptions {
+  /** Working directory identifying the project scope document. */
+  cwd?: string;
+  /** Pi agent dir; defaults to getAgentDir(). */
+  agentDir?: string;
+  /** Pi host-owned Project Trust. Defaults to false: project additions stay excluded. */
+  projectTrusted?: boolean;
+  /** Exact names already claimed by pre-existing Pi skills (host-owned namespace layer). */
+  piSkillNames?: string[];
+}
+
+/** One Projected Skill contributed at its original snapshot location (no copy). */
+export interface ExposedSkill {
+  name: string;
+  skillId: string;
+  pluginId: string;
+  installationId: string;
+  sourceScope: 'global' | 'project';
+  /** Absolute skill directory containing SKILL.md. */
+  skillDir: string;
+}
+
+export type SkippedInstallationReason =
+  | 'missing-snapshot'
+  | 'missing-cache-entry'
+  | 'catalog-unreadable'
+  | 'entry-not-found'
+  | 'no-skills';
+
+export interface SkippedInstallation {
+  installationId: string;
+  reason: SkippedInstallationReason;
+}
+
+export interface ExposureResult {
+  /** Deterministically ordered skill directories for `resources_discover` → `skillPaths`. */
+  skillPaths: string[];
+  exposed: ExposedSkill[];
+  skipped: SkippedInstallation[];
+}
+
+function safeFingerprint(fp: string | undefined): fp is string {
+  return typeof fp === 'string' && /^[0-9a-f]{64}$/.test(fp);
+}
+
+function emptyScopeState(): BridgeState {
+  return { schemaVersion: 1, stateRevision: '0', registrations: [], installations: [], scopeOverrides: [] };
+}
+
+/** Passive closed read: corrupted or incompatible documents contribute nothing and never throw. */
+function readScopeOrEmpty(scope: 'global' | 'project', opts: RuntimeSkillExposureOptions): BridgeState {
+  const read = readBridgeStateSync(scope, { cwd: opts.cwd, agentDir: opts.agentDir });
+  return read.status === 'ok' || read.status === 'missing' ? read.state! : emptyScopeState();
+}
+
+/**
+ * Locate one Installation's plugin directory inside a snapshot root by resolving its
+ * Marketplace Entry ID through the retained catalog, then verify containment.
+ */
+function resolvePluginDirInSnapshot(snapshotRoot: string, installation: EffectiveInstallation, scope: 'global' | 'project'): string | undefined {
+  const catalogPath = join(snapshotRoot, '.agents', 'plugins', 'marketplace.json');
+  try {
+    if (!existsSync(catalogPath) || statSync(catalogPath).size > BUDGET.maxCatalogBytes) return undefined;
+    const parsed: unknown = JSON.parse(readFileSync(catalogPath, 'utf8'));
+    const result = parseCatalog(parsed, { scope });
+    if (!result.catalog) return undefined;
+    return resolveEntryPluginDir(snapshotRoot, result.catalog, installation);
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveEntryPluginDir(snapshotRoot: string, catalog: Catalog, installation: EffectiveInstallation): string | undefined {
+  const pointer = installation.marketplaceEntryId?.slice(installation.marketplaceEntryId.indexOf('/plugins/'));
+  let entry = pointer !== undefined
+    ? catalog.entries.find((item) => item.entryId === pointer && item.type === 'local' && item.available && item.path)
+    : undefined;
+  if (!entry && installation.manifestName) {
+    entry = catalog.entries.find((item) => item.name === installation.manifestName && item.type === 'local' && item.available && item.path);
+  }
+  if (!entry) return undefined;
+  const contained = resolveContained(snapshotRoot, entry.path!, 'directory');
+  return contained.outcome.kind === 'ok' ? contained.outcome.canonicalPath : undefined;
+}
+
+/** Read each skills/<dir>/SKILL.md descriptor name exactly as Pi resolves it (frontmatter name, else directory name). */
+function skillCandidates(pluginDir: string): Array<{ name: string; skillDir: string }> {
+  const skillsDir = join(pluginDir, 'skills');
+  if (!existsSync(skillsDir) || !statSync(skillsDir).isDirectory()) return [];
+  const found: Array<{ name: string; skillDir: string }> = [];
+  let entries;
+  try {
+    entries = readdirSync(skillsDir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
+  } catch {
+    return [];
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const skillDir = join(skillsDir, entry.name);
+    const descriptor = join(skillDir, 'SKILL.md');
+    if (!existsSync(descriptor)) continue;
+    const name = descriptorSkillName(skillDir, descriptor);
+    if (name) found.push({ name, skillDir });
+  }
+  return found;
+}
+
+function descriptorSkillName(skillDir: string, descriptorPath: string): string | undefined {
+  try {
+    // Pi drops skills whose descriptor cannot be parsed or lacks a description; mirror that here.
+    const text = readFileSync(descriptorPath, 'utf-8');
+    const { frontmatter } = parseFrontmatter<Record<string, unknown>>(text);
+    const description = frontmatter?.description;
+    if (typeof description !== 'string' || description.trim().length === 0) return undefined;
+    const declared = frontmatter?.name;
+    return typeof declared === 'string' && declared.trim().length > 0 ? declared.trim() : basename(skillDir);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Compute the Runtime Skill Exposure for the current Effective State. Pure read-time behavior:
+ * never mutates either Bridge State document, never writes an Attempt Receipt, never throws on
+ * missing material.
+ */
+export function discoverProjectedSkillPaths(opts: RuntimeSkillExposureOptions = {}): ExposureResult {
+  const globalState = readScopeOrEmpty('global', opts);
+  const projectState = readScopeOrEmpty('project', opts);
+  const effective: EffectiveState = computeEffectiveState(globalState, projectState, { projectTrusted: opts.projectTrusted === true });
+
+  const registrationsById = new Map(effective.registrations.map((registration) => [`${registration.sourceScope}:${registration.id}`, registration]));
+  const entriesRoot = getCacheEntriesDir(getCacheDir(opts.agentDir));
+
+  interface Candidate extends SkillCandidate {
+    sourceScope: 'global' | 'project';
+    installationId: string;
+    skillDir: string;
+  }
+  const candidates: Candidate[] = [];
+  const skipped: SkippedInstallation[] = [];
+
+  for (const installation of effective.installations) {
+    const registration = registrationsById.get(`${installation.sourceScope}:${installation.registrationId}`);
+    if (!registration || !installation.marketplaceEntryId) {
+      skipped.push({ installationId: installation.id, reason: 'entry-not-found' });
+      continue;
+    }
+
+    let snapshotRoot: string | undefined;
+    if (registration.sourceKind === 'local') {
+      // Live registered Marketplace Root at its canonical real path (mirrors inspection).
+      try {
+        snapshotRoot = registration.source && existsSync(registration.source)
+          ? realpathSync.native(registration.source)
+          : undefined;
+      } catch {
+        snapshotRoot = undefined;
+      }
+    } else if (registration.sourceKind === 'git') {
+      if (!safeFingerprint(registration.validationSnapshot)) {
+        skipped.push({ installationId: installation.id, reason: 'missing-snapshot' });
+        continue;
+      }
+      // Source Cache addressing matches inspection reuse: the Registration's retained
+      // base-tree fingerprint pins the entry against eviction.
+      const entryDir = join(entriesRoot, registration.validationSnapshot);
+      if (!existsSync(entryDir)) {
+        skipped.push({ installationId: installation.id, reason: 'missing-cache-entry' });
+        continue;
+      }
+      snapshotRoot = entryDir;
+    } else {
+      skipped.push({ installationId: installation.id, reason: 'missing-snapshot' });
+      continue;
+    }
+    if (!snapshotRoot) {
+      skipped.push({ installationId: installation.id, reason: 'catalog-unreadable' });
+      continue;
+    }
+
+    const pluginDir = resolvePluginDirInSnapshot(snapshotRoot, installation, installation.sourceScope);
+    if (!pluginDir) {
+      skipped.push({
+        installationId: installation.id,
+        reason: existsSync(join(snapshotRoot, '.agents', 'plugins', 'marketplace.json')) ? 'entry-not-found' : 'catalog-unreadable',
+      });
+      continue;
+    }
+    const skills = skillCandidates(pluginDir);
+    if (skills.length === 0) {
+      skipped.push({ installationId: installation.id, reason: 'no-skills' });
+      continue;
+    }
+    for (const skill of skills) {
+      candidates.push({
+        layer: installation.sourceScope,
+        name: skill.name,
+        skillId: `${installation.pluginId}/${skill.name}`,
+        pluginId: installation.pluginId,
+        sourceScope: installation.sourceScope,
+        installationId: installation.id,
+        skillDir: skill.skillDir,
+      });
+    }
+  }
+
+  // Only collision survivors are contributed; layering is Pi → Project Scope → Global Scope.
+  const bridgeCandidates: SkillCandidate[] = opts.piSkillNames?.length
+    ? [
+        ...opts.piSkillNames.map((name): SkillCandidate => ({ layer: 'pi', name, skillId: `pi/${name}`, pluginId: '(pi)' })),
+        ...candidates.map(({ layer, name, skillId, pluginId }) => ({ layer, name, skillId, pluginId })),
+      ]
+    : candidates.map(({ layer, name, skillId, pluginId }) => ({ layer, name, skillId, pluginId }));
+  const survivors = new Set(resolveRuntimeSkillCollisions(bridgeCandidates).survivors.map((s) => s.skillId));
+
+  const exposed = candidates
+    .filter((candidate) => survivors.has(candidate.skillId))
+    .sort((a, b) => a.skillDir.localeCompare(b.skillDir))
+    .map((candidate): ExposedSkill => ({
+      name: candidate.name,
+      skillId: candidate.skillId,
+      pluginId: candidate.pluginId,
+      installationId: candidate.installationId,
+      sourceScope: candidate.sourceScope,
+      skillDir: candidate.skillDir,
+    }));
+
+  return { skillPaths: exposed.map((skill) => skill.skillDir), exposed, skipped };
+}

--- a/src/projection/exposure.ts
+++ b/src/projection/exposure.ts
@@ -110,7 +110,12 @@ function resolvePluginDirInSnapshot(snapshotRoot: string, installation: Effectiv
 }
 
 function resolveEntryPluginDir(snapshotRoot: string, catalog: Catalog, installation: EffectiveInstallation): string | undefined {
-  const pointer = installation.marketplaceEntryId?.slice(installation.marketplaceEntryId.indexOf('/plugins/'));
+  // A malformed Marketplace Entry ID without the "/plugins/" marker yields an undefined pointer
+  // so resolution falls back to manifestName instead of degrading to a bogus tail slice.
+  const markerIndex = installation.marketplaceEntryId?.indexOf('/plugins/') ?? -1;
+  const pointer = installation.marketplaceEntryId && markerIndex >= 0
+    ? installation.marketplaceEntryId.slice(markerIndex)
+    : undefined;
   let entry = pointer !== undefined
     ? catalog.entries.find((item) => item.entryId === pointer && item.type === 'local' && item.available && item.path)
     : undefined;

--- a/src/projection/index.ts
+++ b/src/projection/index.ts
@@ -1,4 +1,5 @@
 export * from './effective-state.js';
 export * from './collision.js';
+export * from './exposure.js';
 export * from './overrides.js';
 export * from './project.js';

--- a/tests/integration/exposure-extension.test.ts
+++ b/tests/integration/exposure-extension.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Integration: the Bridge Extension registers the host resource-discovery handler and returns
+ * Runtime Skill Exposure paths through `resources_discover` (Issue #54, ADR 0001).
+ *
+ * External observable behavior only: startup and reload reasons produce identical contributions,
+ * Project Trust gates project additions, and passive inspection writes no Attempt Receipt.
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import registerBridgeExtension from '../../extensions/pi/index.js';
+import { commitBridgeState } from '../../src/bridge-state/store.js';
+import { getReceiptsJournalPath } from '../../src/bridge-state/paths.js';
+import { SourceCache } from '../../src/cache/source-cache.js';
+import type { BridgeState } from '../../src/bridge-state/types.js';
+
+const GLOBAL_REG = '11111111-1111-4111-8111-111111111111';
+const FINGERPRINT = 'a'.repeat(64);
+
+interface DiscoverHandler {
+  (event: { type: 'resources_discover'; cwd: string; reason: 'startup' | 'reload' }, ctx: { cwd: string; isProjectTrusted(): boolean }): Promise<{ skillPaths?: string[] }>;
+}
+
+function captureHandlers(): Map<string, DiscoverHandler> {
+  const handlers = new Map<string, DiscoverHandler>();
+  registerBridgeExtension({
+    on(event: string, handler: DiscoverHandler) {
+      handlers.set(event, handler);
+    },
+    registerCommand() {},
+  } as never);
+  return handlers;
+}
+
+function makeEnv() {
+  const root = mkdtempSync(join(tmpdir(), 'exposure-extension-'));
+  const env = {
+    root,
+    agentDir: join(root, 'agent'),
+    projectDir: join(root, 'project'),
+    marketplace: join(root, 'marketplace'),
+  };
+  mkdirSync(join(env.marketplace, '.agents', 'plugins'), { recursive: true });
+  writeFileSync(
+    join(env.marketplace, '.agents', 'plugins', 'marketplace.json'),
+    JSON.stringify({
+      name: 'acme-marketplace',
+      plugins: [{ name: 'release-helper', source: { source: 'local', path: './plugins/release-helper' } }],
+    }),
+  );
+  mkdirSync(join(env.marketplace, 'plugins', 'release-helper', '.codex-plugin'), { recursive: true });
+  writeFileSync(join(env.marketplace, 'plugins', 'release-helper', '.codex-plugin', 'plugin.json'), JSON.stringify({ name: 'release-helper', skills: './skills/' }));
+  mkdirSync(join(env.marketplace, 'plugins', 'release-helper', 'skills', 'release-notes'), { recursive: true });
+  writeFileSync(
+    join(env.marketplace, 'plugins', 'release-helper', 'skills', 'release-notes', 'SKILL.md'),
+    '---\nname: release-notes\ndescription: Write release notes\n---\n\nWrite release notes.\n',
+  );
+  return env;
+}
+
+async function seedEnabledGlobalInstallation(agentDir: string, projectDir: string): Promise<void> {
+  await commitBridgeState(
+    'global',
+    (state: BridgeState) => ({
+      ...state,
+      registrations: [
+        ...state.registrations,
+        {
+          id: GLOBAL_REG,
+          alias: 'acme',
+          marketplaceName: 'acme-marketplace',
+          sourceKind: 'git' as const,
+          source: 'https://github.com/acme/marketplace.git',
+          canonicalLocator: 'https://github.com/acme/marketplace.git',
+          validationSnapshot: FINGERPRINT,
+        },
+      ],
+      installations: [
+        ...state.installations,
+        {
+          id: `global/${GLOBAL_REG}/acme-marketplace/release-helper`,
+          pluginId: `${GLOBAL_REG}/acme-marketplace/release-helper`,
+          installationState: 'enabled' as const,
+          registrationId: GLOBAL_REG,
+          marketplaceEntryId: `${GLOBAL_REG}/acme-marketplace/plugins/0`,
+          validationSnapshot: `bound-${FINGERPRINT.slice(0, 8)}`,
+          manifestName: 'release-helper',
+        },
+      ],
+    }),
+    { agentDir, cwd: projectDir },
+  );
+}
+
+let envs: ReturnType<typeof makeEnv>[] = [];
+
+beforeEach(() => {
+  envs = [];
+});
+
+afterEach(() => {
+  delete process.env.PI_CODING_AGENT_DIR;
+  delete process.env.PI_AGENT_DIR;
+  while (envs.length > 0) rmSync(envs.pop()!.root, { recursive: true, force: true });
+});
+
+describe('Bridge Extension resources_discover seam (#54)', () => {
+  it('registers a resources_discover handler that contributes enabled Installation skills on startup and reload', async () => {
+    const env = makeEnv();
+    envs.push(env);
+    // Acquire the marketplace tree into the Source Cache exactly like Git acquisition.
+    await new SourceCache({ agentDir: env.agentDir }).storeTree(env.marketplace, FINGERPRINT);
+    await seedEnabledGlobalInstallation(env.agentDir, env.projectDir);
+    process.env.PI_CODING_AGENT_DIR = env.agentDir;
+    process.env.PI_AGENT_DIR = env.agentDir;
+
+    const handlers = captureHandlers();
+    const handler = handlers.get('resources_discover');
+    expect(handler).toBeDefined();
+
+    const ctx = { cwd: env.projectDir, isProjectTrusted: () => true };
+    const startup = await handler!({ type: 'resources_discover', cwd: env.projectDir, reason: 'startup' }, ctx);
+    const reload = await handler!({ type: 'resources_discover', cwd: env.projectDir, reason: 'reload' }, ctx);
+
+    expect(startup.skillPaths).toHaveLength(1);
+    expect(startup.skillPaths).toEqual(reload.skillPaths);
+    expect(startup.skillPaths![0]!).toContain(join('plugins', 'release-helper', 'skills', 'release-notes'));
+    expect(existsSync(join(startup.skillPaths![0]!, 'SKILL.md'))).toBe(true);
+  });
+
+  it('gates project additions on Project Trust through the host context and writes no Attempt Receipt', async () => {
+    const env = makeEnv();
+    envs.push(env);
+    await new SourceCache({ agentDir: env.agentDir }).storeTree(env.marketplace, FINGERPRINT);
+    await seedEnabledGlobalInstallation(env.agentDir, env.projectDir);
+    process.env.PI_CODING_AGENT_DIR = env.agentDir;
+    process.env.PI_AGENT_DIR = env.agentDir;
+
+    const handlers = captureHandlers();
+    const handler = handlers.get('resources_discover')!;
+    let trusted = false;
+    const untrusted = await handler(
+      { type: 'resources_discover', cwd: env.projectDir, reason: 'startup' },
+      { cwd: env.projectDir, isProjectTrusted: () => trusted },
+    );
+    expect(untrusted.skillPaths).toHaveLength(1); // global baseline still contributes
+
+    trusted = true;
+    const result = await handler(
+      { type: 'resources_discover', cwd: env.projectDir, reason: 'reload' },
+      { cwd: env.projectDir, isProjectTrusted: () => trusted },
+    );
+    expect(result.skillPaths).toEqual(untrusted.skillPaths);
+
+    // Passive inspection creates none.
+    expect(existsSync(getReceiptsJournalPath('global', { agentDir: env.agentDir, cwd: env.projectDir }))).toBe(false);
+    expect(existsSync(getReceiptsJournalPath('project', { agentDir: env.agentDir, cwd: env.projectDir }))).toBe(false);
+  });
+});

--- a/tests/unit/projection/exposure.test.ts
+++ b/tests/unit/projection/exposure.test.ts
@@ -345,6 +345,28 @@ describe('Runtime Skill Exposure — passive inspection only', () => {
     expect(ghost?.reason).toBe('entry-not-found');
   });
 
+  it('treats a malformed Marketplace Entry ID as no pointer and falls back to manifestName instead of a tail slice', async () => {
+    const env = freshEnv();
+    makeMarketplace(env.marketplace, 'release-helper', 'release-helper', ['release-notes']);
+    await seedGitRegistrationAndCache(env);
+    // Overwrite the Installation's marketplaceEntryId with an ID lacking the "/plugins/" marker.
+    await commitBridgeState(
+      'global',
+      (state) => ({
+        ...state,
+        installations: state.installations.map((installation) =>
+          installation.manifestName === 'release-helper' ? { ...installation, marketplaceEntryId: 'not-a-pointer' } : installation,
+        ),
+      }),
+      { agentDir: env.agentDir, cwd: env.projectDir },
+    );
+
+    const result = discoverProjectedSkillPaths({ cwd: env.projectDir, agentDir: env.agentDir });
+    // The retained manifestName still resolves the entry; the malformed ID must not produce a bogus pointer.
+    expect(result.exposed.map((s) => s.name)).toEqual(['release-notes']);
+    expect(result.skipped).toEqual([]);
+  });
+
   it('treats corrupted or incompatible scope documents as empty instead of failing', async () => {
     const env = freshEnv();
     mkdirSync(join(env.agentDir, 'codex-marketplace'), { recursive: true });

--- a/tests/unit/projection/exposure.test.ts
+++ b/tests/unit/projection/exposure.test.ts
@@ -1,0 +1,389 @@
+/**
+ * Runtime Skill Exposure — read-time discovery of Projected Skill paths for Pi's
+ * resource-discovery seam. See CONTEXT.md: Runtime Skill Exposure, Projected Skill,
+ * Effective State, Scope Override, Project Trust, Runtime Skill Collision.
+ *
+ * Only external observable behavior is asserted: which skill directories are contributed,
+ * which Installations are skipped and why, that discovery never mutates Bridge State and
+ * never writes an Attempt Receipt, and that missing cache material never fails discovery.
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { discoverProjectedSkillPaths } from '../../../src/projection/exposure.js';
+import { commitBridgeState, readBridgeStateSync } from '../../../src/bridge-state/store.js';
+import { getReceiptsJournalPath } from '../../../src/bridge-state/paths.js';
+import { SourceCache } from '../../../src/cache/source-cache.js';
+import type { BridgeState } from '../../../src/bridge-state/types.js';
+
+const GLOBAL_REG = '11111111-1111-4111-8111-111111111111';
+
+function makeEnv() {
+  const root = mkdtempSync(join(tmpdir(), 'exposure-unit-'));
+  return {
+    root,
+    agentDir: join(root, 'agent'),
+    projectDir: join(root, 'project'),
+    marketplace: join(root, 'marketplace'),
+  };
+}
+
+/** One marketplace root with a single compatible plugin exposing `skillNames`. */
+function makeMarketplace(root: string, pluginDirName: string, manifestName: string, skillNames: string[]): void {
+  mkdirSync(join(root, '.agents', 'plugins'), { recursive: true });
+  writeFileSync(
+    join(root, '.agents', 'plugins', 'marketplace.json'),
+    JSON.stringify({
+      name: 'acme-marketplace',
+      plugins: [{ name: manifestName, source: { source: 'local', path: `./plugins/${pluginDirName}` } }],
+    }),
+  );
+  makePluginAt(root, pluginDirName, manifestName, skillNames);
+}
+
+function makePluginAt(root: string, pluginDirName: string, manifestName: string, skillNames: string[]): void {
+  mkdirSync(join(root, 'plugins', pluginDirName, '.codex-plugin'), { recursive: true });
+  writeFileSync(join(root, 'plugins', pluginDirName, '.codex-plugin', 'plugin.json'), JSON.stringify({ name: manifestName, skills: './skills/' }));
+  for (const skillName of skillNames) {
+    mkdirSync(join(root, 'plugins', pluginDirName, 'skills', skillName), { recursive: true });
+    writeFileSync(
+      join(root, 'plugins', pluginDirName, 'skills', skillName, 'SKILL.md'),
+      `---\nname: ${skillName}\ndescription: ${skillName} skill\n---\n\n${skillName} body.\n`,
+    );
+  }
+}
+
+async function seedGitRegistrationAndCache(env: ReturnType<typeof makeEnv>, opts: { registrationId?: string } = {}): Promise<{ fingerprint: string }> {
+  const registrationId = opts.registrationId ?? GLOBAL_REG;
+  // Acquire the tree into the Source Cache exactly as Git acquisition would.
+  const cache = new SourceCache({ agentDir: env.agentDir });
+  const fingerprint = 'a'.repeat(64);
+  await cache.storeTree(env.marketplace, fingerprint);
+  await commitBridgeState(
+    'global',
+    (state: BridgeState) => ({
+      ...state,
+      registrations: [
+        ...state.registrations,
+        {
+          id: registrationId,
+          alias: 'acme',
+          marketplaceName: 'acme-marketplace',
+          sourceKind: 'git' as const,
+          source: 'https://github.com/acme/marketplace.git',
+          canonicalLocator: 'https://github.com/acme/marketplace.git',
+          validationSnapshot: fingerprint,
+        },
+      ],
+      installations: [
+        ...state.installations,
+        {
+          id: `global/${registrationId}/acme-marketplace/release-helper`,
+          pluginId: `${registrationId}/acme-marketplace/release-helper`,
+          installationState: 'enabled' as const,
+          registrationId,
+          marketplaceEntryId: `${registrationId}/acme-marketplace/plugins/0`,
+          validationSnapshot: `bound-${fingerprint.slice(0, 8)}`,
+          manifestName: 'release-helper',
+        },
+      ],
+    }),
+    { agentDir: env.agentDir, cwd: env.projectDir },
+  );
+  return { fingerprint };
+}
+
+let envs: ReturnType<typeof makeEnv>[] = [];
+
+function freshEnv(): ReturnType<typeof makeEnv> {
+  const env = makeEnv();
+  envs.push(env);
+  return env;
+}
+
+beforeEach(() => {
+  envs = [];
+});
+
+afterEach(() => {
+  while (envs.length > 0) rmSync(envs.pop()!.root, { recursive: true, force: true });
+});
+
+describe('Runtime Skill Exposure — contribution', () => {
+  it('contributes each surviving skill directory inside the pinned cache entry with provenance', async () => {
+    const env = freshEnv();
+    makeMarketplace(env.marketplace, 'release-helper', 'release-helper', ['release-notes', 'changelog']);
+    const { fingerprint } = await seedGitRegistrationAndCache(env);
+
+    const result = discoverProjectedSkillPaths({ cwd: env.projectDir, agentDir: env.agentDir });
+
+    expect(result.skillPaths).toHaveLength(2);
+    expect(result.exposed.map((s) => s.name).sort()).toEqual(['changelog', 'release-notes']);
+    expect(result.skipped).toEqual([]);
+    for (const exposed of result.exposed) {
+      expect(exposed.pluginId).toBe(`${GLOBAL_REG}/acme-marketplace/release-helper`);
+      expect(exposed.installationId).toBe(`global/${GLOBAL_REG}/acme-marketplace/release-helper`);
+      expect(exposed.skillId).toBe(`${GLOBAL_REG}/acme-marketplace/release-helper/${exposed.name}`);
+      expect(exposed.sourceScope).toBe('global');
+      expect(realpathSync(exposed.skillDir)).toBe(
+        realpathSync(join(new SourceCache({ agentDir: env.agentDir }).entryPath(fingerprint), 'plugins', 'release-helper', 'skills', exposed.name)),
+      );
+      expect(existsSync(join(exposed.skillDir, 'SKILL.md'))).toBe(true);
+    }
+  });
+
+  it('is deterministic across repeated discoveries (startup vs reload see identical output)', async () => {
+    const env = freshEnv();
+    makeMarketplace(env.marketplace, 'release-helper', 'release-helper', ['release-notes']);
+    await seedGitRegistrationAndCache(env);
+
+    const first = discoverProjectedSkillPaths({ cwd: env.projectDir, agentDir: env.agentDir });
+    const second = discoverProjectedSkillPaths({ cwd: env.projectDir, agentDir: env.agentDir });
+    expect(first.skillPaths).toEqual(second.skillPaths);
+  });
+
+  it('excludes disabled Installations — only enabled participate', async () => {
+    const env = freshEnv();
+    makeMarketplace(env.marketplace, 'release-helper', 'release-helper', ['release-notes']);
+    const { fingerprint } = await seedGitRegistrationAndCache(env);
+    await commitBridgeState(
+      'global',
+      (state) => ({
+        ...state,
+        installations: state.installations.map((i) => ({ ...i, installationState: 'disabled' as const })),
+      }),
+      { agentDir: env.agentDir, cwd: env.projectDir },
+    );
+
+    const result = discoverProjectedSkillPaths({ cwd: env.projectDir, agentDir: env.agentDir });
+    expect(result.skillPaths).toEqual([]);
+    expect(result.exposed).toEqual([]);
+    void fingerprint;
+  });
+
+  it('a Registration Override suppresses the whole source subtree', async () => {
+    const env = freshEnv();
+    makeMarketplace(env.marketplace, 'release-helper', 'release-helper', ['release-notes']);
+    await seedGitRegistrationAndCache(env);
+    await commitBridgeState('project', (state) => ({ ...state, scopeOverrides: [{ kind: 'registration', targetId: GLOBAL_REG }] }), { agentDir: env.agentDir, cwd: env.projectDir });
+
+    const result = discoverProjectedSkillPaths({ cwd: env.projectDir, agentDir: env.agentDir, projectTrusted: true });
+    expect(result.skillPaths).toEqual([]);
+
+    // Removing the override reveals the inherited record again at the next read.
+    await commitBridgeState('project', (state) => ({ ...state, scopeOverrides: [] }), { agentDir: env.agentDir, cwd: env.projectDir });
+    expect(discoverProjectedSkillPaths({ cwd: env.projectDir, agentDir: env.agentDir, projectTrusted: true }).skillPaths).toHaveLength(1);
+  });
+
+  it('without Project Trust, project additions do not contribute; global baseline still does', async () => {
+    const env = freshEnv();
+    makeMarketplace(env.marketplace, 'release-helper', 'release-helper', ['global-skill']);
+    await seedGitRegistrationAndCache(env);
+
+    const PROJECT_REG = '22222222-2222-4222-8222-222222222222';
+    const projectMarket = join(env.root, 'project-market');
+    makeMarketplace(projectMarket, 'beta-tool', 'beta-tool', ['project-skill']);
+    const cache = new SourceCache({ agentDir: env.agentDir });
+    const projectFp = 'b'.repeat(64);
+    await cache.storeTree(projectMarket, projectFp);
+    await commitBridgeState(
+      'project',
+      (state) => ({
+        ...state,
+        registrations: [
+          ...state.registrations,
+          {
+            id: PROJECT_REG,
+            alias: 'beta',
+            marketplaceName: 'acme-marketplace',
+            sourceKind: 'git' as const,
+            source: 'https://github.com/acme/project-market.git',
+            validationSnapshot: projectFp,
+          },
+        ],
+        installations: [
+          ...state.installations,
+          {
+            id: `project/${PROJECT_REG}/acme-marketplace/beta-tool`,
+            pluginId: `${PROJECT_REG}/acme-marketplace/beta-tool`,
+            installationState: 'enabled' as const,
+            registrationId: PROJECT_REG,
+            marketplaceEntryId: `${PROJECT_REG}/acme-marketplace/plugins/0`,
+            validationSnapshot: `bound-${projectFp.slice(0, 8)}`,
+            manifestName: 'beta-tool',
+          },
+        ],
+      }),
+      { agentDir: env.agentDir, cwd: env.projectDir },
+    );
+
+    const untrusted = discoverProjectedSkillPaths({ cwd: env.projectDir, agentDir: env.agentDir, projectTrusted: false });
+    expect(untrusted.exposed.map((s) => s.name)).toEqual(['global-skill']);
+
+    const trusted = discoverProjectedSkillPaths({ cwd: env.projectDir, agentDir: env.agentDir, projectTrusted: true });
+    expect(trusted.exposed.map((s) => s.name).sort()).toEqual(['global-skill', 'project-skill']);
+  });
+
+  it('resolves cross-scope Runtime Skill Collision at skill granularity — only the Project survivor is contributed', async () => {
+    const env = freshEnv();
+    makeMarketplace(env.marketplace, 'release-helper', 'release-helper', ['shared-name']);
+    await seedGitRegistrationAndCache(env);
+
+    const PROJECT_REG = '33333333-3333-4333-8333-333333333333';
+    const projectMarket = join(env.root, 'project-market');
+    makeMarketplace(projectMarket, 'helper-two', 'helper-two', ['shared-name']);
+    const cache = new SourceCache({ agentDir: env.agentDir });
+    const projectFp = 'c'.repeat(64);
+    await cache.storeTree(projectMarket, projectFp);
+    await commitBridgeState(
+      'project',
+      (state) => ({
+        ...state,
+        registrations: [
+          ...state.registrations,
+          { id: PROJECT_REG, alias: 'beta', marketplaceName: 'beta-marketplace', sourceKind: 'git' as const, source: 'https://github.com/acme/beta.git', validationSnapshot: projectFp },
+        ],
+        installations: [
+          ...state.installations,
+          {
+            id: `project/${PROJECT_REG}/beta-marketplace/helper-two`,
+            pluginId: `${PROJECT_REG}/beta-marketplace/helper-two`,
+            installationState: 'enabled' as const,
+            registrationId: PROJECT_REG,
+            marketplaceEntryId: `${PROJECT_REG}/beta-marketplace/plugins/0`,
+            validationSnapshot: `bound-${projectFp.slice(0, 8)}`,
+            manifestName: 'helper-two',
+          },
+        ],
+      }),
+      { agentDir: env.agentDir, cwd: env.projectDir },
+    );
+
+    const result = discoverProjectedSkillPaths({ cwd: env.projectDir, agentDir: env.agentDir, projectTrusted: true });
+    expect(result.exposed.map((s) => s.sourceScope)).toEqual(['project']);
+    expect(result.skillPaths).toHaveLength(1);
+    expect(result.skillPaths[0]).toContain(join('plugins', 'helper-two', 'skills', 'shared-name'));
+  });
+
+  it('a pre-existing Pi-layer name reserves the name when supplied via piSkillNames', async () => {
+    const env = freshEnv();
+    makeMarketplace(env.marketplace, 'release-helper', 'release-helper', ['deploy']);
+    await seedGitRegistrationAndCache(env);
+
+    const result = discoverProjectedSkillPaths({ cwd: env.projectDir, agentDir: env.agentDir, piSkillNames: ['deploy'] });
+    expect(result.skillPaths).toEqual([]);
+  });
+});
+
+describe('Runtime Skill Exposure — passive inspection only', () => {
+  it('skips a deleted cache entry without failing, without mutating State, and without writing an Attempt Receipt', async () => {
+    const env = freshEnv();
+    makeMarketplace(env.marketplace, 'release-helper', 'release-helper', ['release-notes']);
+    const { fingerprint } = await seedGitRegistrationAndCache(env);
+    const revisionBefore = readBridgeStateSync('global', { agentDir: env.agentDir, cwd: env.projectDir }).state!.stateRevision;
+
+    // External deletion outside any lifecycle operation.
+    const cache = new SourceCache({ agentDir: env.agentDir });
+    rmSync(cache.entryPath(fingerprint), { recursive: true, force: true });
+    rmSync(cache.metaPath(fingerprint), { force: true });
+
+    const result = discoverProjectedSkillPaths({ cwd: env.projectDir, agentDir: env.agentDir });
+    expect(result.skillPaths).toEqual([]);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]?.reason).toBe('missing-cache-entry');
+
+    // Passive: no receipt journal materialized in either scope, State Revision untouched.
+    expect(readBridgeStateSync('global', { agentDir: env.agentDir, cwd: env.projectDir }).state!.stateRevision).toBe(revisionBefore);
+    expect(existsSync(getReceiptsJournalPath('global', { agentDir: env.agentDir, cwd: env.projectDir }))).toBe(false);
+    expect(existsSync(getReceiptsJournalPath('project', { agentDir: env.agentDir, cwd: env.projectDir }))).toBe(false);
+  });
+
+  it('skips an Installation whose cached catalog cannot be read', async () => {
+    const env = freshEnv();
+    makeMarketplace(env.marketplace, 'release-helper', 'release-helper', ['release-notes']);
+    const { fingerprint } = await seedGitRegistrationAndCache(env);
+
+    const cache = new SourceCache({ agentDir: env.agentDir });
+    rmSync(join(cache.entryPath(fingerprint), '.agents', 'plugins', 'marketplace.json'));
+
+    const result = discoverProjectedSkillPaths({ cwd: env.projectDir, agentDir: env.agentDir });
+    expect(result.skillPaths).toEqual([]);
+    expect(result.skipped[0]?.reason).toBe('catalog-unreadable');
+  });
+
+  it('skips an Installation whose Marketplace Entry cannot be resolved in the snapshot', async () => {
+    const env = freshEnv();
+    makeMarketplace(env.marketplace, 'release-helper', 'release-helper', ['release-notes']);
+    await seedGitRegistrationAndCache(env);
+    await commitBridgeState(
+      'global',
+      (state) => ({
+        ...state,
+        installations: [
+          ...state.installations,
+          {
+            id: `${GLOBAL_REG}/acme-marketplace/ghost`,
+            pluginId: `${GLOBAL_REG}/acme-marketplace/ghost`,
+            installationState: 'enabled' as const,
+            registrationId: GLOBAL_REG,
+            marketplaceEntryId: `${GLOBAL_REG}/acme-marketplace/plugins/99`,
+            validationSnapshot: 'bound-ghost',
+            manifestName: 'ghost',
+          },
+        ],
+      }),
+      { agentDir: env.agentDir, cwd: env.projectDir },
+    );
+
+    const result = discoverProjectedSkillPaths({ cwd: env.projectDir, agentDir: env.agentDir });
+    expect(result.exposed.map((s) => s.name)).toEqual(['release-notes']); // healthy one stays
+    const ghost = result.skipped.find((s) => s.installationId.endsWith('/ghost'));
+    expect(ghost?.reason).toBe('entry-not-found');
+  });
+
+  it('treats corrupted or incompatible scope documents as empty instead of failing', async () => {
+    const env = freshEnv();
+    mkdirSync(join(env.agentDir, 'codex-marketplace'), { recursive: true });
+    writeFileSync(join(env.agentDir, 'codex-marketplace', 'state.json'), '{ corrupted', 'utf-8');
+
+    const result = discoverProjectedSkillPaths({ cwd: env.projectDir, agentDir: env.agentDir });
+    expect(result.skillPaths).toEqual([]);
+    expect(result.exposed).toEqual([]);
+  });
+
+  it('local Registrations expose skills from their live Marketplace Root without a cache round-trip', async () => {
+    const env = freshEnv();
+    makeMarketplace(env.marketplace, 'release-helper', 'release-helper', ['local-skill']);
+    await commitBridgeState(
+      'global',
+      (state) => ({
+        ...state,
+        registrations: [
+          ...state.registrations,
+          { id: GLOBAL_REG, alias: 'acme-local', marketplaceName: 'acme-marketplace', sourceKind: 'local' as const, source: env.marketplace },
+        ],
+        installations: [
+          ...state.installations,
+          {
+            id: `global/${GLOBAL_REG}/acme-marketplace/release-helper`,
+            pluginId: `${GLOBAL_REG}/acme-marketplace/release-helper`,
+            installationState: 'enabled' as const,
+            registrationId: GLOBAL_REG,
+            marketplaceEntryId: `${GLOBAL_REG}/acme-marketplace/plugins/0`,
+            validationSnapshot: 'local-bound-snapshot',
+            manifestName: 'release-helper',
+          },
+        ],
+      }),
+      { agentDir: env.agentDir, cwd: env.projectDir },
+    );
+
+    const result = discoverProjectedSkillPaths({ cwd: env.projectDir, agentDir: env.agentDir });
+    expect(result.exposed.map((s) => s.name)).toEqual(['local-skill']);
+    expect(realpathSync(result.skillPaths[0]!)).toBe(realpathSync(join(env.marketplace, 'plugins', 'release-helper', 'skills', 'local-skill')));
+  });
+});


### PR DESCRIPTION
Closes #54

## 摘要

Bridge Extension 實作 host 資源發現接縫：`pi.on("resources_discover")` 回傳 `skillPaths`（startup 與 reload 兩種 reason 皆支援），依當下 Effective State 之 collision 存活者動態貢獻 skill 目錄，使 enabled Installation 的 Projected Skills 在新 session 或 reload 後實際可用。設計遵循 ADR 0001（Runtime Skill Exposure via host resource discovery）與 CONTEXT.md「Runtime Skill Exposure」。

## 實作

**領域模組 `src/projection/exposure.ts` — `discoverProjectedSkillPaths()`**

- 以現有 `computeEffectiveState()` 驅動（global baseline + project additions − Scope Overrides，僅 enabled、Project Trust 邊界）——重用，未另寫投影規則。
- 僅貢獻 Runtime Skill Collision 存活者：重用 `resolveRuntimeSkillCollisions()`（Pi → Project → Global layering；host Pi 層可經 `piSkillNames` 注入）。
- 路徑解析重用 retained snapshot 定位：
  - Git Registration → Source Cache 中其 recorded base-tree fingerprint 對應 entry（與 inspection reuse 同定址；Registration/Installation snapshots 皆 state-pinned 免於驅逐）。
  - Local Registration → live Marketplace Root（canonical real path，鏡射 read-time inspection）。
  - Marketplace Entry ID 經 retained catalog 解析 + `resolveContained()` 驗證 containment。
- Descriptor 名稱解析與 Pi 原生語意一致（frontmatter `name`，否則目錄名；缺 description 不貢獻）。`invocationPolicy: 'explicit'` 照常貢獻——descriptor 宣告的 `disable-model-invocation: true` 由 Pi 原樣生效（執行期政策表達追蹤於 #55）。

**Extension 接線 `extensions/pi/index.ts`**

- `resources_discover` handler 以 `ctx.cwd` + `ctx.isProjectTrusted()` 呼叫上模組回傳 `{ skillPaths }`；handler 永不拋出（任何例外回空結果），不阻擋 host 資源載入。

## 驗收（對照 issue checklist）

- ✅ Global Scope 安裝並啟用後 reload 即貢獻存活者 skills；disable／override／re-enable 即時反映（單元測試覆蓋）。
- ✅ Registration Override 壓掉來源 subtree 後不再貢獻；移除後恢復。
- ✅ 跨 scope 同名衝突僅 Project 存活者出現（layering 重用既有投影）。
- ✅ Project Trust 未授予／撤銷後 project additions 不參與，global baseline 照常。
- ✅ 快取 entry 遭外部刪除：discovery 正常完成（逐項略過）、無 receipt、無例外；lifecycle 操作仍產生 `SOURCE_REACQUISITION_REQUIRED`／`SOURCE_DRIFT`（既有測試未動）。
- ✅ 全流程零 Attempt Receipt（被動檢查不產生）；`npm run check`（typecheck + 592 tests / 51 files）全綠。

## Out of scope（依 issue）

AVAIL-01 host 掃描、receipt 升級 runtime 可見性斷言、Invocation Policy 執行期表達（#55）、materialize/pinning 新機制。Bridge Ledger「Projected Skills」顯示欄為加分項，未含於本 PR。

## 待決設計問題的落點

1. **快取生命週期**：skillPaths 直接指向 state-pinned cache entry，無 materialize 副本（ADR 0001 裁定；unpinned eviction 不影響使用中 entry）。
2. **Fence/reload 語意**：discovery 與 Attempt Fence / Runtime Application receipt 完全解耦——applied 維持 state-level 語意，exposure 不寫 receipt。
3. **Collision 歸屬**：Bridge 先行過濾至存活者；host 層名稱由 Pi 原生 first-wins layering 自然保留（Bridge 貢獻路徑晚於預設載入）。