### PR TITLE
refactor: Global-only——Schema v2 + WAL migration 剝除 scopeOverrides（#63）

### DIFF
--- a/extensions/pi/ui-strings.ts
+++ b/extensions/pi/ui-strings.ts
@@ -483,6 +483,7 @@ const zhTW = {
   'finding.JOURNAL-02': 'Receipt Journal 有損毀行；已降級保留',
   'finding.PERSIST-01': 'Bridge State 不可讀或已損毀（Persistence Indeterminate）',
   'finding.SCHEMA-01': 'Bridge State schema 版本未知（不相容）；請更新 Bridge Package',
+  'finding.MIGRATE-01': 'v1→v2 遷移時剝除既有非空 scopeOverrides（Project Scope 已退休）',
   'finding.RECON-01': '需要 Startup Reconciliation',
 } as const;
 

--- a/src/bridge-state/migrate.ts
+++ b/src/bridge-state/migrate.ts
@@ -14,17 +14,40 @@
 import { closeSync, existsSync, fsyncSync, mkdirSync, openSync, readFileSync, unlinkSync, writeSync } from 'node:fs';
 import { dirname } from 'node:path';
 
+import { scopeOverridesStrippedFinding, type ValidationFinding } from '../registration/findings.js';
 import { atomicWriteFile } from './atomic.js';
 import { getWalPath } from './paths.js';
 import { parseJson } from './schema.js';
 import { CURRENT_SCHEMA_VERSION, type BridgeState, createEmptyState } from './types.js';
 
 /** Known forward migrations: fromVersion -> migrator. Only migrations listed here are supported. */
-type Migrator = (state: BridgeState) => BridgeState;
+type MigratorResult = { state: BridgeState; findings?: ValidationFinding[] } | BridgeState;
+type Migrator = (state: any) => MigratorResult;
 
 const MIGRATIONS: Record<number, Migrator> = {
-  // Future: 1 -> 2 example
-  // 1: (state) => ({ ...state, schemaVersion: 2, registrations: state.registrations.map(...) })
+  1: (state: any) => {
+    const findings: ValidationFinding[] = [];
+    const hadOverrides = Array.isArray(state.scopeOverrides) && state.scopeOverrides.length > 0;
+    if (hadOverrides) {
+      findings.push(scopeOverridesStrippedFinding(state.scopeOverrides.length));
+    }
+    const cloned = structuredClone(state);
+    delete cloned.scopeOverrides;
+    cloned.schemaVersion = 2;
+    // Normalize Installation IDs: strip retired 'global/' scope prefix if present
+    if (Array.isArray(cloned.installations)) {
+      cloned.installations = cloned.installations.map((inst: any) => {
+        if (typeof inst === 'object' && inst !== null && typeof inst.id === 'string' && inst.id.startsWith('global/')) {
+          return {
+            ...inst,
+            id: inst.pluginId ?? inst.id.slice('global/'.length),
+          };
+        }
+        return inst;
+      });
+    }
+    return { state: cloned, findings };
+  },
 };
 
 export interface MigrationResult {
@@ -36,6 +59,7 @@ export interface MigrationResult {
   toVersion?: number;
   error?: string;
   code?: 'INCOMPATIBLE_NEWER' | 'UNKNOWN_OLD_VERSION' | 'MIGRATION_FAILED' | 'CORRUPTED' | 'DOWNGRADE_BLOCKED';
+  findings?: ValidationFinding[];
 }
 
 /**
@@ -50,7 +74,7 @@ export function migrateForward(state: BridgeState): MigrationResult {
   const from = state.schemaVersion;
 
   if (from === CURRENT_SCHEMA_VERSION) {
-    return { ok: true, state, migrated: false, fromVersion: from, toVersion: CURRENT_SCHEMA_VERSION };
+    return { ok: true, state, migrated: false, fromVersion: from, toVersion: CURRENT_SCHEMA_VERSION, findings: [] };
   }
 
   if (!Number.isInteger(from) || from < 1) {
@@ -70,8 +94,9 @@ export function migrateForward(state: BridgeState): MigrationResult {
   }
 
   // from < CURRENT: need forward chain
-  let cur: BridgeState = structuredClone(state);
+  let cur: any = structuredClone(state);
   let version = from;
+  const allFindings: ValidationFinding[] = [];
   while (version < CURRENT_SCHEMA_VERSION) {
     const migrator = MIGRATIONS[version];
     if (!migrator) {
@@ -82,7 +107,15 @@ export function migrateForward(state: BridgeState): MigrationResult {
       };
     }
     try {
-      cur = migrator(cur);
+      const res = migrator(cur);
+      if (typeof res === 'object' && res !== null && 'state' in res) {
+        cur = res.state;
+        if (res.findings && res.findings.length > 0) {
+          allFindings.push(...res.findings);
+        }
+      } else {
+        cur = res;
+      }
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       return {
@@ -102,7 +135,7 @@ export function migrateForward(state: BridgeState): MigrationResult {
     version = cur.schemaVersion;
   }
 
-  return { ok: true, state: cur, migrated: true, fromVersion: from, toVersion: CURRENT_SCHEMA_VERSION };
+  return { ok: true, state: cur as BridgeState, migrated: true, fromVersion: from, toVersion: CURRENT_SCHEMA_VERSION, findings: allFindings };
 }
 
 /**

--- a/src/bridge-state/repair.ts
+++ b/src/bridge-state/repair.ts
@@ -287,6 +287,8 @@ export async function repairBridgeState(
 
         const stateRevision = stateRead.state!.stateRevision;
         const journalFindings = journal.isDegraded ? journal.findings : [];
+        const stateFindings = stateRead.findings ?? [];
+        const allFindings = [...journalFindings, ...stateFindings];
         const receipt = createReceipt({
           kind: 'State Repair',
           operation: 'Repair State',
@@ -295,8 +297,8 @@ export async function repairBridgeState(
           observedStateRevision: stateRevision,
           durableOutcome: 'unchanged',
           runtimeOutcome: 'none',
-          summary: journalFindings.length > 0 ? 'Completed with diagnostics' : 'Completed',
-          findings: journalFindings,
+          summary: allFindings.length > 0 ? 'Completed with diagnostics' : 'Completed',
+          findings: allFindings,
           recoversReceiptId: indetChain?.rootReceiptId,
         });
         const committed = await commitJournalRepair(

--- a/src/bridge-state/schema.ts
+++ b/src/bridge-state/schema.ts
@@ -19,7 +19,7 @@ export function validateSchema(parsed: unknown): SchemaValidation {
       ok: false,
       code: 'INVALID_SCHEMA',
       error:
-        'Invalid Bridge State: expected { schemaVersion:number, stateRevision:string, registrations:[], installations:[], scopeOverrides:[] }',
+        'Invalid Bridge State: expected { schemaVersion:number, stateRevision:string, registrations:[], installations:[] }',
     };
   }
 
@@ -52,7 +52,6 @@ export function validateSchema(parsed: unknown): SchemaValidation {
     };
   }
 
-  // scopeOverrides only meaningful for project, but global may have empty — allow both
   // registrations/installations elements are not deeply validated at scaffold level
 
   return { ok: true };

--- a/src/bridge-state/store.ts
+++ b/src/bridge-state/store.ts
@@ -127,7 +127,7 @@ function readBridgeStateUnderFileLock(statePath: string): ReadResult {
       raw: parsed.value,
     };
   }
-  return { status: 'ok', state: migration.state };
+  return { status: 'ok', state: migration.state, findings: migration.findings };
 }
 
 async function tryReadBridgeStateUnderFileLock(
@@ -375,7 +375,7 @@ export async function commitBridgeState(
     draft.schemaVersion = CURRENT_SCHEMA_VERSION;
     if (!Array.isArray(draft.registrations)) draft.registrations = [];
     if (!Array.isArray(draft.installations)) draft.installations = [];
-    if (!Array.isArray(draft.scopeOverrides)) draft.scopeOverrides = [];
+    delete (draft as any).scopeOverrides;
 
     // Bump revision monotonically
     const newRevision = nextRevision(current.stateRevision);

--- a/src/bridge-state/types.ts
+++ b/src/bridge-state/types.ts
@@ -11,7 +11,9 @@
  * will strip it entirely.
  */
 
-export const CURRENT_SCHEMA_VERSION = 1;
+import type { ValidationFinding } from '../registration/findings.js';
+
+export const CURRENT_SCHEMA_VERSION = 2;
 
 /** Opaque monotonic identifier. Stored as decimal string, incremented on each successful commit. */
 export type StateRevision = string;
@@ -60,7 +62,7 @@ export interface Registration {
 
 export interface Installation {
   /** Canonical Installation ID = Plugin ID itself (stable across version/path changes).
-   *  Legacy documents may still carry the retired 'global/<pluginId>' form; both resolve. */
+   *  Legacy documents may still carry the retired 'global/<pluginId>' form; normalized in v2. */
   id: string;
   /** Canonical Plugin ID = Marketplace ID + manifest name */
   pluginId: string;
@@ -79,7 +81,7 @@ export interface Installation {
 }
 
 export interface ScopeOverride {
-  /** Retired (issue #59) — kept only so pre-retirement project documents still parse. */
+  /** Retired (issue #59 / #63) — legacy type kept for v1 migration parsing. */
   kind: 'registration' | 'installation';
   /** Canonical Registration ID or Installation ID being suppressed */
   targetId: string;
@@ -92,8 +94,6 @@ export interface BridgeState {
   stateRevision: StateRevision;
   registrations: Registration[];
   installations: Installation[];
-  /** Retired (issue #59) — always empty in practice; legacy entries are ignored at read time. */
-  scopeOverrides: ScopeOverride[];
 }
 
 export type ReadStatus = 'ok' | 'corrupted' | 'incompatible' | 'missing';
@@ -108,6 +108,8 @@ export interface ReadResult {
   raw?: unknown;
   /** Whether state was reconstructed as empty due to missing file */
   isEmptyInit?: boolean;
+  /** Migration diagnostics / findings if any */
+  findings?: ValidationFinding[];
 }
 
 export interface WriteResult {
@@ -138,7 +140,6 @@ export function createEmptyState(): BridgeState {
     stateRevision: '0',
     registrations: [],
     installations: [],
-    scopeOverrides: [],
   };
 }
 
@@ -150,8 +151,7 @@ export function isBridgeState(value: unknown): value is BridgeState {
     typeof o.schemaVersion === 'number' &&
     typeof o.stateRevision === 'string' &&
     Array.isArray(o.registrations) &&
-    Array.isArray(o.installations) &&
-    Array.isArray(o.scopeOverrides)
+    Array.isArray(o.installations)
   );
 }
 

--- a/src/registration/findings.ts
+++ b/src/registration/findings.ts
@@ -86,6 +86,7 @@ export const RULE = {
   RECEIPT_CORRUPT: 'JOURNAL-02',
   STATE_CORRUPT: 'PERSIST-01',
   STATE_SCHEMA_UNKNOWN: 'SCHEMA-01',
+  SCOPE_OVERRIDES_STRIPPED: 'MIGRATE-01',
   RECONCILIATION_REQUIRED: 'RECON-01',
 } as const;
 
@@ -139,6 +140,7 @@ export const CODE = {
   RECEIPT_CORRUPT: 'RECEIPT_CORRUPT',
   STATE_CORRUPT: 'STATE_CORRUPT',
   STATE_SCHEMA_UNKNOWN: 'STATE_SCHEMA_UNKNOWN',
+  SCOPE_OVERRIDES_STRIPPED: 'SCOPE_OVERRIDES_STRIPPED',
   RECONCILIATION_REQUIRED: 'RECONCILIATION_REQUIRED',
 } as const;
 
@@ -178,3 +180,15 @@ export function notice(p: Omit<ValidationFinding, 'classification'>): Validation
 export function hasBlocking(findings: ValidationFinding[]): boolean {
   return findings.some((f) => f.classification === 'blocking');
 }
+
+export function scopeOverridesStrippedFinding(count: number): ValidationFinding {
+  return warning({
+    code: CODE.SCOPE_OVERRIDES_STRIPPED,
+    phase: 'persistence',
+    target: 'registration',
+    pointer: '/scopeOverrides',
+    rule: RULE.SCOPE_OVERRIDES_STRIPPED,
+    outcome: `Stripped ${count} legacy scopeOverride(s) during schema v1 → v2 migration (Project Scope retired)`,
+  });
+}
+

--- a/tests/acceptance/matrix.test.ts
+++ b/tests/acceptance/matrix.test.ts
@@ -45,8 +45,8 @@ describe('Acceptance matrix — per-row gates (smoke that each layer is covered)
   });
 
   it('integration row — synthetic: Bridge State WAL atomic commit exercised', async () => {
-    const { createEmptyState } = await import('../../src/bridge-state/types.js');
-    expect(createEmptyState().schemaVersion).toBe(1);
+    const { createEmptyState, CURRENT_SCHEMA_VERSION } = await import('../../src/bridge-state/types.js');
+    expect(createEmptyState().schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
   });
 
   it('E2E row — synthetic: TUI aggregated command highest seam is exposed', async () => {

--- a/tests/e2e/tui-lifecycle-matrix.test.ts
+++ b/tests/e2e/tui-lifecycle-matrix.test.ts
@@ -16,7 +16,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
-import { createEmptyState, type BridgeState } from '../../src/bridge-state/types.js';
+import { createEmptyState, CURRENT_SCHEMA_VERSION, type BridgeState } from '../../src/bridge-state/types.js';
 import { writeBridgeState, readBridgeState } from '../../src/bridge-state/store.js';
 import { acquireAttemptFence } from '../../src/registration/fence.js';
 import { formatThreeOrthogonalReport } from '../../src/registration/receipt.js';
@@ -54,7 +54,7 @@ describe('E2E TUI highest seam — lifecycle / collision / cache (Issue #24)', (
   it('Bridge State is a single Global document empty on scaffold', async () => {
     const global = await readBridgeState({ agentDir: env.agentDir });
     expect(global.status).toBe('missing');
-    expect(global.state!.schemaVersion).toBe(1);
+    expect(global.state!.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
   });
 
   it('Findings are sorted class→phase→target→pointer→rule with stable rule codes (prototype decision)', async () => {

--- a/tests/integration/startup-reconciliation.test.ts
+++ b/tests/integration/startup-reconciliation.test.ts
@@ -7,6 +7,7 @@ import { runStartupReconciliation } from '../../src/reconciliation/startup.js';
 import { appendReceipt, readReceiptJournal } from '../../src/journal/journal.js';
 import { createReceipt } from '../../src/registration/receipt.js';
 import { getGlobalStatePath } from '../../src/bridge-state/paths.js';
+import { CURRENT_SCHEMA_VERSION } from '../../src/bridge-state/types.js';
 
 const GLOBAL_PENDING_RECEIPT = 'rcpt_40000000-0000-4000-8000-000000000001';
 
@@ -41,11 +42,10 @@ describe('Integration — Startup Reconciliation (Global-only)', () => {
     writeFileSync(
       globalStatePath,
       JSON.stringify({
-        schemaVersion: 1,
+        schemaVersion: CURRENT_SCHEMA_VERSION,
         stateRevision: '2',
         registrations: [{ id: 'reg1', alias: 'market-1' }],
         installations: [{ id: 'weather', pluginId: 'weather', installationState: 'enabled' }],
-        scopeOverrides: [],
       }),
       'utf-8',
     );
@@ -81,11 +81,10 @@ describe('Integration — Startup Reconciliation (Global-only)', () => {
     writeFileSync(
       globalStatePath,
       JSON.stringify({
-        schemaVersion: 1,
+        schemaVersion: CURRENT_SCHEMA_VERSION,
         stateRevision: '1',
         registrations: [],
         installations: [{ id: 'tools', pluginId: 'tools', installationState: 'enabled' }],
-        scopeOverrides: [],
       }),
       'utf-8',
     );

--- a/tests/unit/bridge-state/migrate.test.ts
+++ b/tests/unit/bridge-state/migrate.test.ts
@@ -1,29 +1,147 @@
-import { describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { CURRENT_SCHEMA_VERSION } from '../../../src/bridge-state/types.js';
-import { isDowngradeAttempt, migrateForward } from '../../../src/bridge-state/migrate.js';
+import { CURRENT_SCHEMA_VERSION, type BridgeState } from '../../../src/bridge-state/types.js';
+import {
+  commitMigratedState,
+  isDowngradeAttempt,
+  migrateForward,
+  recoverWalIfNeeded,
+  _internal,
+} from '../../../src/bridge-state/migrate.js';
+import { CODE, RULE } from '../../../src/registration/findings.js';
 
-describe('WAL Migration — schemaVersion binding (Issue #24)', () => {
-  it('migrateForward: CURRENT is no-op (no WAL)', () => {
-    const state = { schemaVersion: CURRENT_SCHEMA_VERSION, stateRevision: '1', registrations: [], installations: [], scopeOverrides: [] } as any;
+describe('WAL Migration — schemaVersion binding & v1→v2 migration (Issue #63)', () => {
+  let tmpRoot: string;
+  let statePath: string;
+
+  beforeEach(() => {
+    tmpRoot = join(tmpdir(), `migrate-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    statePath = join(tmpRoot, 'state.json');
+    mkdirSync(tmpRoot, { recursive: true });
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    } catch {}
+  });
+
+  it('schemaVersion is bound to package version (CURRENT_SCHEMA_VERSION is 2)', () => {
+    expect(CURRENT_SCHEMA_VERSION).toBe(2);
+  });
+
+  it('migrateForward: CURRENT (v2) is no-op (no WAL)', () => {
+    const state: BridgeState = {
+      schemaVersion: CURRENT_SCHEMA_VERSION,
+      stateRevision: '1',
+      registrations: [],
+      installations: [],
+    };
     const res = migrateForward(state);
     expect(res.ok).toBe(true);
     expect(res.migrated).toBe(false);
+    expect(res.fromVersion).toBe(2);
+    expect(res.toVersion).toBe(2);
+    expect(res.findings).toEqual([]);
   });
 
-  it('migrateForward: newer version is incompatible (no auto-migrate)', () => {
-    const state = { schemaVersion: CURRENT_SCHEMA_VERSION + 1, stateRevision: '1', registrations: [], installations: [], scopeOverrides: [] } as any;
+  it('migrateForward: v1 with empty scopeOverrides migrates forward to v2 without findings', () => {
+    const v1State = {
+      schemaVersion: 1,
+      stateRevision: '5',
+      registrations: [{ id: 'reg-1', alias: 'marketplace-1' }],
+      installations: [{ id: 'inst-1', pluginId: 'inst-1', installationState: 'enabled' }],
+      scopeOverrides: [],
+    } as any;
+
+    const res = migrateForward(v1State);
+    expect(res.ok).toBe(true);
+    expect(res.migrated).toBe(true);
+    expect(res.fromVersion).toBe(1);
+    expect(res.toVersion).toBe(2);
+    expect(res.state?.schemaVersion).toBe(2);
+    expect(res.state?.stateRevision).toBe('5');
+    expect(res.state?.registrations).toEqual([{ id: 'reg-1', alias: 'marketplace-1' }]);
+    expect(res.state?.installations).toEqual([{ id: 'inst-1', pluginId: 'inst-1', installationState: 'enabled' }]);
+    expect((res.state as any).scopeOverrides).toBeUndefined();
+    expect(res.findings).toEqual([]);
+  });
+
+  it('migrateForward: v1 with non-empty scopeOverrides strips overrides and records diagnostic finding', () => {
+    const v1State = {
+      schemaVersion: 1,
+      stateRevision: '3',
+      registrations: [{ id: 'reg-1', alias: 'marketplace-1' }],
+      installations: [{ id: 'inst-1', pluginId: 'inst-1', installationState: 'enabled' }],
+      scopeOverrides: [
+        { kind: 'registration', targetId: 'reg-old' },
+        { kind: 'installation', targetId: 'inst-old' },
+      ],
+    } as any;
+
+    const res = migrateForward(v1State);
+    expect(res.ok).toBe(true);
+    expect(res.migrated).toBe(true);
+    expect(res.fromVersion).toBe(1);
+    expect(res.toVersion).toBe(2);
+    expect(res.state?.schemaVersion).toBe(2);
+    expect(res.state?.stateRevision).toBe('3');
+    expect((res.state as any).scopeOverrides).toBeUndefined();
+
+    // Verify non-blocking warning finding
+    expect(res.findings).toHaveLength(1);
+    const finding = res.findings![0];
+    expect(finding.code).toBe(CODE.SCOPE_OVERRIDES_STRIPPED);
+    expect(finding.rule).toBe(RULE.SCOPE_OVERRIDES_STRIPPED);
+    expect(finding.classification).toBe('warning');
+    expect(finding.phase).toBe('persistence');
+    expect(finding.pointer).toBe('/scopeOverrides');
+    expect(finding.outcome).toContain('Stripped 2 legacy scopeOverride(s)');
+  });
+
+  it('migrateForward: v1 with legacy global/ prefixed installation ID normalizes to pluginId', () => {
+    const v1State = {
+      schemaVersion: 1,
+      stateRevision: '4',
+      registrations: [{ id: 'reg-1', alias: 'marketplace-1' }],
+      installations: [
+        { id: 'global/market-1/tool-a', pluginId: 'market-1/tool-a', installationState: 'enabled' },
+        { id: 'market-1/tool-b', pluginId: 'market-1/tool-b', installationState: 'disabled' },
+      ],
+      scopeOverrides: [],
+    } as any;
+
+    const res = migrateForward(v1State);
+    expect(res.ok).toBe(true);
+    expect(res.state?.installations).toEqual([
+      { id: 'market-1/tool-a', pluginId: 'market-1/tool-a', installationState: 'enabled' },
+      { id: 'market-1/tool-b', pluginId: 'market-1/tool-b', installationState: 'disabled' },
+    ]);
+  });
+
+  it('migrateForward: newer version (> 2) is incompatible (fail-closed, no auto-migrate)', () => {
+    const state = {
+      schemaVersion: CURRENT_SCHEMA_VERSION + 1,
+      stateRevision: '1',
+      registrations: [],
+      installations: [],
+    } as any;
     const res = migrateForward(state);
     expect(res.ok).toBe(false);
     expect(res.code).toBe('INCOMPATIBLE_NEWER');
     expect(res.error).toMatch(/requires newer Bridge Package/);
   });
 
-  it('migrateForward: older version without path is UNKNOWN_OLD_VERSION (fail-closed)', () => {
-    // CURRENT is 1, so testing migration from 0 should be corrupted; but simulate older-than-current with missing path
-    // If we bump CURRENT to 2 later, this will exercise the unknown path; for now, fabricate by temporarily making CURRENT=2 scenario
-    // Instead, we directly test corrupted case
-    const state = { schemaVersion: 0, stateRevision: '0', registrations: [], installations: [], scopeOverrides: [] } as any;
+  it('migrateForward: invalid schemaVersion 0 is treated as corrupted', () => {
+    const state = {
+      schemaVersion: 0,
+      stateRevision: '0',
+      registrations: [],
+      installations: [],
+    } as any;
     const res = migrateForward(state);
     expect(res.ok).toBe(false);
     expect(res.code).toBe('CORRUPTED');
@@ -31,13 +149,81 @@ describe('WAL Migration — schemaVersion binding (Issue #24)', () => {
 
   it('isDowngradeAttempt: older target over newer durable is blocked (never write back)', () => {
     expect(isDowngradeAttempt(2, 1)).toBe(true);
-    expect(isDowngradeAttempt(1, 1)).toBe(false);
+    expect(isDowngradeAttempt(3, 2)).toBe(true);
+    expect(isDowngradeAttempt(2, 2)).toBe(false);
     expect(isDowngradeAttempt(1, 2)).toBe(false);
   });
 
-  it('schemaVersion is bound to package version — downgrade guard is closed', () => {
-    // Package version 0.1.0 binds CURRENT_SCHEMA_VERSION=1; a file at version 1 must never be overwritten by a 0-branch build.
-    // This is verified by store.ts refusing to commit with an older schemaVersion.
-    expect(CURRENT_SCHEMA_VERSION).toBe(1);
+  it('commitMigratedState writes WAL, updates state file atomically, and cleans WAL', () => {
+    const migratedState: BridgeState = {
+      schemaVersion: 2,
+      stateRevision: '10',
+      registrations: [{ id: 'reg-1', alias: 'm1' }],
+      installations: [],
+    };
+
+    const committed = commitMigratedState(statePath, migratedState, 1, '10');
+    expect(committed).toBe(true);
+    expect(existsSync(statePath)).toBe(true);
+    expect(existsSync(`${statePath}.wal`)).toBe(false);
+
+    const written = JSON.parse(readFileSync(statePath, 'utf-8'));
+    expect(written.schemaVersion).toBe(2);
+    expect(written.stateRevision).toBe('10');
+  });
+
+  it('recoverWalIfNeeded replays WAL when state file still holds old version after crash', () => {
+    const oldState = {
+      schemaVersion: 1,
+      stateRevision: '3',
+      registrations: [],
+      installations: [],
+    } as any;
+    const targetState: BridgeState = {
+      schemaVersion: 2,
+      stateRevision: '3',
+      registrations: [],
+      installations: [],
+    };
+
+    writeFileSync(statePath, JSON.stringify(oldState), 'utf-8');
+    _internal.writeWalSync(statePath, {
+      fromVersion: 1,
+      toVersion: 2,
+      fromRevision: '3',
+      targetState,
+      createdAt: new Date().toISOString(),
+    });
+
+    const rec = recoverWalIfNeeded(statePath, oldState);
+    expect(rec.recovered).toBe(true);
+    expect(rec.state?.schemaVersion).toBe(2);
+    expect(existsSync(`${statePath}.wal`)).toBe(false);
+
+    const written = JSON.parse(readFileSync(statePath, 'utf-8'));
+    expect(written.schemaVersion).toBe(2);
+  });
+
+  it('recoverWalIfNeeded cleans WAL when state file was already committed', () => {
+    const targetState: BridgeState = {
+      schemaVersion: 2,
+      stateRevision: '4',
+      registrations: [],
+      installations: [],
+    };
+
+    writeFileSync(statePath, JSON.stringify(targetState), 'utf-8');
+    _internal.writeWalSync(statePath, {
+      fromVersion: 1,
+      toVersion: 2,
+      fromRevision: '4',
+      targetState,
+      createdAt: new Date().toISOString(),
+    });
+
+    const rec = recoverWalIfNeeded(statePath, targetState);
+    expect(rec.recovered).toBe(false);
+    expect(existsSync(`${statePath}.wal`)).toBe(false);
   });
 });
+

--- a/tests/unit/bridge-state/repair.test.ts
+++ b/tests/unit/bridge-state/repair.test.ts
@@ -669,4 +669,37 @@ describe('Repair State', () => {
       expect.objectContaining({ code: 'RECEIPT_PERSISTENCE_FAILED' }),
     ]));
   });
+
+  it('surfaces v1→v2 migration finding in Repair State receipt when non-empty scopeOverrides are stripped', async () => {
+    const statePath = getGlobalStatePath(agentDir);
+    mkdirSync(join(agentDir, 'codex-marketplace'), { recursive: true });
+    writeFileSync(
+      statePath,
+      JSON.stringify({
+        schemaVersion: 1,
+        stateRevision: '5',
+        registrations: [{ id: 'reg-a', alias: 'marketplace-a' }],
+        installations: [],
+        scopeOverrides: [{ kind: 'registration', targetId: 'reg-b' }],
+      }),
+      'utf-8',
+    );
+
+    const res = await repairBridgeState({ agentDir });
+    expect(res.success).toBe(true);
+    expect(res.receipt.summary).toBe('Completed with diagnostics');
+    expect(res.receipt.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'SCOPE_OVERRIDES_STRIPPED',
+          rule: 'MIGRATE-01',
+          classification: 'warning',
+        }),
+      ]),
+    );
+
+    const onDisk = JSON.parse(readFileSync(statePath, 'utf-8'));
+    expect(onDisk.schemaVersion).toBe(2);
+    expect(onDisk.scopeOverrides).toBeUndefined();
+  });
 });

--- a/tests/unit/extensions/bridge-ledger.test.ts
+++ b/tests/unit/extensions/bridge-ledger.test.ts
@@ -92,11 +92,10 @@ function snapshot(): BridgeLedgerSnapshot {
     global: {
       status: 'ok',
       state: {
-        schemaVersion: 1,
+        schemaVersion: 2,
         stateRevision: '12',
         registrations: [registration],
         installations: [installation, disabledInstallation],
-        scopeOverrides: [],
       },
     },
     journal: { ...emptyJournal(), receipts: [receipt] },

--- a/tests/unit/projection/effective-state.test.ts
+++ b/tests/unit/projection/effective-state.test.ts
@@ -95,7 +95,7 @@ describe('Effective State — retired scope dimensions (Global-only)', () => {
         { kind: 'registration', targetId: REG },
         { kind: 'installation', targetId: 'reg-b/keep' },
       ],
-    });
+    } as any);
     const effective = computeEffectiveState(legacy);
     expect(effective.registrations).toEqual([]);
     // Overrides carry no records themselves; nothing is suppressed or excluded.
@@ -108,7 +108,7 @@ describe('Effective State — retired scope dimensions (Global-only)', () => {
         registrations: populated.registrations,
         installations: populated.installations,
         scopeOverrides: [{ kind: 'registration', targetId: REG_2 }],
-      }),
+      } as any),
     );
     expect(withLegacy).toEqual(plain);
   });

--- a/tests/unit/reconciliation/startup.test.ts
+++ b/tests/unit/reconciliation/startup.test.ts
@@ -7,6 +7,7 @@ import { runStartupReconciliation } from '../../../src/reconciliation/startup.js
 import { appendReceipt, readReceiptJournal } from '../../../src/journal/journal.js';
 import { createReceipt } from '../../../src/registration/receipt.js';
 import { getGlobalStatePath } from '../../../src/bridge-state/paths.js';
+import { CURRENT_SCHEMA_VERSION } from '../../../src/bridge-state/types.js';
 
 const PENDING_RECEIPT = 'rcpt_50000000-0000-4000-8000-000000000001';
 
@@ -55,11 +56,10 @@ describe('Startup Reconciliation — Global-only', () => {
     writeFileSync(
       statePath,
       JSON.stringify({
-        schemaVersion: 1,
+        schemaVersion: CURRENT_SCHEMA_VERSION,
         stateRevision: '1',
         registrations: [{ id: 'reg1', alias: 'acme' }],
         installations: [],
-        scopeOverrides: [],
       }),
       'utf-8',
     );
@@ -114,11 +114,10 @@ describe('Startup Reconciliation — Global-only', () => {
     writeFileSync(
       getGlobalStatePath(agentDir),
       JSON.stringify({
-        schemaVersion: 1,
+        schemaVersion: CURRENT_SCHEMA_VERSION,
         stateRevision: '1',
         registrations: [{ id: 'reg1', alias: 'acme' }],
         installations: [{ id: 'acme/plugin', pluginId: 'acme/plugin', installationState: 'enabled' }],
-        scopeOverrides: [],
       }),
       'utf-8',
     );

--- a/tests/unit/store.test.ts
+++ b/tests/unit/store.test.ts
@@ -12,7 +12,7 @@ import {
   writeBridgeState,
 } from '../../src/bridge-state/store.js';
 import { getGlobalStatePath, getAgentDir } from '../../src/bridge-state/paths.js';
-import { CURRENT_SCHEMA_VERSION, createEmptyState } from '../../src/bridge-state/types.js';
+import { CURRENT_SCHEMA_VERSION, createEmptyState, type BridgeState } from '../../src/bridge-state/types.js';
 
 const EXITING_LOCK_OWNER = String.raw`
   const { closeSync, fsyncSync, openSync, writeFileSync } = require('node:fs');
@@ -166,13 +166,12 @@ describe('Bridge State store — single Global document, atomicity, corruption',
     expect(final.state!.stateRevision).toBe('5');
   });
 
-  it('persists only authoritative fields (no Effective State / catalogs)', async () => {
+  it('persists only authoritative fields (no Effective State / catalogs / scopeOverrides in v2)', async () => {
     await commitBridgeState(() => ({
         schemaVersion: CURRENT_SCHEMA_VERSION,
         stateRevision: '0', // will be bumped
         registrations: [{ id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', alias: 'test' }],
         installations: [{ id: 'test/plugin', pluginId: 'test/plugin', installationState: 'enabled' }],
-        scopeOverrides: [],
       }),
       { agentDir: env.agentDir },
     );
@@ -182,8 +181,8 @@ describe('Bridge State store — single Global document, atomicity, corruption',
     expect(raw.stateRevision).toBe('1');
     expect(raw.registrations).toHaveLength(1);
     expect(raw.installations).toHaveLength(1);
-    // Retired field stays an empty array until the schema v2 migration strips it (#63)
-    expect(raw.scopeOverrides).toEqual([]);
+    // Scope Overrides stripped in schema v2 (#63)
+    expect(raw.scopeOverrides).toBeUndefined();
     // No Effective State fields
     expect(raw.effectiveState).toBeUndefined();
     expect(raw.catalog).toBeUndefined();
@@ -288,17 +287,77 @@ describe('Bridge State store — single Global document, atomicity, corruption',
   });
 
   it('writeBridgeState directly respects atomicity and version', async () => {
-    const state = {
+    const state: BridgeState = {
       schemaVersion: CURRENT_SCHEMA_VERSION,
       stateRevision: '1',
       registrations: [],
       installations: [],
-      scopeOverrides: [],
     };
     const w = await writeBridgeState(state, { agentDir: env.agentDir });
     expect(w.success).toBe(true);
     const r = await readBridgeState({ agentDir: env.agentDir });
     expect(r.state!.stateRevision).toBe('1');
+  });
+
+  it('automatically WAL-migrates v1 file with empty scopeOverrides to v2 on read', async () => {
+    const gPath = getGlobalStatePath(env.agentDir);
+    mkdirSync(join(env.agentDir, 'codex-marketplace'), { recursive: true });
+    writeFileSync(
+      gPath,
+      JSON.stringify({
+        schemaVersion: 1,
+        stateRevision: '10',
+        registrations: [{ id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', alias: 'market-a' }],
+        installations: [{ id: 'global/plugin-x', pluginId: 'plugin-x', installationState: 'enabled' }],
+        scopeOverrides: [],
+      }),
+      'utf-8',
+    );
+
+    const res = await readBridgeState({ agentDir: env.agentDir });
+    expect(res.status).toBe('ok');
+    expect(res.state?.schemaVersion).toBe(2);
+    expect(res.state?.stateRevision).toBe('10');
+    expect(res.state?.registrations).toHaveLength(1);
+    expect(res.state?.installations[0].id).toBe('plugin-x');
+    expect((res.state as any)?.scopeOverrides).toBeUndefined();
+    expect(res.findings).toEqual([]);
+
+    // File on disk must now be schemaVersion 2 without WAL remaining
+    const onDisk = JSON.parse(readFileSync(gPath, 'utf-8'));
+    expect(onDisk.schemaVersion).toBe(2);
+    expect(onDisk.scopeOverrides).toBeUndefined();
+    expect(existsSync(`${gPath}.wal`)).toBe(false);
+  });
+
+  it('automatically WAL-migrates v1 file with non-empty scopeOverrides to v2 and surfaces diagnostic finding', async () => {
+    const gPath = getGlobalStatePath(env.agentDir);
+    mkdirSync(join(env.agentDir, 'codex-marketplace'), { recursive: true });
+    writeFileSync(
+      gPath,
+      JSON.stringify({
+        schemaVersion: 1,
+        stateRevision: '20',
+        registrations: [{ id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', alias: 'market-b' }],
+        installations: [],
+        scopeOverrides: [{ kind: 'registration', targetId: 'reg-legacy' }],
+      }),
+      'utf-8',
+    );
+
+    const res = await readBridgeState({ agentDir: env.agentDir });
+    expect(res.status).toBe('ok');
+    expect(res.state?.schemaVersion).toBe(2);
+    expect(res.state?.stateRevision).toBe('20');
+    expect((res.state as any)?.scopeOverrides).toBeUndefined();
+    expect(res.findings).toHaveLength(1);
+    expect(res.findings![0].rule).toBe('MIGRATE-01');
+    expect(res.findings![0].classification).toBe('warning');
+
+    const onDisk = JSON.parse(readFileSync(gPath, 'utf-8'));
+    expect(onDisk.schemaVersion).toBe(2);
+    expect(onDisk.scopeOverrides).toBeUndefined();
+    expect(existsSync(`${gPath}.wal`)).toBe(false);
   });
 
   it('Stale State Revision rejection releases the lock — subsequent commit with correct revision succeeds and no *.lock remains (issue #24 fix)', async () => {


### PR DESCRIPTION
## Parent

Closes #63（parent: #58）

## What changed

Schema 升版與 WAL forward migration（#58 決策 D3）：

### Schema 升版與型別定義
- `CURRENT_SCHEMA_VERSION` 升至 **2**。
- `BridgeState` 與 `createEmptyState` 正式剝除 `scopeOverrides` 欄位；新寫入狀態檔案不再包含 `scopeOverrides`。
- `isBridgeState` 與 `validateSchema` 調整為支援 Schema v2，未知/較新版本維持 fail-closed `incompatible`。

### WAL Forward Migration (v1 → v2)
- 實作 v1 → v2 前向遷移：
  - 剝除 `scopeOverrides` 欄位。
  - **非空 overrides 一律剝除並記錄 diagnostic finding**（`CODE.SCOPE_OVERRIDES_STRIPPED` / `MIGRATE-01`，warning 分類），不 fail-closed，避免卡死正常流程。
  - Installation ID 規格化：自動去除遺留之 `global/` 前綴，統一為 `pluginId`。
- 讀取時自動觸發 WAL 交易遷移並 fsync / atomic rename，中斷時具備 WAL 重播與自我修復保護。
- 降級寫回防護維持不變（`isDowngradeAttempt` 阻擋舊版覆寫新版檔案）。
- **D2／D3**：遷移全程僅針對 Global state 文件，完全不碰觸 `{cwd}/.pi/` 下任何檔案。

### 診斷與 Repair State 呈現
- `ReadResult` 支援回傳 migration findings。
- `repairBridgeState` 收據將包含遷移產生的 diagnostic findings，非空 overrides 剝除時呈現 `Completed with diagnostics`。
- `ui-strings.ts` 新增 `finding.MIGRATE-01` 本地化字串。

### 測試覆蓋
- `migrate.test.ts` 覆蓋 v1 空 overrides / 非空 overrides 遷移、Installation ID 正規化、WAL commit / replay / clean 與降級防護。
- `store.test.ts` 與 `repair.test.ts` 覆蓋讀取自動遷移與 Repair State 診斷回報。
- `npm run check` 全綠（typecheck + 49 files / 564 tests）。

## Out of scope

- README 改寫與 0.2.0 版本定錨（#64）