### PR TITLE
feat: Bridge State——Registration 新增 format 屬性與 v2→v3 遷移（#44）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `pi-codex-marketplace` are documented here. Format follow
 
 ## [Unreleased]
 
+### Changed
+- **Bridge State Schema v3 + format 屬性遷移** (#44)：`schemaVersion` 升為 `3`。
+  - `Registration` 記錄新增 Marketplace Format 屬性（`codex | claude`）——本票只鋪持久層地基，格式偵測與 claude 解析由後續票交付。
+  - v2 → v3 WAL migration 為既有 Registration 自動補上 `format=codex` 預設值，內容零損失（已宣告的 `codex | claude` 值原樣保留）。
+  - 新寫入的 Registration 可承載 `format=claude` 並正確回讀。
+
 ## [0.2.0] - 2026-08-26
 
 ### Removed (Breaking)

--- a/src/bridge-state/migrate.ts
+++ b/src/bridge-state/migrate.ts
@@ -48,6 +48,21 @@ const MIGRATIONS: Record<number, Migrator> = {
     }
     return { state: cloned, findings };
   },
+  2: (state: any) => {
+    // Issue #44 — registration `format` attribute (codex | claude) persistence foundation.
+    // Backfill a lossless 'codex' default onto every Registration missing a valid format; any
+    // already-declared 'codex' | 'claude' value is preserved untouched (no content loss).
+    const cloned = structuredClone(state);
+    if (Array.isArray(cloned.registrations)) {
+      cloned.registrations = cloned.registrations.map((reg: any) => {
+        if (typeof reg !== 'object' || reg === null) return reg;
+        if (reg.format === 'codex' || reg.format === 'claude') return reg;
+        return { ...reg, format: 'codex' };
+      });
+    }
+    cloned.schemaVersion = 3;
+    return { state: cloned };
+  },
 };
 
 export interface MigrationResult {

--- a/src/bridge-state/types.ts
+++ b/src/bridge-state/types.ts
@@ -11,15 +11,23 @@
 
 import type { ValidationFinding } from '../registration/findings.js';
 
-export const CURRENT_SCHEMA_VERSION = 2;
+export const CURRENT_SCHEMA_VERSION = 3;
 
 /** Opaque monotonic identifier. Stored as decimal string, incremented on each successful commit. */
 export type StateRevision = string;
+
+/** Marketplace Format — codex | claude (persistence foundation, issue #44).
+ *  Format detection / claude parsing is delivered by later tickets; the persistence
+ *  layer carries the value through and legacy registrations are backfilled to 'codex'
+ *  by the v2→v3 migration. Absence (pre-v3) always reads back as 'codex' after migration. */
+export type MarketplaceFormat = 'codex' | 'claude';
 
 /** Minimal shape for scaffold — later tickets extend with Source Key, Validation Snapshot, etc. */
 export interface Registration {
   /** Immutable lowercase UUIDv4, allocated before preflight */
   id: string;
+  /** Marketplace Format carried by this Registration. v2→v3 migration backfills 'codex' for legacy records. */
+  format?: MarketplaceFormat;
   /** Human-readable alias, derived from marketplace name */
   alias?: string;
   /** Declared marketplace name (kebab-case) */

--- a/tests/unit/bridge-state/migrate.test.ts
+++ b/tests/unit/bridge-state/migrate.test.ts
@@ -13,7 +13,7 @@ import {
 } from '../../../src/bridge-state/migrate.js';
 import { CODE, RULE } from '../../../src/registration/findings.js';
 
-describe('WAL Migration — schemaVersion binding & v1→v2 migration (Issue #63)', () => {
+describe('WAL Migration — schemaVersion binding & v1→v3 migration (Issue #63, #44)', () => {
   let tmpRoot: string;
   let statePath: string;
 
@@ -29,11 +29,11 @@ describe('WAL Migration — schemaVersion binding & v1→v2 migration (Issue #63
     } catch {}
   });
 
-  it('schemaVersion is bound to package version (CURRENT_SCHEMA_VERSION is 2)', () => {
-    expect(CURRENT_SCHEMA_VERSION).toBe(2);
+  it('schemaVersion is bound to package version (CURRENT_SCHEMA_VERSION is 3)', () => {
+    expect(CURRENT_SCHEMA_VERSION).toBe(3);
   });
 
-  it('migrateForward: CURRENT (v2) is no-op (no WAL)', () => {
+  it('migrateForward: CURRENT (v3) is no-op (no WAL)', () => {
     const state: BridgeState = {
       schemaVersion: CURRENT_SCHEMA_VERSION,
       stateRevision: '1',
@@ -43,12 +43,12 @@ describe('WAL Migration — schemaVersion binding & v1→v2 migration (Issue #63
     const res = migrateForward(state);
     expect(res.ok).toBe(true);
     expect(res.migrated).toBe(false);
-    expect(res.fromVersion).toBe(2);
-    expect(res.toVersion).toBe(2);
+    expect(res.fromVersion).toBe(3);
+    expect(res.toVersion).toBe(3);
     expect(res.findings).toEqual([]);
   });
 
-  it('migrateForward: v1 with empty scopeOverrides migrates forward to v2 without findings', () => {
+  it('migrateForward: v1 with empty scopeOverrides migrates forward to v3 without findings and backfills format=codex', () => {
     const v1State = {
       schemaVersion: 1,
       stateRevision: '5',
@@ -61,10 +61,10 @@ describe('WAL Migration — schemaVersion binding & v1→v2 migration (Issue #63
     expect(res.ok).toBe(true);
     expect(res.migrated).toBe(true);
     expect(res.fromVersion).toBe(1);
-    expect(res.toVersion).toBe(2);
-    expect(res.state?.schemaVersion).toBe(2);
+    expect(res.toVersion).toBe(3);
+    expect(res.state?.schemaVersion).toBe(3);
     expect(res.state?.stateRevision).toBe('5');
-    expect(res.state?.registrations).toEqual([{ id: 'reg-1', alias: 'marketplace-1' }]);
+    expect(res.state?.registrations).toEqual([{ id: 'reg-1', alias: 'marketplace-1', format: 'codex' }]);
     expect(res.state?.installations).toEqual([{ id: 'inst-1', pluginId: 'inst-1', installationState: 'enabled' }]);
     expect((res.state as any).scopeOverrides).toBeUndefined();
     expect(res.findings).toEqual([]);
@@ -86,9 +86,10 @@ describe('WAL Migration — schemaVersion binding & v1→v2 migration (Issue #63
     expect(res.ok).toBe(true);
     expect(res.migrated).toBe(true);
     expect(res.fromVersion).toBe(1);
-    expect(res.toVersion).toBe(2);
-    expect(res.state?.schemaVersion).toBe(2);
+    expect(res.toVersion).toBe(3);
+    expect(res.state?.schemaVersion).toBe(3);
     expect(res.state?.stateRevision).toBe('3');
+    expect(res.state?.registrations).toEqual([{ id: 'reg-1', alias: 'marketplace-1', format: 'codex' }]);
     expect((res.state as any).scopeOverrides).toBeUndefined();
 
     // Verify non-blocking warning finding
@@ -122,7 +123,56 @@ describe('WAL Migration — schemaVersion binding & v1→v2 migration (Issue #63
     ]);
   });
 
-  it('migrateForward: newer version (> 2) is incompatible (fail-closed, no auto-migrate)', () => {
+  it('migrateForward: v2 backfills format=codex on every Registration missing a valid format, zero loss (Issue #44)', () => {
+    const v2State = {
+      schemaVersion: 2,
+      stateRevision: '9',
+      registrations: [
+        { id: 'reg-1', alias: 'marketplace-1', sourceKind: 'git', source: 'https://github.com/example/mp' },
+        { id: 'reg-2', alias: 'marketplace-2', sourceKind: 'local', source: '/tmp/mp' },
+        { id: 'reg-3', alias: 'marketplace-3', format: 'claude', sourceKind: 'git' },
+        { id: 'reg-4', alias: 'marketplace-4', format: 'codex' },
+      ],
+      installations: [{ id: 'inst-1', pluginId: 'market-1/tool-a', installationState: 'enabled' }],
+    } as any;
+
+    const res = migrateForward(v2State);
+    expect(res.ok).toBe(true);
+    expect(res.migrated).toBe(true);
+    expect(res.fromVersion).toBe(2);
+    expect(res.toVersion).toBe(3);
+    expect(res.state?.schemaVersion).toBe(3);
+    expect(res.state?.stateRevision).toBe('9');
+    expect(res.findings).toEqual([]);
+
+    // Zero content loss: all original fields survive; missing format backfilled to codex;
+    // already-declared codex | claude values preserved untouched.
+    expect(res.state?.registrations).toEqual([
+      { id: 'reg-1', alias: 'marketplace-1', sourceKind: 'git', source: 'https://github.com/example/mp', format: 'codex' },
+      { id: 'reg-2', alias: 'marketplace-2', sourceKind: 'local', source: '/tmp/mp', format: 'codex' },
+      { id: 'reg-3', alias: 'marketplace-3', format: 'claude', sourceKind: 'git' },
+      { id: 'reg-4', alias: 'marketplace-4', format: 'codex' },
+    ]);
+    expect(res.state?.installations).toEqual([{ id: 'inst-1', pluginId: 'market-1/tool-a', installationState: 'enabled' }]);
+  });
+
+  it('migrateForward: v2 backfills format=codex even for empty registrations array (no registrations, no findings)', () => {
+    const v2State = {
+      schemaVersion: 2,
+      stateRevision: '2',
+      registrations: [],
+      installations: [],
+    } as any;
+
+    const res = migrateForward(v2State);
+    expect(res.ok).toBe(true);
+    expect(res.migrated).toBe(true);
+    expect(res.state?.schemaVersion).toBe(3);
+    expect(res.state?.registrations).toEqual([]);
+    expect(res.findings).toEqual([]);
+  });
+
+  it('migrateForward: newer version (> 3) is incompatible (fail-closed, no auto-migrate)', () => {
     const state = {
       schemaVersion: CURRENT_SCHEMA_VERSION + 1,
       stateRevision: '1',
@@ -156,31 +206,31 @@ describe('WAL Migration — schemaVersion binding & v1→v2 migration (Issue #63
 
   it('commitMigratedState writes WAL, updates state file atomically, and cleans WAL', () => {
     const migratedState: BridgeState = {
-      schemaVersion: 2,
+      schemaVersion: 3,
       stateRevision: '10',
-      registrations: [{ id: 'reg-1', alias: 'm1' }],
+      registrations: [{ id: 'reg-1', alias: 'm1', format: 'codex' }],
       installations: [],
     };
 
-    const committed = commitMigratedState(statePath, migratedState, 1, '10');
+    const committed = commitMigratedState(statePath, migratedState, 2, '10');
     expect(committed).toBe(true);
     expect(existsSync(statePath)).toBe(true);
     expect(existsSync(`${statePath}.wal`)).toBe(false);
 
     const written = JSON.parse(readFileSync(statePath, 'utf-8'));
-    expect(written.schemaVersion).toBe(2);
+    expect(written.schemaVersion).toBe(3);
     expect(written.stateRevision).toBe('10');
   });
 
   it('recoverWalIfNeeded replays WAL when state file still holds old version after crash', () => {
     const oldState = {
-      schemaVersion: 1,
+      schemaVersion: 2,
       stateRevision: '3',
       registrations: [],
       installations: [],
     } as any;
     const targetState: BridgeState = {
-      schemaVersion: 2,
+      schemaVersion: 3,
       stateRevision: '3',
       registrations: [],
       installations: [],
@@ -188,8 +238,8 @@ describe('WAL Migration — schemaVersion binding & v1→v2 migration (Issue #63
 
     writeFileSync(statePath, JSON.stringify(oldState), 'utf-8');
     _internal.writeWalSync(statePath, {
-      fromVersion: 1,
-      toVersion: 2,
+      fromVersion: 2,
+      toVersion: 3,
       fromRevision: '3',
       targetState,
       createdAt: new Date().toISOString(),
@@ -197,16 +247,16 @@ describe('WAL Migration — schemaVersion binding & v1→v2 migration (Issue #63
 
     const rec = recoverWalIfNeeded(statePath, oldState);
     expect(rec.recovered).toBe(true);
-    expect(rec.state?.schemaVersion).toBe(2);
+    expect(rec.state?.schemaVersion).toBe(3);
     expect(existsSync(`${statePath}.wal`)).toBe(false);
 
     const written = JSON.parse(readFileSync(statePath, 'utf-8'));
-    expect(written.schemaVersion).toBe(2);
+    expect(written.schemaVersion).toBe(3);
   });
 
   it('recoverWalIfNeeded cleans WAL when state file was already committed', () => {
     const targetState: BridgeState = {
-      schemaVersion: 2,
+      schemaVersion: 3,
       stateRevision: '4',
       registrations: [],
       installations: [],
@@ -214,8 +264,8 @@ describe('WAL Migration — schemaVersion binding & v1→v2 migration (Issue #63
 
     writeFileSync(statePath, JSON.stringify(targetState), 'utf-8');
     _internal.writeWalSync(statePath, {
-      fromVersion: 1,
-      toVersion: 2,
+      fromVersion: 2,
+      toVersion: 3,
       fromRevision: '4',
       targetState,
       createdAt: new Date().toISOString(),
@@ -226,4 +276,3 @@ describe('WAL Migration — schemaVersion binding & v1→v2 migration (Issue #63
     expect(existsSync(`${statePath}.wal`)).toBe(false);
   });
 });
-

--- a/tests/unit/bridge-state/repair.test.ts
+++ b/tests/unit/bridge-state/repair.test.ts
@@ -670,7 +670,7 @@ describe('Repair State', () => {
     ]));
   });
 
-  it('surfaces v1→v2 migration finding in Repair State receipt when non-empty scopeOverrides are stripped', async () => {
+  it('surfaces v1→v3 migration finding in Repair State receipt when non-empty scopeOverrides are stripped', async () => {
     const statePath = getGlobalStatePath(agentDir);
     mkdirSync(join(agentDir, 'codex-marketplace'), { recursive: true });
     writeFileSync(
@@ -699,7 +699,8 @@ describe('Repair State', () => {
     );
 
     const onDisk = JSON.parse(readFileSync(statePath, 'utf-8'));
-    expect(onDisk.schemaVersion).toBe(2);
+    expect(onDisk.schemaVersion).toBe(3);
+    expect(onDisk.registrations[0].format).toBe('codex');
     expect(onDisk.scopeOverrides).toBeUndefined();
   });
 });

--- a/tests/unit/store.test.ts
+++ b/tests/unit/store.test.ts
@@ -166,7 +166,7 @@ describe('Bridge State store — single Global document, atomicity, corruption',
     expect(final.state!.stateRevision).toBe('5');
   });
 
-  it('persists only authoritative fields (no Effective State / catalogs / scopeOverrides in v2)', async () => {
+  it('persists only authoritative fields (no Effective State / catalogs / scopeOverrides; v3 current)', async () => {
     await commitBridgeState(() => ({
         schemaVersion: CURRENT_SCHEMA_VERSION,
         stateRevision: '0', // will be bumped
@@ -299,7 +299,7 @@ describe('Bridge State store — single Global document, atomicity, corruption',
     expect(r.state!.stateRevision).toBe('1');
   });
 
-  it('automatically WAL-migrates v1 file with empty scopeOverrides to v2 on read', async () => {
+  it('automatically WAL-migrates v1 file with empty scopeOverrides to v3 on read (Issue #44)', async () => {
     const gPath = getGlobalStatePath(env.agentDir);
     mkdirSync(join(env.agentDir, 'codex-marketplace'), { recursive: true });
     writeFileSync(
@@ -316,21 +316,24 @@ describe('Bridge State store — single Global document, atomicity, corruption',
 
     const res = await readBridgeState({ agentDir: env.agentDir });
     expect(res.status).toBe('ok');
-    expect(res.state?.schemaVersion).toBe(2);
+    expect(res.state?.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     expect(res.state?.stateRevision).toBe('10');
     expect(res.state?.registrations).toHaveLength(1);
+    // Legacy registration automatically carries format=codex after migration
+    expect(res.state?.registrations[0].format).toBe('codex');
     expect(res.state?.installations[0].id).toBe('plugin-x');
     expect((res.state as any)?.scopeOverrides).toBeUndefined();
     expect(res.findings).toEqual([]);
 
-    // File on disk must now be schemaVersion 2 without WAL remaining
+    // File on disk must now be schemaVersion 3 without WAL remaining
     const onDisk = JSON.parse(readFileSync(gPath, 'utf-8'));
-    expect(onDisk.schemaVersion).toBe(2);
+    expect(onDisk.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
+    expect(onDisk.registrations[0].format).toBe('codex');
     expect(onDisk.scopeOverrides).toBeUndefined();
     expect(existsSync(`${gPath}.wal`)).toBe(false);
   });
 
-  it('automatically WAL-migrates v1 file with non-empty scopeOverrides to v2 and surfaces diagnostic finding', async () => {
+  it('automatically WAL-migrates v1 file with non-empty scopeOverrides to v3 and surfaces diagnostic finding', async () => {
     const gPath = getGlobalStatePath(env.agentDir);
     mkdirSync(join(env.agentDir, 'codex-marketplace'), { recursive: true });
     writeFileSync(
@@ -347,17 +350,57 @@ describe('Bridge State store — single Global document, atomicity, corruption',
 
     const res = await readBridgeState({ agentDir: env.agentDir });
     expect(res.status).toBe('ok');
-    expect(res.state?.schemaVersion).toBe(2);
+    expect(res.state?.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     expect(res.state?.stateRevision).toBe('20');
+    expect(res.state?.registrations[0].format).toBe('codex');
     expect((res.state as any)?.scopeOverrides).toBeUndefined();
     expect(res.findings).toHaveLength(1);
     expect(res.findings![0].rule).toBe('MIGRATE-01');
     expect(res.findings![0].classification).toBe('warning');
 
     const onDisk = JSON.parse(readFileSync(gPath, 'utf-8'));
-    expect(onDisk.schemaVersion).toBe(2);
+    expect(onDisk.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     expect(onDisk.scopeOverrides).toBeUndefined();
     expect(existsSync(`${gPath}.wal`)).toBe(false);
+  });
+
+  it('round-trips a Registration with format=claude through write then read (Issue #44)', async () => {
+    const gPath = getGlobalStatePath(env.agentDir);
+    const claudeState: BridgeState = {
+      ...createEmptyState(),
+      stateRevision: '5',
+      registrations: [
+        {
+          id: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+          alias: 'mattpocock-skills',
+          format: 'claude',
+          sourceKind: 'git',
+          source: 'https://github.com/mattpocock/skills',
+        },
+      ],
+      installations: [],
+    };
+
+    const w = await commitBridgeState(() => claudeState, { agentDir: env.agentDir });
+    expect(w.success).toBe(true);
+
+    // On-disk v3 document preserves format=claude verbatim
+    const onDisk = JSON.parse(readFileSync(gPath, 'utf-8'));
+    expect(onDisk.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
+    expect(onDisk.registrations).toEqual([
+      expect.objectContaining({
+        id: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+        format: 'claude',
+        source: 'https://github.com/mattpocock/skills',
+      }),
+    ]);
+
+    // Read-back yields exactly the claude format (no auto-migration, no re-defaulting)
+    const r = await readBridgeState({ agentDir: env.agentDir });
+    expect(r.status).toBe('ok');
+    expect(r.state?.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
+    expect(r.state?.registrations[0].format).toBe('claude');
+    expect(r.state?.registrations[0].source).toBe('https://github.com/mattpocock/skills');
   });
 
   it('Stale State Revision rejection releases the lock — subsequent commit with correct revision succeeds and no *.lock remains (issue #24 fix)', async () => {


### PR DESCRIPTION
## Parent

Closes #44（parent: #43）

## What changed

Bridge State 持久層地基（#43 分配之一，#44）：Registration 新增 Marketplace Format 屬性並以 WAL migration 升級 schema。

### 型別與 Schema v3
- `CURRENT_SCHEMA_VERSION` 升至 **3**。
- 新增 `MarketplaceFormat`（`codex | claude`）型別與 `Registration.format` 屬性。
- 新寫入的 Registration 可承載 `format=claude` 並正確回讀（round-trip）。

### WAL Forward Migration (v2 → v3)
- 實作 v2 → v3 前向遷移：既有 Registration 自動補上 `format=codex` 預設值，**內容零損失**（缺值才補，既有欄位全保留）；已宣告的 `codex | claude` 值原樣保留。
- 維持既有遷移先例：WAL 交易、exactly-one-version 不變式、讀取時自動觸發並 fsync / atomic rename。
- 降級寫回防護與未知／較新版本 fail-closed 語意不變。

### 測試覆蓋
- `migrate.test.ts` 新增 v2 → v3 遷移案例（零損失補值、保留已宣告值、v1→v3 chain）。
- `store.test.ts` 新增 `format=claude` write → read round-trip 與 v1（含 overrides）自動遷移至 v3。
- `repair.test.ts` 更新遷移後 schemaVersion 斷言。
- `npm run check` 全綠（typecheck + 49 files / 567 tests）。

## Out of scope

- 格式偵測、claude catalog 解析與生命週期行為——由 #43 後續票交付，本票只鋪持久層地基。