### PR TITLE
feat: 格式偵測接入登記與瀏覽流程——codex 優先、claude 全程可註冊、披露/收據反映 Marketplace Format（#47）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `pi-codex-marketplace` are documented here. Format follow
 
 ## [Unreleased]
 
+### Added
+- **格式偵測接入登記與瀏覽流程（local + git）** (#47)：
+  - 掃描 Marketplace Root 決定性推導 Marketplace Format（codex 優先；兩種 catalog 並存時自動採用 codex，無額外提問）。
+  - 僅含 `.claude-plugin/marketplace.json` 的 repo 全程可登記：`format=claude` 固化於 Registration；兩者皆無時 CATALOG_MISSING 行為不變。
+  - 驗證披露、Registration Confirmation 畫面與 Attempt Receipt（Transaction Sheet、Receipt Journal、Attempt Summary 通知）顯示 Marketplace Format。
+  - 瀏覽（Bridge Ledger / 安裝選單）讀經註冊格式：Compatible entry 顯示外掛與技能清單，不合格 entry 顯示 Unavailable 原因；上游格式翻轉不被靜默採用，僅經 Marketplace Refresh 產生的 Update Candidate 加上明確 Apply Update 變更。
+  - transaction-flow 測試以 mock Git executor 完整登記仿 mattpocock 夾具成功。
+
 ### Changed
 - **Bridge State Schema v3 + format 屬性遷移** (#44)：`schemaVersion` 升為 `3`。
   - `Registration` 記錄新增 Marketplace Format 屬性（`codex | claude`）——本票只鋪持久層地基，格式偵測與 claude 解析由後續票交付。

--- a/extensions/pi/git-registration.ts
+++ b/extensions/pi/git-registration.ts
@@ -14,9 +14,10 @@ import type { ExtensionCommandContext, ExtensionUIContext } from '@earendil-work
 import {
   preflightGitRegistration,
   confirmGitRegistration,
+  type GitRegistrationFlowOptions,
 } from '../../src/registration/git-flow.js';
 import type { GitSelectorInput } from '../../src/registration/git-selector.js';
-import { uiText } from './ui-strings.js';
+import { marketplaceFormatText, uiText } from './ui-strings.js';
 import {
   fullValidationDisclosureLines,
   reportOutcome,
@@ -36,8 +37,14 @@ async function transactionStep(
   return false;
 }
 
+/**
+ * One interactive git registration flow invocation.
+ * The optional flow options thread the Acquisition Trust Base seams (executor / trust / cache)
+ * for tests and embedders; production callers rely on the real Git executor.
+ */
 export async function runGitRegistrationFlow(
   ctx: ExtensionCommandContext,
+  flowOpts: Pick<GitRegistrationFlowOptions, 'executor' | 'trust' | 'cache'> = {},
 ): Promise<void> {
   const ui: ExtensionUIContext = ctx.ui;
 
@@ -99,7 +106,7 @@ export async function runGitRegistrationFlow(
     ],
   })) return;
 
-  const opts = {};
+  const opts: GitRegistrationFlowOptions = { ...flowOpts };
   const res = await preflightGitRegistration(locator, selectorInput, opts);
   if (!res.ok) {
     await reportTerminalPreflightOutcome(ctx, res.outcome);
@@ -121,6 +128,7 @@ export async function runGitRegistrationFlow(
     }),
     uiText('reg.git.detail.resolvedRevision', { revision: quoteTerminalText(pf.resolvedRevision) }),
     uiText('reg.detail.marketplace', { name: quoteTerminalText(pf.marketplaceName) }),
+    uiText('reg.detail.format', { format: marketplaceFormatText(pf.format) }),
     uiText('reg.detail.entries', {
       total: pf.catalog.entries.length,
       locatable: pf.catalog.entries.filter((entry) => entry.available).length,

--- a/extensions/pi/journal.ts
+++ b/extensions/pi/journal.ts
@@ -18,7 +18,7 @@ import { acquireAttemptFence } from '../../src/registration/fence.js';
 import { blocking, CODE, notice, RULE, type ValidationFinding } from '../../src/registration/findings.js';
 import { createReceipt, type AttemptReceipt } from '../../src/registration/receipt.js';
 import { fullValidationDisclosureLines, reportOutcome } from './registration.js';
-import { attemptSummaryText, uiText } from './ui-strings.js';
+import { attemptSummaryText, marketplaceFormatText, uiText } from './ui-strings.js';
 import { quoteTerminalText } from './terminal-presentation.js';
 import { openTransactionSheet, type TransactionSheetModel } from './transaction-sheet.js';
 
@@ -478,6 +478,9 @@ export async function runReceiptJournalView(
         expected: quote(rc.expectedStateRevision),
         observed: quote(rc.observedStateRevision ?? rc.targetStateRevision ?? '?'),
       }));
+      if (rc.marketplaceFormat) {
+        lines.push('  ' + uiText('journal.view.receipt.format', { format: marketplaceFormatText(rc.marketplaceFormat) }));
+      }
       if (rc.recoversReceiptId) {
         lines.push('  ' + uiText('journal.view.receipt.recovers', { receiptId: quote(rc.recoversReceiptId) }));
       }

--- a/extensions/pi/registration.ts
+++ b/extensions/pi/registration.ts
@@ -17,7 +17,7 @@ import {
 } from '../../src/registration/flow.js';
 import { sortFindings, type ValidationFinding } from '../../src/registration/findings.js';
 import type { AttemptReceipt } from '../../src/registration/receipt.js';
-import { attemptSummaryText, findingOutcomeText, uiText, verdictText } from './ui-strings.js';
+import { attemptSummaryText, findingOutcomeText, marketplaceFormatText, uiText, verdictText } from './ui-strings.js';
 import { quoteTerminalText } from './terminal-presentation.js';
 import { openTransactionSheet, type TransactionSheetModel } from './transaction-sheet.js';
 
@@ -101,6 +101,7 @@ export async function runLocalRegistrationFlow(
     uiText('reg.detail.registrationId', { id: quoteTerminalText(pf.registrationId) }),
     uiText('reg.detail.source', { source: quoteTerminalText(pf.canonicalPath) }),
     uiText('reg.detail.marketplace', { name: quoteTerminalText(pf.marketplaceName) }),
+    uiText('reg.detail.format', { format: marketplaceFormatText(pf.format) }),
     uiText('reg.detail.entries', {
       total: pf.catalog.entries.length,
       locatable: pf.catalog.entries.filter((entry) => entry.available).length,
@@ -210,8 +211,12 @@ export async function reportOutcome(
     validationSnapshot: rc.validationSnapshot,
     receipt: rc,
   });
+  const notifyMessage = rc.marketplaceFormat
+    ? `${uiText('reg.outcome.notify', { summary: attemptSummaryText(rc.summary), receiptId: quoteTerminalText(rc.id) })} · ${
+        uiText('reg.outcome.notify.formatSuffix', { format: marketplaceFormatText(rc.marketplaceFormat) })}`
+    : uiText('reg.outcome.notify', { summary: attemptSummaryText(rc.summary), receiptId: quoteTerminalText(rc.id) });
   ctx.ui.notify(
-    uiText('reg.outcome.notify', { summary: attemptSummaryText(rc.summary), receiptId: quoteTerminalText(rc.id) }),
+    notifyMessage,
     notifyType,
   );
 }

--- a/extensions/pi/transaction-sheet.ts
+++ b/extensions/pi/transaction-sheet.ts
@@ -13,6 +13,7 @@ import {
   attemptSummaryGloss,
   closedValue,
   findingOutcomeText,
+  marketplaceFormatText,
   recoveryActionGloss,
   transactionStepLabel,
   uiText,
@@ -98,6 +99,9 @@ function receiptAxes(receipt: AttemptReceipt, theme: TransactionSheetTheme): [st
     field(theme, uiText('sheet.field.kind'), receipt.kind),
     field(theme, uiText('sheet.field.operation'), receipt.operation),
     field(theme, uiText('sheet.field.trigger'), receipt.trigger),
+    ...(receipt.marketplaceFormat === undefined
+      ? []
+      : [field(theme, uiText('sheet.field.marketplaceFormat'), marketplaceFormatText(receipt.marketplaceFormat))]),
   ];
   return [durable, findings, runtime];
 }

--- a/extensions/pi/ui-strings.ts
+++ b/extensions/pi/ui-strings.ts
@@ -15,6 +15,7 @@
  */
 
 import type { AttemptSummary, RecoveryAction } from '../../src/registration/receipt.js';
+import type { MarketplaceFormat } from '../../src/bridge-state/types.js';
 import type { ValidationFinding } from '../../src/registration/findings.js';
 import type { TransactionStep } from './transaction-sheet.js';
 
@@ -52,6 +53,8 @@ const zhTW = {
 
   // --- closed-value glosses (canonical always rendered first) ---------------
 
+  'format.gloss.codex': 'Codex 格式',
+  'format.gloss.claude': 'Claude 格式',
   'summary.gloss.Completed': '完成',
   'summary.gloss.Completed with diagnostics': '完成但有診斷',
   'summary.gloss.Declined': '已婉拒',
@@ -114,6 +117,7 @@ const zhTW = {
   'sheet.field.kind': '種類',
   'sheet.field.operation': '操作',
   'sheet.field.trigger': '觸發',
+  'sheet.field.marketplaceFormat': 'Marketplace Format',
   'sheet.attemptSummary': 'Attempt Summary',
   'sheet.recoveryActions': 'Recovery Actions（復原動作）',
   'sheet.keys': 'Enter：繼續｜Esc/q/Ctrl-C：取消',
@@ -225,6 +229,7 @@ const zhTW = {
   'reg.detail.registrationId': 'Registration ID {id}',
   'reg.detail.source': '來源 {source}',
   'reg.detail.marketplace': 'Marketplace {name}',
+  'reg.detail.format': 'Marketplace Format {format}',
   'reg.detail.entries': 'Entries {total}（可定位 {locatable} / 無法定位 {unavailable}）',
   'reg.detail.profile': 'Compatibility Profile {profile}',
   'reg.detail.ruleset': 'Validation Ruleset {ruleset}',
@@ -263,6 +268,7 @@ const zhTW = {
   'reg.commit.persist': '寫入 Registration ID {id}',
   'reg.commit.authority': '於 {scope} 以 State Revision {revision} 寫入授權文件',
   'reg.outcome.notify': 'Attempt Summary：{summary} · Receipt {receiptId}',
+  'reg.outcome.notify.formatSuffix': 'Marketplace Format {format}',
 
   // --- installation.ts ---------------------------------------------------------
   'inst.select.registered': '選擇已註冊 Marketplace',
@@ -390,6 +396,7 @@ const zhTW = {
   'journal.view.recent.empty': '（Journal 為空）',
   'journal.view.receipt.summary': '摘要：{summary}｜持久：{durable}｜運行時：{runtime}',
   'journal.view.receipt.revision': 'State Revision：{expected} → {observed}',
+  'journal.view.receipt.format': 'Marketplace Format：{format}',
   'journal.view.receipt.recovers': '復原對象：{receiptId}',
   'journal.view.receipt.findings': 'Findings：{findings}',
   'journal.notFound': 'Receipt Journal 找不到精確 Receipt ID {receiptId}。',
@@ -558,6 +565,11 @@ export function recoveryActionText(action: RecoveryAction): string {
 export function recoveryActionGloss(action: RecoveryAction): string {
   const glossId = RECOVERY_ACTION_GLOSS[action];
   return glossId ? uiText(glossId) : '';
+}
+
+/** Marketplace Format closed value presented canonical-first with its zh_TW gloss. */
+export function marketplaceFormatText(format: MarketplaceFormat): string {
+  return closedValue(format, uiText(format === 'claude' ? 'format.gloss.claude' : 'format.gloss.codex'));
 }
 
 const STEP_GLOSS: Record<TransactionStep, MessageId> = {

--- a/src/installation/inspection.ts
+++ b/src/installation/inspection.ts
@@ -14,8 +14,9 @@ import {
   type CompatiblePlugin,
   type PluginClassification,
 } from '../compatibility/profile.js';
-import type { Registration } from '../bridge-state/types.js';
+import type { Registration, MarketplaceFormat } from '../bridge-state/types.js';
 import type { MarketplaceEntry } from '../registration/catalog.js';
+import { catalogContractFor } from '../registration/format.js';
 import { parseCatalog } from '../registration/catalog.js';
 import { resolveContained } from '../registration/contained.js';
 import { CODE, RULE, blocking, hasBlocking, sortFindings, type ValidationFinding } from '../registration/findings.js';
@@ -50,6 +51,8 @@ export interface InspectionOptions {
   baseSnapshot?: ValidationSnapshot;
   /** Suppress the recorded-snapshot drift Blocking Finding — Refresh compares fingerprints explicitly instead. */
   ignoreRecordedDrift?: boolean;
+  /** Format-bound catalog override for candidate validation of a replacement/new source state (Refresh / Rebind). Committed registrations always read through their registered format. */
+  format?: MarketplaceFormat;
   agentDir?: string;
   cache?: SourceCache;
 }
@@ -60,6 +63,10 @@ function inspectionFinding(code: string, rule: string, target: ValidationFinding
 
 /** Inspect every Marketplace Entry once. All filesystem work occurs after a bounded snapshot. */
 export function inspectMarketplaceEntries(registration: Registration, opts: InspectionOptions = {}): MarketplaceInspection {
+  // Browse reads through the REGISTERED format — an upstream flip is never adopted implicitly;
+  // candidate validation (Refresh / Rebind) passes the detected live format explicitly.
+  const format: MarketplaceFormat = opts.format ?? registration.format ?? 'codex';
+  const contract = catalogContractFor(format);
   const override = Boolean(opts.root && opts.baseSnapshot);
   let root: string;
   let snapshotResult: { ok: boolean; snapshot?: ValidationSnapshot; findings: ValidationFinding[] };
@@ -122,7 +129,7 @@ export function inspectMarketplaceEntries(registration: Registration, opts: Insp
     const key = localSourceKey(registration.source);
     if (!key.ok) return { entries: [], findings: [inspectionFinding(CODE.SOURCE_REACQUISITION_REQUIRED, RULE.SOURCE_REACQUISITION_REQUIRED, 'registration', key.error ?? 'Marketplace Root cannot be revalidated')] };
     root = key.sourceKey!.canonicalPath!;
-    const catalogPath = join(root, '.agents', 'plugins', 'marketplace.json');
+    const catalogPath = join(root, ...contract.relPath.split('/'));
     try {
       if (lstatSync(catalogPath).size > BUDGET.maxCatalogBytes) {
         return { entries: [], findings: [inspectionFinding(CODE.BUDGET_EXCEEDED, RULE.BUDGET_EXCEEDED, 'catalog', `Validation Budget exceeded: catalog exceeds ${BUDGET.maxCatalogBytes} bytes`)] };
@@ -139,7 +146,7 @@ export function inspectMarketplaceEntries(registration: Registration, opts: Insp
     };
   }
 
-  const catalogPath = join(root, '.agents', 'plugins', 'marketplace.json');
+  const catalogPath = join(root, ...contract.relPath.split('/'));
 
   let catalogRaw: string;
   let catalogValue: unknown;
@@ -149,9 +156,9 @@ export function inspectMarketplaceEntries(registration: Registration, opts: Insp
     catalogRaw = bytes.toString('utf8');
     catalogValue = JSON.parse(catalogRaw);
   } catch {
-    return { entries: [], snapshot: snapshotResult.snapshot, findings: [inspectionFinding(CODE.CATALOG_MISSING, RULE.CATALOG_MISSING, 'catalog', 'Marketplace Catalog cannot be read')] };
+    return { entries: [], snapshot: snapshotResult.snapshot, findings: [inspectionFinding(CODE.CATALOG_MISSING, RULE.CATALOG_MISSING, 'catalog', `Marketplace Catalog cannot be read at ${contract.relPath}`)] };
   }
-  const parsed = parseCatalog(catalogValue);
+  const parsed = contract.parse(catalogValue);
   if (!parsed.catalog) return { entries: [], snapshot: snapshotResult.snapshot, findings: parsed.findings };
   const marketplaceId = `${registration.id}/${parsed.catalog.name}`;
   const drift = !opts.ignoreRecordedDrift && registration.validationSnapshot && registration.validationSnapshot !== snapshotResult.snapshot!.fingerprint
@@ -169,7 +176,7 @@ export function inspectMarketplaceEntries(registration: Registration, opts: Insp
       baseClassification = classifyPlugin(contained.outcome.canonicalPath, {
         marketplaceId,
         marketplaceEntryId: `${marketplaceId}${entry.entryId}`,
-        format: registration.format,
+        format,
       });
       classifications.set(contained.outcome.canonicalPath, baseClassification);
     }

--- a/src/lifecycle/rebind.ts
+++ b/src/lifecycle/rebind.ts
@@ -30,6 +30,7 @@ import {
   type GitSelectorInput,
 } from '../registration/git-selector.js';
 import { createReceipt, type AttemptReceipt } from '../registration/receipt.js';
+import { detectMarketplaceFormat } from '../registration/format.js';
 import { findDuplicateRegistration, sourceKeyForLocalRoot } from '../registration/registration.js';
 import { buildGitSnapshot, buildLocalSnapshot } from '../registration/snapshot.js';
 import { gitSourceKey, type SourceKey } from '../registration/source-key.js';
@@ -152,10 +153,14 @@ function rebindToLocal(
   const snap = buildLocalSnapshot(sourceKey.canonicalPath!, sourceKey);
   if (!snap.ok || !snap.snapshot) return blocked(trigger, revision, snap.findings, recordedSnapshot);
 
+  // The replacement source's own format is detected fresh; it lands on the Registration only
+  // when the disclosed Update Plan is explicitly applied.
+  const replacementFormat = detectMarketplaceFormat(sourceKey.canonicalPath!);
   const inspection = inspectMarketplaceEntries(identityProbe(registrationId), {
     root: sourceKey.canonicalPath!,
     baseSnapshot: snap.snapshot,
     ignoreRecordedDrift: true,
+    format: replacementFormat ?? undefined,
   });
   const name = marketplaceNameOf(registrationId, inspection.marketplaceId);
   if (!inspection.marketplaceId || inspection.findings.some((f) => f.classification === 'blocking')) {
@@ -170,6 +175,7 @@ function rebindToLocal(
     recordedFingerprint: undefined,
     snapshot: snap.snapshot,
     marketplaceName: name,
+    format: replacementFormat ?? undefined,
     catalog: { name, entries: inspection.entries.map((item) => item.entry) },
     inspection,
     sourceKey,
@@ -234,10 +240,12 @@ async function rebindToGit(
     });
     if (!snap.ok || !snap.snapshot) return blocked(trigger, revision, snap.findings, recordedSnapshot);
 
+    const replacementFormat = detectMarketplaceFormat(acq.acquiredPath!);
     const inspection = inspectMarketplaceEntries(identityProbe(registrationId), {
       root: acq.acquiredPath!,
       baseSnapshot: snap.snapshot,
       ignoreRecordedDrift: true,
+      format: replacementFormat ?? undefined,
     });
     const name = marketplaceNameOf(registrationId, inspection.marketplaceId);
     if (!inspection.marketplaceId || inspection.findings.some((f) => f.classification === 'blocking')) {
@@ -250,6 +258,7 @@ async function rebindToGit(
       recordedFingerprint: undefined,
       snapshot: snap.snapshot,
       marketplaceName: name,
+      format: replacementFormat ?? undefined,
       catalog: { name, entries: inspection.entries.map((item) => item.entry) },
       inspection,
       sourceKey: boundKey,

--- a/src/lifecycle/refresh.ts
+++ b/src/lifecycle/refresh.ts
@@ -11,7 +11,7 @@
 
 import { readBridgeState } from '../bridge-state/store.js';
 import type { BridgeState } from '../bridge-state/types.js';
-import type { Registration } from '../bridge-state/types.js';
+import type { MarketplaceFormat, Registration } from '../bridge-state/types.js';
 import type { MarketplaceInspection } from '../installation/inspection.js';
 import { inspectMarketplaceEntries } from '../installation/inspection.js';
 import type { Catalog } from '../registration/catalog.js';
@@ -29,6 +29,7 @@ import {
   type GitExecutor,
 } from '../registration/git-acquisition.js';
 import { SourceCache } from '../cache/source-cache.js';
+import { detectMarketplaceFormat } from '../registration/format.js';
 import { normalizeGitLocator } from '../registration/git-locator.js';
 import {
   normalizeGitSelector,
@@ -66,6 +67,8 @@ export interface UpdateCandidate {
   /** Newly validated snapshot with full tree + binds (base-tree fingerprint, as registered). */
   snapshot: ValidationSnapshot;
   marketplaceName: string;
+  /** Marketplace Format detected on the candidate source state; applied only by the explicit Apply Update / Rebind commit. */
+  format?: MarketplaceFormat;
   catalog: Catalog;
   inspection: MarketplaceInspection;
   sourceKey: SourceKey;
@@ -176,7 +179,10 @@ function refreshLocalRegistration(
   }
 
   if (!registration.validationSnapshot || snap.snapshot.fingerprint !== registration.validationSnapshot) {
-    const inspection = inspectMarketplaceEntries(registration, { ignoreRecordedDrift: true });
+    // The candidate's own format is detected fresh from the live tree — a flipped root can only
+    // reach the Registration through this Update Candidate plus an explicit Apply Update.
+    const liveFormat = detectMarketplaceFormat(registration.source);
+    const inspection = inspectMarketplaceEntries(registration, { ignoreRecordedDrift: true, format: liveFormat ?? undefined });
     const name = marketplaceNameOf(registration.id, inspection.marketplaceId) || registration.marketplaceName || '';
     const candidate: UpdateCandidate = {
       registrationId: registration.id,
@@ -185,6 +191,7 @@ function refreshLocalRegistration(
       recordedResolvedRevision: registration.resolvedRevision,
       snapshot: snap.snapshot,
       marketplaceName: name,
+      format: liveFormat ?? undefined,
       catalog: { name, entries: inspection.entries.map((item) => item.entry) },
       inspection,
       sourceKey: registration.sourceKey,
@@ -341,10 +348,12 @@ async function refreshGitRegistration(
     if (!snap.ok || !snap.snapshot) {
       return blocked(registration.id, revision, snap.findings, registration.validationSnapshot);
     }
+    const liveFormat = detectMarketplaceFormat(root);
     const inspection = inspectMarketplaceEntries(registration, {
       root,
       baseSnapshot: snap.snapshot,
       ignoreRecordedDrift: true,
+      format: liveFormat ?? undefined,
     });
     const name = marketplaceNameOf(registration.id, inspection.marketplaceId) || registration.marketplaceName || '';
     const candidate: UpdateCandidate = {
@@ -354,6 +363,7 @@ async function refreshGitRegistration(
       recordedResolvedRevision: registration.resolvedRevision,
       snapshot: snap.snapshot,
       marketplaceName: name,
+      format: liveFormat ?? undefined,
       catalog: { name, entries: inspection.entries.map((item) => item.entry) },
       inspection,
       sourceKey: newSourceKey,

--- a/src/lifecycle/update.ts
+++ b/src/lifecycle/update.ts
@@ -88,6 +88,9 @@ function draftNextState(state: BridgeState, plan: UpdatePlan): BridgeState {
         budget: candidate.snapshot.budget,
       },
     };
+    // Marketplace Format is fixed onto the Registration; it changes only here — through the
+    // disclosed Update Candidate and this explicit atomic commit (never implicitly).
+    if (candidate.format) next.format = candidate.format;
     if (candidate.resolvedRevision) next.resolvedRevision = candidate.resolvedRevision;
     if (plan.rebindSource) {
       next.sourceKind = plan.rebindSource.sourceKind;

--- a/src/registration/flow.ts
+++ b/src/registration/flow.ts
@@ -14,7 +14,7 @@ import { readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { commitBridgeState, readBridgeState } from '../bridge-state/store.js';
-import type { Registration } from '../bridge-state/types.js';
+import type { MarketplaceFormat, Registration } from '../bridge-state/types.js';
 import { BUDGET } from './budget.js';
 import {
   CODE,
@@ -25,6 +25,7 @@ import {
   type ValidationFinding,
 } from './findings.js';
 import { parseCatalog, type Catalog } from './catalog.js';
+import { catalogContractFor, detectMarketplaceFormat } from './format.js';
 import { resolveContained } from './contained.js';
 import { acquireAttemptFence, type AttemptFenceHandle } from './fence.js';
 import { createReceipt, type AttemptReceipt } from './receipt.js';
@@ -38,7 +39,13 @@ import {
 import { buildLocalSnapshot, type ValidationSnapshot } from './snapshot.js';
 import type { SourceKey } from './source-key.js';
 
-export const MARKETPLACE_CATALOG_RELPATH = '.agents/plugins/marketplace.json';
+/**
+ * Canonical codex Marketplace Catalog location within a Marketplace Root.
+ * Kept as the historical export name; the claude counterpart lives in
+ * `catalogContractFor('claude').relPath` (see ./format.ts).
+ */
+export const MARKETPLACE_CATALOG_RELPATH = CODEX_RELPATH;
+import { CODEX_MARKETPLACE_CATALOG_RELPATH as CODEX_RELPATH } from './format.js';
 
 export interface RegistrationFlowOptions {
   agentDir?: string;
@@ -54,6 +61,8 @@ export interface LocalRegistrationPreflight {
   sourceKey: SourceKey;
   canonicalPath: string;
   marketplaceName: string;
+  /** Marketplace Format detected from the root content (codex prioritized); fixed onto the Registration. */
+  format: MarketplaceFormat;
   catalog: Catalog;
   snapshot: ValidationSnapshot;
   findings: ValidationFinding[];
@@ -95,12 +104,14 @@ async function blockedResult(
   handle: AttemptFenceHandle | null,
   opts: RegistrationFlowOptions = {},
   existing?: Registration,
+  marketplaceFormat?: MarketplaceFormat,
 ): Promise<{ ok: false; outcome: RegistrationOutcome }> {
   if (handle) handle.release();
   const receipt = createReceipt({
     operation: OPERATION,
     trigger: triggerFor(rootPath),
     expectedStateRevision: expectedRevision,
+    marketplaceFormat,
     summary: 'Blocked',
     findings,
   });
@@ -173,13 +184,12 @@ export async function preflightLocalRegistration(
     const sourceKey = sourceKeyRes.sourceKey;
     const canonicalPath = sourceKey.canonicalPath!;
 
-    // Marketplace Catalog — canonical `.agents/plugins/marketplace.json`
     const findings: ValidationFinding[] = [];
-    const catalogPath = join(canonicalPath, MARKETPLACE_CATALOG_RELPATH);
-    let catalogBytes = 0;
-    try {
-      catalogBytes = statSync(catalogPath).size;
-    } catch {
+
+    // Marketplace Format — decisive scan of the root content (codex prioritized over claude).
+    // Neither canonical catalog present ⇒ the unchanged CATALOG_MISSING Blocking Finding.
+    const detectedFormat = detectMarketplaceFormat(canonicalPath);
+    if (!detectedFormat) {
       const finding = blocking({
         code: CODE.CATALOG_MISSING,
         phase: 'validation',
@@ -190,12 +200,28 @@ export async function preflightLocalRegistration(
       });
       return blockedResult(rootPath, expectedRevision, [finding], handle, opts);
     }
+    const contract = catalogContractFor(detectedFormat);
+    const catalogPath = join(canonicalPath, ...contract.relPath.split('/'));
+    let catalogBytes = 0;
+    try {
+      catalogBytes = statSync(catalogPath).size;
+    } catch {
+      const finding = blocking({
+        code: CODE.CATALOG_MISSING,
+        phase: 'validation',
+        target: 'catalog',
+        pointer: contract.relPath,
+        rule: RULE.CATALOG_MISSING,
+        outcome: `Marketplace Catalog not found at ${contract.relPath}; legacy marketplace shapes do not participate in Bridge ingestion`,
+      });
+      return blockedResult(rootPath, expectedRevision, [finding], handle, opts);
+    }
     if (catalogBytes > BUDGET.maxCatalogBytes) {
       const finding = blocking({
         code: CODE.BUDGET_EXCEEDED,
         phase: 'validation',
         target: 'catalog',
-        pointer: MARKETPLACE_CATALOG_RELPATH,
+        pointer: contract.relPath,
         rule: RULE.BUDGET_EXCEEDED,
         outcome: `Validation Budget exceeded: catalog ${catalogBytes} bytes > ${BUDGET.maxCatalogBytes}`,
       });
@@ -211,19 +237,20 @@ export async function preflightLocalRegistration(
         code: CODE.CATALOG_MALFORMED,
         phase: 'validation',
         target: 'catalog',
-        pointer: MARKETPLACE_CATALOG_RELPATH,
+        pointer: contract.relPath,
         rule: RULE.CATALOG_MALFORMED,
         outcome: `unable to parse marketplace.json: ${msg}`,
       });
-      return blockedResult(rootPath, expectedRevision, [finding], handle, opts);
+      return blockedResult(rootPath, expectedRevision, [finding], handle, opts, undefined, detectedFormat);
     }
 
-    const catalogResult = parseCatalog(parsed);
+    const catalogResult = contract.parse(parsed);
     findings.push(...catalogResult.findings);
     if (!catalogResult.ok) {
-      return blockedResult(rootPath, expectedRevision, sortFindings(findings), handle, opts);
+      return blockedResult(rootPath, expectedRevision, sortFindings(findings), handle, opts, undefined, detectedFormat);
     }
     const catalog = catalogResult.catalog!;
+    const format: MarketplaceFormat = detectedFormat;
 
     if (catalog.name.length > BUDGET.maxNameLength) {
       findings.push(
@@ -301,6 +328,7 @@ export async function preflightLocalRegistration(
       sourceKey,
       canonicalPath,
       marketplaceName: catalog.name,
+      format,
       catalog,
       snapshot: snapshotResult.snapshot!,
       findings: sorted,
@@ -344,6 +372,7 @@ export async function confirmLocalRegistration(
       trigger: triggerFor(preflight.canonicalPath),
       expectedStateRevision: preflight.stateRevision,
       validationSnapshot: preflight.snapshot.fingerprint,
+      marketplaceFormat: preflight.format,
       summary: 'Blocked',
       findings: [
         blocking({
@@ -369,6 +398,7 @@ export async function confirmLocalRegistration(
       trigger: triggerFor(preflight.canonicalPath),
       expectedStateRevision: preflight.stateRevision,
       validationSnapshot: preflight.snapshot.fingerprint,
+      marketplaceFormat: preflight.format,
       summary: 'Declined',
       findings: preflight.findings,
       stateChanged: false,
@@ -386,6 +416,7 @@ export async function confirmLocalRegistration(
       trigger: triggerFor(preflight.canonicalPath),
       expectedStateRevision: preflight.stateRevision,
       validationSnapshot: preflight.snapshot.fingerprint,
+      marketplaceFormat: preflight.format,
       summary: 'Persistence Indeterminate',
       findings: [
         blocking({
@@ -410,6 +441,7 @@ export async function confirmLocalRegistration(
       expectedStateRevision: preflight.stateRevision,
       targetStateRevision: currentRevision,
       validationSnapshot: preflight.snapshot.fingerprint,
+      marketplaceFormat: preflight.format,
       summary: 'Rejected as Stale',
       findings: [
         blocking({
@@ -436,6 +468,7 @@ export async function confirmLocalRegistration(
       trigger: triggerFor(preflight.canonicalPath),
       expectedStateRevision: preflight.stateRevision,
       validationSnapshot: preflight.snapshot.fingerprint,
+      marketplaceFormat: preflight.format,
       summary: 'Blocked',
       findings: [dup.finding!],
     });
@@ -452,6 +485,7 @@ export async function confirmLocalRegistration(
       trigger: triggerFor(preflight.canonicalPath),
       expectedStateRevision: preflight.stateRevision,
       validationSnapshot: preflight.snapshot.fingerprint,
+      marketplaceFormat: preflight.format,
       summary: 'Rejected as Stale',
       findings: [
         blocking({
@@ -475,6 +509,7 @@ export async function confirmLocalRegistration(
     id: preflight.registrationId,
     alias: preflight.alias,
     marketplaceName: preflight.marketplaceName,
+    format: preflight.format,
     sourceKind: 'local',
     source: preflight.canonicalPath,
     sourceKey: preflight.sourceKey,
@@ -496,6 +531,7 @@ export async function confirmLocalRegistration(
       expectedStateRevision: preflight.stateRevision,
       targetStateRevision: '?',
       validationSnapshot: preflight.snapshot.fingerprint,
+      marketplaceFormat: preflight.format,
       summary,
       findings: [
         blocking({
@@ -523,6 +559,7 @@ export async function confirmLocalRegistration(
     targetStateRevision: targetRevision,
     observedStateRevision: targetRevision,
     validationSnapshot: preflight.snapshot.fingerprint,
+    marketplaceFormat: preflight.format,
     summary: hasDiagnostics ? 'Completed with diagnostics' : 'Completed',
     findings: preflight.findings,
     stateChanged: true,
@@ -551,6 +588,7 @@ export function disclosureSummary(preflight: LocalRegistrationPreflight): string
   const lines = [
     `Source: ${preflight.canonicalPath}`,
     `Marketplace: ${preflight.marketplaceName}`,
+    `Marketplace Format: ${preflight.format}`,
     `State Revision: ${preflight.stateRevision}`,
     `Validation Snapshot: ${preflight.snapshot.fingerprint.slice(0, 16)}…`,
     `Entries: ${entries.length} (${available} locatable / ${unavailable} unavailable)`,

--- a/src/registration/format.ts
+++ b/src/registration/format.ts
@@ -1,0 +1,63 @@
+/**
+ * Marketplace Format — the codex | claude attribute derived decisively from Marketplace Root
+ * content. The glossary entry lands with the R1 docs ticket (#49); the attribute itself and its
+ * codex-priority / explicit-flip semantics are decided by #43. See also CONTEXT.md:
+ * Marketplace Catalog, Marketplace Registration.
+ *
+ * Detection order is fixed and codex-prioritized: a root exposing both catalogs is codex without
+ * any additional user question. A root exposing neither is CATALOG_MISSING territory (null) —
+ * the registration flows turn that into the unchanged Blocking Finding.
+ *
+ * The detected format is fixed onto the Registration record; it never changes implicitly at
+ * runtime. A later upstream flip can only surface as an Update Candidate produced by an explicit
+ * Marketplace Refresh and change through an explicit Apply Update.
+ */
+
+import { statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { MarketplaceFormat } from '../bridge-state/types.js';
+import { parseCatalog, type CatalogResult } from './catalog.js';
+import { CLAUDE_MARKETPLACE_CATALOG_RELPATH, parseClaudeCatalog } from './claude-catalog.js';
+
+/** Canonical `.agents/plugins/marketplace.json` object (codex format catalog path). */
+export const CODEX_MARKETPLACE_CATALOG_RELPATH = '.agents/plugins/marketplace.json';
+export { CLAUDE_MARKETPLACE_CATALOG_RELPATH };
+
+export interface FormatBoundCatalogContract {
+  /** Snapshot-relative catalog location owned by this format. */
+  relPath: string;
+  /** The format's structural catalog parser. */
+  parse(obj: unknown): CatalogResult;
+}
+
+const CONTRACTS: Record<MarketplaceFormat, FormatBoundCatalogContract> = {
+  codex: { relPath: CODEX_MARKETPLACE_CATALOG_RELPATH, parse: parseCatalog },
+  claude: { relPath: CLAUDE_MARKETPLACE_CATALOG_RELPATH, parse: parseClaudeCatalog },
+};
+
+/** The closed, format-bound catalog contract (canonical path + structural parser). */
+export function catalogContractFor(format: MarketplaceFormat): FormatBoundCatalogContract {
+  return CONTRACTS[format];
+}
+
+/**
+ * Detect the Marketplace Format of one Marketplace Root by scanning for the canonical catalogs.
+ * Deterministic; codex wins when both exist; null means neither exists.
+ *
+ * The check follows symlinks (`statSync`) so a Contained Symlink pointing at a regular file
+ * inside the root counts as its target (CONTEXT.md: Contained Symlink); broken or special
+ * entries simply fall through. Root escape is not handled here — the Validation Snapshot's
+ * symlink containment Blocking Finding denies such sources before any confirmation.
+ */
+export function detectMarketplaceFormat(root: string): MarketplaceFormat | null {
+  for (const format of ['codex', 'claude'] as const) {
+    const abs = join(root, ...CONTRACTS[format].relPath.split('/'));
+    try {
+      if (statSync(abs).isFile()) return format;
+    } catch {
+      // absent / broken link — continue in fixed priority order
+    }
+  }
+  return null;
+}

--- a/src/registration/git-flow.ts
+++ b/src/registration/git-flow.ts
@@ -12,10 +12,11 @@ import { readFileSync, statSync, realpathSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { commitBridgeState, readBridgeState } from '../bridge-state/store.js';
-import type { Registration } from '../bridge-state/types.js';
+import type { MarketplaceFormat, Registration } from '../bridge-state/types.js';
 import { BUDGET } from './budget.js';
 import { CODE, RULE, blocking, hasBlocking, sortFindings, type ValidationFinding } from './findings.js';
-import { parseCatalog, type Catalog } from './catalog.js';
+import type { Catalog } from './catalog.js';
+import { catalogContractFor, detectMarketplaceFormat } from './format.js';
 import { resolveContained } from './contained.js';
 import { acquireAttemptFence, type AttemptFenceHandle } from './fence.js';
 import { createReceipt, type AttemptReceipt } from './receipt.js';
@@ -27,7 +28,7 @@ import { normalizeGitLocator, type CanonicalGitLocator } from './git-locator.js'
 import { normalizeGitSelector, parseGitSelectorString, type GitSelectorInput, type NormalizedGitSelector } from './git-selector.js';
 import { acquireGitSource, cleanupAcquisition, type GitExecutor, type AcquisitionTrustOptions } from './git-acquisition.js';
 import { SourceCache } from '../cache/source-cache.js';
-import { MARKETPLACE_CATALOG_RELPATH } from './flow.js';
+import { CODEX_MARKETPLACE_CATALOG_RELPATH as MARKETPLACE_CATALOG_RELPATH } from './format.js';
 
 export interface GitRegistrationFlowOptions {
   agentDir?: string;
@@ -51,6 +52,8 @@ export interface GitRegistrationPreflight {
   selector: NormalizedGitSelector;
   resolvedRevision: string;
   marketplaceName: string;
+  /** Marketplace Format detected from the acquired root content (codex prioritized); fixed onto the Registration. */
+  format: MarketplaceFormat;
   catalog: Catalog;
   snapshot: ValidationSnapshot;
   findings: ValidationFinding[];
@@ -88,12 +91,14 @@ async function blockedResult(
   handle: AttemptFenceHandle | null,
   opts: GitRegistrationFlowOptions = {},
   existing?: Registration,
+  marketplaceFormat?: MarketplaceFormat,
 ): Promise<{ ok: false; outcome: GitRegistrationOutcome }> {
   if (handle) handle.release();
   const receipt = createReceipt({
     operation: OPERATION,
     trigger: triggerFor(locatorInput, selectorInput),
     expectedStateRevision: expectedRevision,
+    marketplaceFormat,
     summary: 'Blocked',
     findings,
   });
@@ -216,13 +221,11 @@ export async function preflightGitRegistration(
     (sourceKey as SourceKey).canonicalUrl = locator.canonicalUrl;
     (sourceKey as SourceKey).selector = selCanonical;
 
-    // Catalog / containment / budget
+    // Catalog / containment / budget — format detected from the acquired root content
+    // (codex prioritized over claude); neither catalog present ⇒ unchanged CATALOG_MISSING.
     const findings: ValidationFinding[] = [];
-    const catalogPath = join(acquiredPath, MARKETPLACE_CATALOG_RELPATH);
-    let catalogBytes = 0;
-    try {
-      catalogBytes = statSync(catalogPath).size;
-    } catch {
+    const detectedFormat = detectMarketplaceFormat(acquiredPath);
+    if (!detectedFormat) {
       const finding = blocking({
         code: CODE.CATALOG_MISSING,
         phase: 'validation',
@@ -234,12 +237,29 @@ export async function preflightGitRegistration(
       cleanupAcquisition(acquiredPath);
       return blockedResult(locatorInput, selCanonical, expectedRevision, [finding], handle, opts);
     }
+    const contract = catalogContractFor(detectedFormat);
+    const catalogPath = join(acquiredPath, ...contract.relPath.split('/'));
+    let catalogBytes = 0;
+    try {
+      catalogBytes = statSync(catalogPath).size;
+    } catch {
+      const finding = blocking({
+        code: CODE.CATALOG_MISSING,
+        phase: 'validation',
+        target: 'catalog',
+        pointer: contract.relPath,
+        rule: RULE.CATALOG_MISSING,
+        outcome: `Marketplace Catalog not found at ${contract.relPath}; legacy marketplace shapes do not participate in Bridge ingestion`,
+      });
+      cleanupAcquisition(acquiredPath);
+      return blockedResult(locatorInput, selCanonical, expectedRevision, [finding], handle, opts);
+    }
     if (catalogBytes > BUDGET.maxCatalogBytes) {
       const finding = blocking({
         code: CODE.BUDGET_EXCEEDED,
         phase: 'validation',
         target: 'catalog',
-        pointer: MARKETPLACE_CATALOG_RELPATH,
+        pointer: contract.relPath,
         rule: RULE.BUDGET_EXCEEDED,
         outcome: `Validation Budget exceeded: catalog ${catalogBytes} bytes > ${BUDGET.maxCatalogBytes}`,
       });
@@ -256,21 +276,22 @@ export async function preflightGitRegistration(
         code: CODE.CATALOG_MALFORMED,
         phase: 'validation',
         target: 'catalog',
-        pointer: MARKETPLACE_CATALOG_RELPATH,
+        pointer: contract.relPath,
         rule: RULE.CATALOG_MALFORMED,
         outcome: `unable to parse marketplace.json: ${msg}`,
       });
       cleanupAcquisition(acquiredPath);
-      return blockedResult(locatorInput, selCanonical, expectedRevision, [finding], handle, opts);
+      return blockedResult(locatorInput, selCanonical, expectedRevision, [finding], handle, opts, undefined, detectedFormat);
     }
 
-    const catalogResult = parseCatalog(parsed);
+    const catalogResult = contract.parse(parsed);
     findings.push(...catalogResult.findings);
     if (!catalogResult.ok) {
       cleanupAcquisition(acquiredPath);
-      return blockedResult(locatorInput, selCanonical, expectedRevision, sortFindings(findings), handle, opts);
+      return blockedResult(locatorInput, selCanonical, expectedRevision, sortFindings(findings), handle, opts, undefined, detectedFormat);
     }
     const catalog = catalogResult.catalog!;
+    const format: MarketplaceFormat = detectedFormat;
 
     if (catalog.name.length > BUDGET.maxNameLength) {
       findings.push(
@@ -363,6 +384,7 @@ export async function preflightGitRegistration(
       selector,
       resolvedRevision,
       marketplaceName: catalog.name,
+      format,
       catalog,
       snapshot: snapshotResult.snapshot!,
       findings: sorted,
@@ -406,6 +428,7 @@ export async function confirmGitRegistration(
       trigger: triggerFor(preflight.locator.canonicalUrl, preflight.selector.canonical),
       expectedStateRevision: preflight.stateRevision,
       validationSnapshot: preflight.snapshot.fingerprint,
+      marketplaceFormat: preflight.format,
       summary: 'Blocked',
       findings: [
         blocking({
@@ -434,6 +457,7 @@ export async function confirmGitRegistration(
       trigger: triggerFor(preflight.locator.canonicalUrl, preflight.selector.canonical),
       expectedStateRevision: preflight.stateRevision,
       validationSnapshot: preflight.snapshot.fingerprint,
+      marketplaceFormat: preflight.format,
       summary: 'Declined',
       findings: preflight.findings,
       stateChanged: false,
@@ -450,6 +474,7 @@ export async function confirmGitRegistration(
       trigger: triggerFor(preflight.locator.canonicalUrl, preflight.selector.canonical),
       expectedStateRevision: preflight.stateRevision,
       validationSnapshot: preflight.snapshot.fingerprint,
+      marketplaceFormat: preflight.format,
       summary: 'Persistence Indeterminate',
       findings: [
         blocking({
@@ -474,6 +499,7 @@ export async function confirmGitRegistration(
       expectedStateRevision: preflight.stateRevision,
       targetStateRevision: currentRevision,
       validationSnapshot: preflight.snapshot.fingerprint,
+      marketplaceFormat: preflight.format,
       summary: 'Rejected as Stale',
       findings: [
         blocking({
@@ -499,6 +525,7 @@ export async function confirmGitRegistration(
       trigger: triggerFor(preflight.locator.canonicalUrl, preflight.selector.canonical),
       expectedStateRevision: preflight.stateRevision,
       validationSnapshot: preflight.snapshot.fingerprint,
+      marketplaceFormat: preflight.format,
       summary: 'Blocked',
       findings: [dup.finding!],
     });
@@ -511,6 +538,7 @@ export async function confirmGitRegistration(
     id: preflight.registrationId,
     alias: preflight.alias,
     marketplaceName: preflight.marketplaceName,
+    format: preflight.format,
     sourceKind: 'git',
     source: preflight.locator.canonicalUrl,
     sourceKey: preflight.sourceKey,
@@ -535,6 +563,7 @@ export async function confirmGitRegistration(
       expectedStateRevision: preflight.stateRevision,
       targetStateRevision: '?',
       validationSnapshot: preflight.snapshot.fingerprint,
+      marketplaceFormat: preflight.format,
       summary,
       findings: [
         blocking({
@@ -562,6 +591,7 @@ export async function confirmGitRegistration(
     targetStateRevision: targetRevision,
     observedStateRevision: targetRevision,
     validationSnapshot: preflight.snapshot.fingerprint,
+    marketplaceFormat: preflight.format,
     summary: hasDiagnostics ? 'Completed with diagnostics' : 'Completed',
     findings: preflight.findings,
     stateChanged: true,
@@ -589,6 +619,7 @@ export function disclosureSummaryGit(preflight: GitRegistrationPreflight): strin
     `Git Selector: ${preflight.selector.kind} → ${preflight.selector.canonical}`,
     `Resolved Revision: ${preflight.resolvedRevision}`,
     `Marketplace: ${preflight.marketplaceName}`,
+    `Marketplace Format: ${preflight.format}`,
     `State Revision: ${preflight.stateRevision}`,
     `Validation Snapshot: ${preflight.snapshot.fingerprint.slice(0, 16)}…`,
     `Entries: ${entries.length} (${available} locatable / ${unavailable} unavailable)`,

--- a/src/registration/receipt.ts
+++ b/src/registration/receipt.ts
@@ -8,6 +8,7 @@
 
 import { randomUUID } from 'node:crypto';
 
+import type { MarketplaceFormat } from '../bridge-state/types.js';
 import { CODE, hasBlocking, sortFindings, type ValidationFinding } from './findings.js';
 import { redactSource } from './source-key.js';
 
@@ -64,6 +65,8 @@ export interface AttemptReceipt {
   observedStateRevision?: string;
   /** Bound Validation Snapshot fingerprint. */
   validationSnapshot?: string;
+  /** Marketplace Format validated by this attempt when detection had already resolved it. */
+  marketplaceFormat?: MarketplaceFormat;
   /** Array of snapshot fingerprints involved. */
   snapshotFingerprints?: string[];
   /** Three-orthogonal axis 1: Durable persistence outcome. */
@@ -162,6 +165,10 @@ function isOptionalReceiptId(value: unknown): value is string | undefined {
   return value === undefined || isReceiptId(value);
 }
 
+function isOptionalMarketplaceFormat(value: unknown): value is MarketplaceFormat | undefined {
+  return value === undefined || value === 'codex' || value === 'claude';
+}
+
 function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((item) => typeof item === 'string');
 }
@@ -199,6 +206,7 @@ export function isAttemptReceipt(value: unknown): value is AttemptReceipt {
     isOptionalString(value.targetStateRevision) &&
     isOptionalString(value.observedStateRevision) &&
     isOptionalString(value.validationSnapshot) &&
+    isOptionalMarketplaceFormat(value.marketplaceFormat) &&
     (value.snapshotFingerprints === undefined || isStringArray(value.snapshotFingerprints)) &&
     typeof value.durableOutcome === 'string' &&
     DURABLE_OUTCOMES.has(value.durableOutcome as DurableOutcome) &&
@@ -230,6 +238,8 @@ export interface ReceiptOptions {
   targetStateRevision?: string;
   observedStateRevision?: string;
   validationSnapshot?: string;
+  /** Marketplace Format validated by this attempt when detection had already resolved it. */
+  marketplaceFormat?: MarketplaceFormat;
   snapshotFingerprints?: string[];
   durableOutcome?: DurableOutcome;
   runtimeOutcome?: RuntimeOutcome;
@@ -415,6 +425,7 @@ export function createReceipt(opts: ReceiptOptions): AttemptReceipt {
     targetStateRevision: opts.targetStateRevision,
     observedStateRevision: opts.observedStateRevision,
     validationSnapshot: opts.validationSnapshot,
+    marketplaceFormat: opts.marketplaceFormat,
     snapshotFingerprints: opts.snapshotFingerprints,
     durableOutcome: durable,
     findings: sortedFindings,

--- a/tests/integration/lifecycle-format-flip.test.ts
+++ b/tests/integration/lifecycle-format-flip.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Integration — Marketplace Format flip semantics (#47).
+ *
+ * A Registration's Marketplace Format is fixed at confirmation. When the upstream source later
+ * flips (e.g. the codex catalog disappears and only the claude catalog remains), the change may
+ * surface only as an Update Candidate produced by an explicit Marketplace Refresh, and lands on
+ * the Registration only through an explicit Apply Update. Browse never adopts the flip silently.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { readBridgeState } from '../../src/bridge-state/store.js';
+import { inspectMarketplaceEntries } from '../../src/installation/inspection.js';
+import { refreshRegistration } from '../../src/lifecycle/refresh.js';
+import { buildUpdatePlan } from '../../src/lifecycle/update-plan.js';
+import { applyUpdate } from '../../src/lifecycle/update.js';
+import {
+  confirmLocalRegistration,
+  preflightLocalRegistration,
+} from '../../src/registration/flow.js';
+
+function makeEnv() {
+  const root = mkdtempSync(join(tmpdir(), 'format-flip-'));
+  return {
+    root,
+    agentDir: join(root, 'agent'),
+    marketplace: join(root, 'marketplace'),
+  };
+}
+
+/** Both catalogs coexist; codex must win detection without any extra question. */
+function makeDualCatalogRoot(root: string): void {
+  mkdirSync(join(root, '.agents', 'plugins'), { recursive: true });
+  mkdirSync(join(root, '.claude-plugin'), { recursive: true });
+
+  mkdirSync(join(root, 'plugins', 'release-helper', '.codex-plugin'), { recursive: true });
+  mkdirSync(join(root, 'plugins', 'release-helper', 'skills', 'release-notes'), { recursive: true });
+  writeFileSync(
+    join(root, '.agents', 'plugins', 'marketplace.json'),
+    JSON.stringify({
+      name: 'acme-marketplace',
+      plugins: [{ name: 'release-helper', source: { source: 'local', path: './plugins/release-helper' } }],
+    }),
+  );
+  writeFileSync(join(root, 'plugins', 'release-helper', '.codex-plugin', 'plugin.json'), JSON.stringify({ name: 'release-helper', skills: './skills/' }));
+  writeFileSync(
+    join(root, 'plugins', 'release-helper', 'skills', 'release-notes', 'SKILL.md'),
+    '---\nname: release-notes\ndescription: Write release notes\n---\n\nWrite release notes.\n',
+  );
+
+  mkdirSync(join(root, 'claude-plugin-src', '.claude-plugin'), { recursive: true });
+  writeFileSync(join(root, 'claude-plugin-src', '.claude-plugin', 'plugin.json'), JSON.stringify({ name: 'mattpocock-skills', skills: ['./skills/code-review'] }));
+  mkdirSync(join(root, 'claude-plugin-src', 'skills', 'code-review'), { recursive: true });
+  writeFileSync(
+    join(root, 'claude-plugin-src', 'skills', 'code-review', 'SKILL.md'),
+    '---\nname: code-review\ndescription: Review code changes\n---\n\nReview code.\n',
+  );
+  writeFileSync(
+    join(root, '.claude-plugin', 'marketplace.json'),
+    JSON.stringify({
+      name: 'matt-marketplace',
+      owner: { name: 'Matt Pocock' },
+      plugins: [{ name: 'mattpocock-skills', source: './claude-plugin-src' }],
+    }),
+  );
+}
+
+/** The flip: upstream removes the codex catalog entirely. */
+function flipToClaudeOnly(root: string): void {
+  rmSync(join(root, '.agents'), { recursive: true, force: true });
+}
+
+describe('Marketplace Format flip — Refresh → Update Candidate → explicit Apply Update', () => {
+  let env: ReturnType<typeof makeEnv>;
+  let registrationId: string;
+
+  beforeEach(async () => {
+    env = makeEnv();
+    makeDualCatalogRoot(env.marketplace);
+    const preflight = await preflightLocalRegistration(env.marketplace, { agentDir: env.agentDir });
+    expect(preflight.ok).toBe(true);
+    if (!preflight.ok) return;
+    // codex wins while both catalogs coexist
+    expect(preflight.preflight.format).toBe('codex');
+    const confirmed = await confirmLocalRegistration(preflight.preflight, true, { agentDir: env.agentDir });
+    expect(confirmed.status).toBe('completed');
+    if (confirmed.status !== 'completed') return;
+    registrationId = confirmed.registration.id;
+  });
+
+  afterEach(() => rmSync(env.root, { recursive: true, force: true }));
+
+  it('surfacing the flip requires a Refresh; applying it requires an explicit Apply Update', async () => {
+    flipToClaudeOnly(env.marketplace);
+
+    // Browse stays bound to the registered codex format — no silent adoption.
+    const stateBefore = await readBridgeState({ agentDir: env.agentDir });
+    const registered = stateBefore.state!.registrations.find((item) => item.id === registrationId)!;
+    expect(registered.format).toBe('codex');
+    const browse = inspectMarketplaceEntries(registered);
+    expect(browse.entries.some((item) => item.plugin)).toBe(false);
+    expect(browse.findings.some((finding) => finding.code === 'CATALOG_MISSING')).toBe(true);
+
+    // Explicit Marketplace Refresh validates the flipped tree under its detected claude format.
+    const refreshed = await refreshRegistration(registrationId, { agentDir: env.agentDir });
+    expect(refreshed.status).toBe('update-candidate');
+    if (refreshed.status !== 'update-candidate') return;
+    expect(refreshed.candidate.format).toBe('claude');
+    expect(refreshed.candidate.inspection.marketplaceId).toBe(`${registrationId}/matt-marketplace`);
+
+    // Bridge State is still unchanged before Apply Update.
+    const stateMid = await readBridgeState({ agentDir: env.agentDir });
+    expect(stateMid.state!.registrations.find((item) => item.id === registrationId)!.format).toBe('codex');
+
+    const plan = buildUpdatePlan(refreshed.candidate, [], refreshed.candidate.stateRevision, {
+      kind: 'apply-update',
+      registrationConfirmed: true,
+      choices: {},
+    });
+    expect(plan.ok).toBe(true);
+    if (!plan.ok) return;
+    const applied = await applyUpdate(plan.plan, { agentDir: env.agentDir });
+    expect(applied.status).toBe('completed');
+
+    const stateAfter = await readBridgeState({ agentDir: env.agentDir });
+    const flipped = stateAfter.state!.registrations.find((item) => item.id === registrationId)!;
+    expect(flipped.format).toBe('claude');
+
+    // And now browse reads the claude catalog.
+    const browseAfter = inspectMarketplaceEntries(flipped);
+    expect(browseAfter.marketplaceId).toBe(`${registrationId}/matt-marketplace`);
+    expect(browseAfter.entries.filter((item) => item.classification === 'compatible')).toHaveLength(1);
+  });
+});

--- a/tests/unit/extensions/transaction-flows.test.ts
+++ b/tests/unit/extensions/transaction-flows.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, cpSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -10,7 +10,7 @@ import { inspectMarketplaceEntries } from '../../../src/installation/inspection.
 import { appendReceipt, readReceiptJournal } from '../../../src/journal/journal.js';
 import { dispatchLedgerAction, formatStartupReceipt } from '../../../extensions/pi/index.js';
 import { TRANSACTION_STEPS } from '../../../extensions/pi/transaction-sheet.js';
-import { transactionStepLabel, uiText, verdictText, findingOutcomeText } from '../../../extensions/pi/ui-strings.js';
+import { transactionStepLabel, uiText, verdictText, findingOutcomeText, marketplaceFormatText } from '../../../extensions/pi/ui-strings.js';
 import { quoteTerminalText } from '../../../extensions/pi/terminal-presentation.js';
 import {
   fullValidationDisclosureLines,
@@ -1478,5 +1478,104 @@ describe('Bridge Ledger transaction flow adapters', () => {
     expect(confirmationTitles[1]).toMatch(/^Activation Confirmation/);
     const installed = await readBridgeState({ agentDir });
     expect(installed.state?.installations[0]?.installationState).toBe('enabled');
+  });
+
+  it('registers a mattpocock-shaped claude repo end-to-end through the mock Git executor (#47)', async () => {
+    // --- claude-only fixture: mattpocock-like layout with nested skill categories ---
+    const fixture = join(root, 'matt-fixture');
+    mkdirSync(join(fixture, '.claude-plugin'), { recursive: true });
+    const pluginRoot = join(fixture, 'plugins', 'mattpocock-skills');
+    mkdirSync(join(pluginRoot, '.claude-plugin'), { recursive: true });
+    for (const [skillDir, frontmatter] of [
+      ['skills/engineering/code-review', 'name: code-review\ndescription: Review code changes\ndisable-model-invocation: true'],
+      ['skills/diagnostics/diagnosing-bugs', 'name: diagnosing-bugs\ndescription: Diagnose hard bugs'],
+    ] as const) {
+      mkdirSync(join(pluginRoot, ...skillDir.split('/')), { recursive: true });
+      writeFileSync(join(pluginRoot, ...skillDir.split('/'), 'SKILL.md'), `---\n${frontmatter}\n---\n\nBody.\n`);
+    }
+    writeFileSync(
+      join(pluginRoot, '.claude-plugin', 'plugin.json'),
+      JSON.stringify({ name: 'mattpocock-skills', skills: ['./skills/engineering/code-review', './skills/diagnostics/diagnosing-bugs'] }),
+    );
+    writeFileSync(
+      join(fixture, '.claude-plugin', 'marketplace.json'),
+      JSON.stringify({
+        name: 'mattpocock-marketplace',
+        owner: { name: 'Matt Pocock' },
+        plugins: [{ name: 'mattpocock-skills', source: './plugins/mattpocock-skills' }],
+      }),
+    );
+
+    const sha = 'a'.repeat(40);
+    const executor = async (args: string[]) => {
+      if (args.includes('ls-remote')) {
+        return { exitCode: 0, stdout: `${sha}\trefs/heads/main\n`, stderr: '' };
+      }
+      if (args.includes('clone')) {
+        const dest = args[args.length - 1]!;
+        cpSync(fixture, dest, { recursive: true });
+        mkdirSync(join(dest, '.git'), { recursive: true });
+        return { exitCode: 0, stdout: '', stderr: '' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    };
+
+    const events: string[] = [];
+    const renderedByStep = new Map<string, string>();
+    let confirmationBody = '';
+    const notifications: string[] = [];
+    const ctx = {
+      cwd,
+      mode: 'tui',
+      hasUI: true,
+      isProjectTrusted: () => true,
+      ui: {
+        select: async () => uiText('reg.git.selector.default'),
+        input: async () => 'https://github.com/mattpocock/skills',
+        custom: async (factory: any): Promise<unknown> => new Promise((resolve) => {
+          const component = factory({ requestRender: () => {} }, theme, {}, resolve);
+          let rendered = component.render(120).join('\n');
+          const active = TRANSACTION_STEPS.find((step, index) =>
+            rendered.includes(`▸ ${index + 1} ${transactionStepLabel(step)}（${uiText('step.activeSuffix')}）`));
+          if (active) {
+            events.push(active);
+            if (active === 'Validation' && !renderedByStep.has(active)) {
+              // expand the collapsible full Validation Disclosure before capturing
+              component.handleInput?.('d');
+              rendered = component.render(120).join('\n');
+            }
+            if (!renderedByStep.has(active)) renderedByStep.set(active, rendered);
+          }
+          component.handleInput?.('\r');
+        }),
+        confirm: async (_title: string, message: string) => {
+          confirmationBody = message;
+          return true;
+        },
+        notify: (message: string) => notifications.push(message),
+      },
+    };
+
+    await runGitRegistrationFlow(ctx as never, { executor });
+
+    // Full transaction: Intent → Validation → Consent → Plan → Commit → Receipt
+    expect(events).toEqual(['Intent', 'Validation', 'Consent', 'Plan', 'Commit', 'Receipt']);
+
+    // Validation disclosure and Registration Confirmation both show the detected format.
+    expect(renderedByStep.get('Validation')).toContain(`Marketplace Format ${marketplaceFormatText('claude')}`);
+    expect(confirmationBody).toContain(marketplaceFormatText('claude'));
+
+    const state = await readBridgeState({ agentDir });
+    const registration = state.state?.registrations[0];
+    expect(registration).toBeDefined();
+    expect(registration!.format).toBe('claude');
+    expect(registration!.sourceKind).toBe('git');
+    expect(registration!.canonicalLocator).toBe('https://github.com/mattpocock/skills');
+
+    const journal = await readReceiptJournal({ agentDir });
+    const receipt = journal.receipts.at(-1)!;
+    expect(receipt.summary).toBe('Completed');
+    expect(receipt.marketplaceFormat).toBe('claude');
+    expect(notifications.join('\n')).toContain(marketplaceFormatText('claude'));
   });
 });

--- a/tests/unit/installation/inspection-format.test.ts
+++ b/tests/unit/installation/inspection-format.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { commitBridgeState, readBridgeState } from '../../../src/bridge-state/store.js';
+import type { Registration } from '../../../src/bridge-state/types.js';
+import { inspectMarketplaceEntries } from '../../../src/installation/inspection.js';
+
+type Env = { agentDir: string; root: string };
+
+function makeEnv(): Env {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'inspection-format-')));
+  return { agentDir: join(root, 'agent'), root };
+}
+
+/** mattpocock-shaped claude marketplace: nested skill categories under declared skills paths. */
+function makeClaudeRoot(root: string): void {
+  mkdirSync(join(root, '.claude-plugin'), { recursive: true });
+  const pluginRoot = join(root, 'plugins', 'mattpocock-skills');
+  mkdirSync(join(pluginRoot, '.claude-plugin'), { recursive: true });
+  mkdirSync(join(pluginRoot, 'skills', 'engineering', 'code-review'), { recursive: true });
+  writeFileSync(
+    join(pluginRoot, 'skills', 'engineering', 'code-review', 'SKILL.md'),
+    '---\nname: code-review\ndescription: Review code changes\ndisable-model-invocation: true\n---\n\nReview code.\n',
+  );
+  mkdirSync(join(pluginRoot, 'skills', 'interview', 'grilling'), { recursive: true });
+  writeFileSync(
+    join(pluginRoot, 'skills', 'interview', 'grilling', 'SKILL.md'),
+    '---\nname: grilling\ndescription: Grill the plan\n---\n\nGrill.\n',
+  );
+  writeFileSync(
+    join(pluginRoot, '.claude-plugin', 'plugin.json'),
+    JSON.stringify({ name: 'mattpocock-skills', skills: ['./skills/engineering/code-review', './skills/interview/grilling'] }),
+  );
+  writeFileSync(
+    join(root, '.claude-plugin', 'marketplace.json'),
+    JSON.stringify({
+      name: 'matt-marketplace',
+      owner: { name: 'Matt Pocock' },
+      plugins: [
+        { name: 'mattpocock-skills', source: './plugins/mattpocock-skills' },
+        // bare name entry → Unavailable with its stable reason
+        { name: 'external-tool', source: 'external-tool' },
+      ],
+    }),
+  );
+}
+
+async function registerLocal(env: Env, format?: 'codex' | 'claude', validationSnapshot?: string): Promise<Registration> {
+  const registration: Registration = {
+    id: '22222222-2222-4222-8222-222222222222',
+    marketplaceName: 'matt-marketplace',
+    sourceKind: 'local',
+    source: env.root,
+    ...(format ? { format } : {}),
+    ...(validationSnapshot ? { validationSnapshot } : {}),
+  };
+  await commitBridgeState(
+    (current) => ({ ...current, registrations: [...current.registrations, registration] }),
+    { agentDir: env.agentDir },
+  );
+  return registration;
+}
+
+describe('Marketplace Entry inspection — format-bound browse (#47)', () => {
+  let env: Env;
+
+  beforeEach(() => {
+    env = makeEnv();
+    makeClaudeRoot(env.root);
+  });
+  afterEach(() => {
+    try { rmSync(env.root, { recursive: true, force: true }); } catch {}
+  });
+
+  it('browses a registered claude marketplace: Compatible entry lists the plugin and every nested skill', async () => {
+    const registration = await registerLocal(env, 'claude');
+    const inspection = inspectMarketplaceEntries(registration);
+
+    expect(inspection.marketplaceId).toBe(`${registration.id}/matt-marketplace`);
+    const compatible = inspection.entries.filter((item) => item.classification === 'compatible');
+    expect(compatible).toHaveLength(1);
+    expect(compatible[0]!.plugin!.manifestName).toBe('mattpocock-skills');
+    const skillNames = compatible[0]!.plugin!.skills.map((skill) => skill.name);
+    expect(skillNames).toEqual(['code-review', 'grilling']);
+    // Invocation Policy derives solely from the Skill Descriptor frontmatter in claude format
+    expect(compatible[0]!.plugin!.skills.find((skill) => skill.name === 'code-review')!.invocationPolicy).toBe('explicit');
+    expect(compatible[0]!.plugin!.skills.find((skill) => skill.name === 'grilling')!.invocationPolicy).toBe('implicit');
+  });
+
+  it('discloses why an unqualified claude entry is an Unavailable Entry', async () => {
+    const registration = await registerLocal(env, 'claude');
+    const inspection = inspectMarketplaceEntries(registration);
+
+    const unavailable = inspection.entries.find((item) => item.entry.name === 'external-tool');
+    expect(unavailable?.classification).toBeUndefined();
+    expect(unavailable?.unavailableReason).toMatch(/bare name source/);
+  });
+
+  it('reads a codex-registered root through codex only — an upstream flip is never adopted implicitly', async () => {
+    // Registration was created as codex (both catalogs used to coexist; codex won).
+    mkdirSync(join(env.root, '.agents', 'plugins'), { recursive: true });
+    writeFileSync(
+      join(env.root, '.agents', 'plugins', 'marketplace.json'),
+      JSON.stringify({ name: 'matt-marketplace', plugins: [{ name: 'legacy', path: './plugins/mattpocock-skills' }] }),
+    );
+    const registration = await registerLocal(env, 'codex', 'c'.repeat(64));
+
+    // Upstream removes the codex catalog — browse stays bound to the registered format.
+    rmSync(join(env.root, '.agents'), { recursive: true, force: true });
+
+    const inspection = inspectMarketplaceEntries(registration);
+    expect(inspection.entries).toEqual([]);
+    // fail-closed: the registered format cannot read its catalog, and nothing claude-shaped appears
+    expect(inspection.findings.some((finding) => finding.code === 'CATALOG_MISSING')).toBe(true);
+    expect(inspection.entries.some((item) => item.plugin)).toBe(false);
+  });
+
+  it('legacy registrations without a persisted format keep reading codex', async () => {
+    mkdirSync(join(env.root, '.agents', 'plugins'), { recursive: true });
+    mkdirSync(join(env.root, 'plugins', 'release-helper'), { recursive: true });
+    writeFileSync(join(env.root, 'plugins', 'release-helper', 'plugin.json'), JSON.stringify({ name: 'release-helper' }));
+    writeFileSync(join(env.root, 'plugins', 'release-helper', 'SKILL.md'), '# release-helper');
+    writeFileSync(
+      join(env.root, '.agents', 'plugins', 'marketplace.json'),
+      JSON.stringify({ name: 'matt-marketplace', plugins: [{ name: 'release-helper', path: './plugins/release-helper' }] }),
+    );
+
+    // v2→v3 migration backfills 'codex'; an absent attribute must behave identically.
+    const registration = await registerLocal(env);
+    const inspection = inspectMarketplaceEntries(registration);
+    expect(inspection.entries).toHaveLength(1);
+    expect(inspection.marketplaceId).toBe(`${registration.id}/matt-marketplace`);
+  });
+});

--- a/tests/unit/registration/flow.test.ts
+++ b/tests/unit/registration/flow.test.ts
@@ -337,3 +337,113 @@ describe('Local Marketplace Registration flow', () => {
     expect(missing?.pointer).toBe(MARKETPLACE_CATALOG_RELPATH);
   });
 });
+describe('Marketplace Format detection wiring — local registration', () => {
+  let env: Env;
+  let root: string;
+
+  beforeEach(() => {
+    env = makeEnv();
+    root = realpathSync(mkdtempSync(join(tmpdir(), 'claude-root-')));
+  });
+  afterEach(() => {
+    try {
+      rmSync(env.tmpRoot, { recursive: true, force: true });
+      rmSync(root, { recursive: true, force: true });
+    } catch {}
+  });
+
+  function makeClaudeMarketplace(marketRoot: string, name = 'matt-marketplace'): void {
+    mkdirSync(join(marketRoot, '.claude-plugin'), { recursive: true });
+    const pluginRoot = join(marketRoot, 'plugins', 'mattpocock-skills');
+    mkdirSync(join(pluginRoot, '.claude-plugin'), { recursive: true });
+    mkdirSync(join(pluginRoot, 'skills', 'engineering', 'code-review'), { recursive: true });
+    writeFileSync(
+      join(pluginRoot, 'skills', 'engineering', 'code-review', 'SKILL.md'),
+      '---\nname: code-review\ndescription: Review code changes\ndisable-model-invocation: true\n---\n\nReview code.\n',
+    );
+    mkdirSync(join(pluginRoot, 'skills', 'diagnostics', 'diagnosing-bugs'), { recursive: true });
+    writeFileSync(
+      join(pluginRoot, 'skills', 'diagnostics', 'diagnosing-bugs', 'SKILL.md'),
+      '---\nname: diagnosing-bugs\ndescription: Diagnose hard bugs\n---\n\nDiagnose.\n',
+    );
+    writeFileSync(
+      join(pluginRoot, '.claude-plugin', 'plugin.json'),
+      JSON.stringify({ name: 'mattpocock-skills', skills: ['./skills/engineering/code-review', './skills/diagnostics/diagnosing-bugs'] }),
+    );
+    writeFileSync(
+      join(marketRoot, '.claude-plugin', 'marketplace.json'),
+      JSON.stringify({
+        name,
+        owner: { name: 'Matt Pocock' },
+        plugins: [{ name: 'mattpocock-skills', source: './plugins/mattpocock-skills', description: 'skill collection' }],
+      }),
+    );
+  }
+
+  it('registers a claude-only repo and fixes format=claude onto the Registration', async () => {
+    makeClaudeMarketplace(root);
+    const res = await preflightLocalRegistration(root, opts(env));
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.preflight.format).toBe('claude');
+    expect(disclosureSummary(res.preflight)).toContain('Marketplace Format: claude');
+
+    const outcome = await confirmLocalRegistration(res.preflight, true, opts(env));
+    expect(outcome.status).toBe('completed');
+    if (outcome.status !== 'completed') return;
+    expect(outcome.registration.format).toBe('claude');
+    expect(outcome.receipt.marketplaceFormat).toBe('claude');
+    // inert entry metadata (description) is disclosed as a Validation Warning
+    expect(outcome.receipt.summary).toBe('Completed with diagnostics');
+
+    const state = await readBridgeState({ agentDir: env.agentDir });
+    expect(state.state!.registrations[0].format).toBe('claude');
+  });
+
+  it('adopts codex without an extra question when both catalogs coexist', async () => {
+    makeClaudeMarketplace(root);
+    mkdirSync(join(root, '.agents', 'plugins'), { recursive: true });
+    mkdirSync(join(root, 'plugins', 'release-helper'), { recursive: true });
+    writeFileSync(join(root, 'plugins', 'release-helper', 'plugin.json'), JSON.stringify({ name: 'release-helper' }));
+    writeFileSync(join(root, 'plugins', 'release-helper', 'SKILL.md'), '# release-helper');
+    writeFileSync(
+      join(root, '.agents', 'plugins', 'marketplace.json'),
+      JSON.stringify({ name: 'acme-marketplace', plugins: [{ name: 'release-helper', path: './plugins/release-helper' }] }),
+    );
+
+    const res = await preflightLocalRegistration(root, opts(env));
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.preflight.format).toBe('codex');
+    expect(disclosureSummary(res.preflight)).toContain('Marketplace Format: codex');
+    cancelLocalRegistration(res.preflight);
+  });
+
+  it('keeps CATALOG_MISSING unchanged when neither catalog exists', async () => {
+    mkdirSync(join(root, 'unrelated'), { recursive: true });
+    const res = await preflightLocalRegistration(root, opts(env));
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.outcome.status).toBe('blocked');
+    if (res.outcome.status !== 'blocked') return;
+    expect(res.outcome.findings[0].code).toBe('CATALOG_MISSING');
+  });
+
+  it('parses claude catalogs under their fail-closed field policy when format=claude', async () => {
+    makeClaudeMarketplace(root);
+    writeFileSync(
+      join(root, '.claude-plugin', 'marketplace.json'),
+      JSON.stringify({
+        name: 'matt-marketplace',
+        owner: { name: 'Matt Pocock' },
+        plugins: [{ name: 'mattpocock-skills', source: './skills', rogueField: true }],
+      }),
+    );
+    const res = await preflightLocalRegistration(root, opts(env));
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.outcome.status).toBe('blocked');
+    if (res.outcome.status !== 'blocked') return;
+    expect(res.outcome.findings.some((f) => f.code === 'CATALOG_UNKNOWN_FIELD')).toBe(true);
+  });
+});

--- a/tests/unit/registration/format.test.ts
+++ b/tests/unit/registration/format.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  CLAUDE_MARKETPLACE_CATALOG_RELPATH,
+  CODEX_MARKETPLACE_CATALOG_RELPATH,
+  catalogContractFor,
+  detectMarketplaceFormat,
+} from '../../../src/registration/format.js';
+
+describe('Marketplace Format detection', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'format-detect-'));
+  });
+  afterEach(() => {
+    try { rmSync(root, { recursive: true, force: true }); } catch {}
+  });
+
+  function writeCodex(body: unknown = { name: 'acme', plugins: [] }): void {
+    mkdirSync(join(root, '.agents', 'plugins'), { recursive: true });
+    writeFileSync(join(root, CODEX_MARKETPLACE_CATALOG_RELPATH), JSON.stringify(body));
+  }
+  function writeClaude(body: unknown = { name: 'acme', owner: { name: 'o' }, plugins: [] }): void {
+    mkdirSync(join(root, '.claude-plugin'), { recursive: true });
+    writeFileSync(join(root, CLAUDE_MARKETPLACE_CATALOG_RELPATH), JSON.stringify(body));
+  }
+
+  it('detects codex when only the codex catalog exists', () => {
+    writeCodex();
+    expect(detectMarketplaceFormat(root)).toBe('codex');
+  });
+
+  it('detects claude when only the claude catalog exists', () => {
+    writeClaude();
+    expect(detectMarketplaceFormat(root)).toBe('claude');
+  });
+
+  it('prioritizes codex when both catalogs coexist — no extra question is asked', () => {
+    writeCodex();
+    writeClaude();
+    expect(detectMarketplaceFormat(root)).toBe('codex');
+  });
+
+  it('returns null when neither catalog exists (CATALOG_MISSING territory)', () => {
+    expect(detectMarketplaceFormat(root)).toBeNull();
+  });
+
+  it('does not accept a directory sitting at the catalog path', () => {
+    mkdirSync(join(root, '.agents', 'plugins', 'marketplace.json'), { recursive: true });
+    mkdirSync(join(root, '.claude-plugin'), { recursive: true });
+    writeFileSync(join(root, CLAUDE_MARKETPLACE_CATALOG_RELPATH), '{}');
+    expect(detectMarketplaceFormat(root)).toBe('claude');
+  });
+
+  it('follows a contained symlinked catalog to its in-root target (Contained Symlink)', () => {
+    writeClaude();
+    // A codex catalog that is a symlink to the claude catalog file inside the same root.
+    mkdirSync(join(root, '.agents', 'plugins'), { recursive: true });
+    symlinkSync(
+      join(root, CLAUDE_MARKETPLACE_CATALOG_RELPATH),
+      join(root, CODEX_MARKETPLACE_CATALOG_RELPATH),
+    );
+    expect(detectMarketplaceFormat(root)).toBe('codex');
+  });
+
+  it('treats a broken symlinked catalog as absent and falls through to the next candidate', () => {
+    mkdirSync(join(root, '.agents', 'plugins'), { recursive: true });
+    symlinkSync(join(root, 'nowhere.json'), join(root, CODEX_MARKETPLACE_CATALOG_RELPATH));
+    writeClaude();
+    expect(detectMarketplaceFormat(root)).toBe('claude');
+  });
+
+  it('binds each format to its canonical catalog contract', () => {
+    const codex = catalogContractFor('codex');
+    expect(codex.relPath).toBe(CODEX_MARKETPLACE_CATALOG_RELPATH);
+    const claude = catalogContractFor('claude');
+    expect(claude.relPath).toBe(CLAUDE_MARKETPLACE_CATALOG_RELPATH);
+
+    // The parser dispatch honors the closed field policy of each shape.
+    const claudeParsed = claude.parse({ name: 'acme', owner: { name: 'o' }, plugins: [] });
+    expect(claudeParsed.ok).toBe(true);
+    const claudeUnknown = claude.parse({ name: 'acme', owner: { name: 'o' }, plugins: [], rogue: 1 });
+    expect(claudeUnknown.ok).toBe(false);
+
+    const codexParsed = codex.parse({ name: 'acme', plugins: [] });
+    expect(codexParsed.ok).toBe(true);
+  });
+});

--- a/tests/unit/registration/git-flow.test.ts
+++ b/tests/unit/registration/git-flow.test.ts
@@ -368,3 +368,73 @@ describe('Git Marketplace Registration flow', () => {
     }
   });
 });
+
+describe('Marketplace Format detection wiring — git registration', () => {
+  let env: ReturnType<typeof makeEnv>;
+  let fixture: string;
+  const locator = 'https://github.com/mattpocock/skills';
+
+  beforeEach(() => {
+    env = makeEnv();
+    fixture = realpathSync(mkdtempSync(join(tmpdir(), 'mkt-git-claude-')));
+    // claude-only repo: `.claude-plugin/` catalogs with a manifest-backed plugin
+    mkdirSync(join(fixture, '.claude-plugin'), { recursive: true });
+    const pluginRoot = join(fixture, 'plugins', 'mattpocock-skills');
+    mkdirSync(join(pluginRoot, '.claude-plugin'), { recursive: true });
+    mkdirSync(join(pluginRoot, 'skills', 'engineering', 'code-review'), { recursive: true });
+    writeFileSync(
+      join(pluginRoot, 'skills', 'engineering', 'code-review', 'SKILL.md'),
+      '---\nname: code-review\ndescription: Review code changes\n---\n\nReview code.\n',
+    );
+    writeFileSync(
+      join(pluginRoot, '.claude-plugin', 'plugin.json'),
+      JSON.stringify({ name: 'mattpocock-skills', skills: ['./skills/engineering/code-review'] }),
+    );
+    writeFileSync(
+      join(fixture, '.claude-plugin', 'marketplace.json'),
+      JSON.stringify({
+        name: 'mattpocock-marketplace',
+        owner: { name: 'Matt Pocock' },
+        plugins: [{ name: 'mattpocock-skills', source: './plugins/mattpocock-skills' }],
+      }),
+    );
+  });
+  afterEach(() => {
+    try { rmSync(env.tmpRoot, { recursive: true, force: true }); } catch {}
+    try { rmSync(fixture, { recursive: true, force: true }); } catch {}
+  });
+
+  it('registers an acquired claude-only repo and fixes format=claude onto the Registration', async () => {
+    const exec = makeMockExecutor(fixture, { sha: 'f'.repeat(40) });
+    const res = await preflightGitRegistration(locator, { kind: 'branch', value: 'main' }, gitOpts(env, exec));
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.preflight.format).toBe('claude');
+    expect(disclosureSummaryGit(res.preflight)).toContain('Marketplace Format: claude');
+
+    const outcome = await confirmGitRegistration(res.preflight, true, gitOpts(env, exec));
+    expect(outcome.status).toBe('completed');
+    if (outcome.status !== 'completed') return;
+    expect(outcome.registration.format).toBe('claude');
+    expect(outcome.receipt.marketplaceFormat).toBe('claude');
+
+    const state = await readBridgeState({ agentDir: env.agentDir });
+    expect(state.state!.registrations[0].format).toBe('claude');
+    expect(state.state!.registrations[0].canonicalLocator).toBe(locator);
+  });
+
+  it('keeps CATALOG_MISSING unchanged when the acquired repo has neither catalog', async () => {
+    const emptyFixture = realpathSync(mkdtempSync(join(tmpdir(), 'empty-git-claude-')));
+    try {
+      const exec = makeMockExecutor(emptyFixture);
+      const res = await preflightGitRegistration(locator, { kind: 'branch', value: 'main' }, gitOpts(env, exec));
+      expect(res.ok).toBe(false);
+      if (res.ok) return;
+      expect(res.outcome.status).toBe('blocked');
+      if (res.outcome.status !== 'blocked') return;
+      expect(res.outcome.findings[0].code).toBe('CATALOG_MISSING');
+    } finally {
+      try { rmSync(emptyFixture, { recursive: true, force: true }); } catch {}
+    }
+  });
+});


### PR DESCRIPTION
Closes #47
Parent: #43

## 摘要

將 Marketplace Format（`codex | claude`）偵測接入 local 與 git 登記流程與瀏覽接縫：掃描 Marketplace Root 決定性推導格式（codex 優先），claude repo 全程可登記，披露／確認／收據／Attempt Summary 呈現格式，瀏覽顯示每個 entry 的真實分類結果與 Unavailable 原因。

## 實作

- **`src/registration/format.ts`（新）**：`detectMarketplaceFormat(root)` 固定 codex 優先掃描；`catalogContractFor(format)` 綁定各格式的 canonical catalog 路徑與結構解析器。跟隨 Contained Symlink（statSync），斷鏈視同缺席。
- **登記流程（local + git）**：偵測格式 → 依格式分流 catalog 讀取/解析/budget → `format` 固化於 Registration；兩者皆無時 CATALOG_MISSING 行為不變（訊息原樣保留）。claude 解析失敗走 claude parser 的 fail-closed 欄位政策。
- **翻轉語意**：瀏覽一律讀經**註冊當下**的格式（上游移除 codex catalog → CATALOG_MISSING + fail-closed，絕不靜默切換）；Marketplace Refresh / Rebind 以候選來源偵測的新格式產生 Update Candidate（`UpdateCandidate.format`），僅經明確 Apply Update 的原子提交寫入 `Registration.format`。
- **收據反映格式**：`AttemptReceipt.marketplaceFormat?`（含 journal 邊界守衛）；Transaction Sheet Receipt 軸、Receipt Journal 檢視、最終 Attempt Summary 通知皆顯示 `claude（Claude 格式）` 形式的閉集值。
- **TUI**：local/git 驗證披露新增 Marketplace Format 列；git-registration 開放 `executor/trust/cache` 測試接縫（正式呼叫端不變）。

## 驗收對照

| #47 驗收條件 | 落點 |
|---|---|
| claude-only repo 登記成功且 format=claude 固化 | flow/git-flow + `flow.test.ts` / `git-flow.test.ts` |
| 並存自動採 codex；翻轉僅經 Update Candidate + Apply Update | `format.test.ts` 優先序 + `lifecycle-format-flip.test.ts` 端到端 |
| 兩者皆無 → CATALOG_MISSING 不變 | 兩流程 blocked 路徑 + 既有測試全數維持 |
| 披露/確認畫面與收據顯示格式 | ui-strings / transaction-sheet / journal / registration |
| 瀏覽顯示分類結果與 Unavailable 原因 | `inspection-format.test.ts` |
| transaction-flow mock executor 登記仿 mattpocock 夾具 | `transaction-flows.test.ts`（六階段全劇本 + 格式斷言） |

## 驗證

- `npm run typecheck` ✅
- `npm test`：53 files / **721 tests passed**
- 雙軸 code-review（Standards + Spec 平行子代理）：Spec 六項驗收全數有實作與測試證據、無範圍蔓延；Standards 發現（CHANGELOG 補載、術語引用、symlink 偵測語意）已於本 commit 修正。