### PR TITLE
feat: Claude 外掛完整生命週期與驗收劇本——Install/Enable/Disable/Refresh 語意一致、平坦碰撞裁決與 mattpocock 劇本通過（#48）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to `pi-codex-marketplace` are documented here. Format follow
 ## [Unreleased]
 
 ### Added
+- **Claude 外掛完整生命週期與驗收劇本** (#48)：
+  - Claude 安裝生命週期完備：`Install Disabled` 建立 disabled 狀態（無須 Activation Confirmation）；啟用經由 `preflightPluginEnable` 重新驗證並要求 `Activation Confirmation`（Default No）。
+  - Runtime Application 與投影：安裝啟用後 `projectEffectiveState` 及 `discoverProjectedSkillPaths` 動態貢獻 Claude plugins 的宣告技能目錄，並遵循 `Pi → Global` 優先序。
+  - Runtime Skill Collision 如實裁決：本地 Pi 原生 skill 優先保留，碰撞之 Bridge 候選標示為 `unavailable-collision`，未碰撞技能正常投影，外掛分類不受影響保持 `Compatible`。
+  - Refresh 與 Update Plan：上游變更產生 format-bound `Update Candidate`；`buildUpdatePlan` 與 `applyUpdate` 遵循全有全無原子提交，要求重新 Registration Confirmation 與 Activation Confirmation。
+  - Registration Removal 連帶級聯同 registration 下所有 Claude Installations，Global Scope 其餘註冊與安裝不受波及。
+  - 驗收劇本與測試：以 mattpocock-shaped fixture 完整驗證相容外掛、技能列出、同名碰撞與 TUI transaction-flow。
 - **格式偵測接入登記與瀏覽流程（local + git）** (#47)：
   - 掃描 Marketplace Root 決定性推導 Marketplace Format（codex 優先；兩種 catalog 並存時自動採用 codex，無額外提問）。
   - 僅含 `.claude-plugin/marketplace.json` 的 repo 全程可登記：`format=claude` 固化於 Registration；兩者皆無時 CATALOG_MISSING 行為不變。

--- a/src/projection/exposure.ts
+++ b/src/projection/exposure.ts
@@ -26,8 +26,9 @@ import { parseFrontmatter } from '@earendil-works/pi-coding-agent';
 
 import { getCacheEntriesDir, getCacheDir } from '../cache/paths.js';
 import { readBridgeStateSync } from '../bridge-state/store.js';
-import { createEmptyState, type BridgeState, type Installation, type Registration } from '../bridge-state/types.js';
-import { parseCatalog, type Catalog } from '../registration/catalog.js';
+import { createEmptyState, type BridgeState, type Installation, type MarketplaceFormat, type Registration } from '../bridge-state/types.js';
+import { catalogContractFor } from '../registration/format.js';
+import { type Catalog } from '../registration/catalog.js';
 import { BUDGET } from '../registration/budget.js';
 import { resolveContained } from '../registration/contained.js';
 import { computeEffectiveState } from './effective-state.js';
@@ -83,12 +84,17 @@ function readGlobalOrEmpty(opts: RuntimeSkillExposureOptions): BridgeState {
  * Locate one Installation's plugin directory inside a snapshot root by resolving its
  * Marketplace Entry ID through the retained catalog, then verify containment.
  */
-function resolvePluginDirInSnapshot(snapshotRoot: string, installation: Installation): string | undefined {
-  const catalogPath = join(snapshotRoot, '.agents', 'plugins', 'marketplace.json');
+function resolvePluginDirInSnapshot(
+  snapshotRoot: string,
+  installation: Installation,
+  format: MarketplaceFormat = 'codex',
+): string | undefined {
+  const contract = catalogContractFor(format);
+  const catalogPath = join(snapshotRoot, ...contract.relPath.split('/'));
   try {
     if (!existsSync(catalogPath) || statSync(catalogPath).size > BUDGET.maxCatalogBytes) return undefined;
     const parsed: unknown = JSON.parse(readFileSync(catalogPath, 'utf8'));
-    const result = parseCatalog(parsed);
+    const result = contract.parse(parsed);
     if (!result.catalog) return undefined;
     return resolveEntryPluginDir(snapshotRoot, result.catalog, installation);
   } catch {
@@ -115,7 +121,31 @@ function resolveEntryPluginDir(snapshotRoot: string, catalog: Catalog, installat
 }
 
 /** Read each skills/<dir>/SKILL.md descriptor name exactly as Pi resolves it (frontmatter name, else directory name). */
-function skillCandidates(pluginDir: string): Array<{ name: string; skillDir: string }> {
+function skillCandidates(pluginDir: string, format: MarketplaceFormat = 'codex'): Array<{ name: string; skillDir: string }> {
+  if (format === 'claude') {
+    const manifestPath = join(pluginDir, '.claude-plugin', 'plugin.json');
+    if (!existsSync(manifestPath) || !statSync(manifestPath).isFile()) return [];
+    let manifest: Record<string, unknown>;
+    try {
+      manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    } catch {
+      return [];
+    }
+    if (!Array.isArray(manifest.skills)) return [];
+    const found: Array<{ name: string; skillDir: string }> = [];
+    for (const skillDecl of manifest.skills) {
+      if (typeof skillDecl !== 'string') continue;
+      const resolved = resolveContained(pluginDir, skillDecl, 'directory');
+      if (resolved.outcome.kind !== 'ok') continue;
+      const skillDir = resolved.outcome.canonicalPath;
+      const descriptor = join(skillDir, 'SKILL.md');
+      if (!existsSync(descriptor)) continue;
+      const name = descriptorSkillName(skillDir, descriptor);
+      if (name) found.push({ name, skillDir });
+    }
+    return found;
+  }
+
   const skillsDir = join(pluginDir, 'skills');
   if (!existsSync(skillsDir) || !statSync(skillsDir).isDirectory()) return [];
   const found: Array<{ name: string; skillDir: string }> = [];
@@ -208,15 +238,17 @@ export function discoverProjectedSkillPaths(opts: RuntimeSkillExposureOptions = 
       continue;
     }
 
-    const pluginDir = resolvePluginDirInSnapshot(snapshotRoot, installation);
+    const format = registration.format ?? 'codex';
+    const pluginDir = resolvePluginDirInSnapshot(snapshotRoot, installation, format);
     if (!pluginDir) {
+      const contract = catalogContractFor(format);
       skipped.push({
         installationId: installation.id,
-        reason: existsSync(join(snapshotRoot, '.agents', 'plugins', 'marketplace.json')) ? 'entry-not-found' : 'catalog-unreadable',
+        reason: existsSync(join(snapshotRoot, ...contract.relPath.split('/'))) ? 'entry-not-found' : 'catalog-unreadable',
       });
       continue;
     }
-    const skills = skillCandidates(pluginDir);
+    const skills = skillCandidates(pluginDir, format);
     if (skills.length === 0) {
       skipped.push({ installationId: installation.id, reason: 'no-skills' });
       continue;

--- a/tests/integration/claude-lifecycle.test.ts
+++ b/tests/integration/claude-lifecycle.test.ts
@@ -1,0 +1,477 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, realpathSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { commitBridgeState, readBridgeState } from '../../src/bridge-state/store.js';
+import type { BridgeState, Registration } from '../../src/bridge-state/types.js';
+import {
+  preflightPluginInstallation,
+  confirmPluginInstallation,
+  preflightPluginEnable,
+  confirmPluginEnable,
+  preflightPluginDisable,
+  confirmPluginDisable,
+} from '../../src/installation/flow.js';
+import { inspectMarketplaceEntries } from '../../src/installation/inspection.js';
+import { computeEffectiveState } from '../../src/projection/effective-state.js';
+import { discoverProjectedSkillPaths } from '../../src/projection/exposure.js';
+import { projectEffectiveState, requestRuntimeApplication } from '../../src/projection/runtime.js';
+import { refreshRegistration } from '../../src/lifecycle/refresh.js';
+import { buildUpdatePlan } from '../../src/lifecycle/update-plan.js';
+import { applyUpdate } from '../../src/lifecycle/update.js';
+import {
+  preflightRegistrationRemoval,
+  confirmRegistrationRemoval,
+  preflightInstallationRemoval,
+  confirmInstallationRemoval,
+} from '../../src/lifecycle/removal.js';
+
+import { localSourceKey } from '../../src/registration/source-key.js';
+
+type Env = { agentDir: string; root: string; marketplace: string };
+
+function makeEnv(): Env {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'claude-lifecycle-')));
+  return { agentDir: join(root, 'agent'), root, marketplace: join(root, 'marketplace') };
+}
+
+/** Matt Pocock shaped Claude marketplace fixture */
+function makeMattPocockMarketplace(root: string, skills: string[] = ['code-review', 'grilling']): void {
+  mkdirSync(join(root, '.claude-plugin'), { recursive: true });
+  const pluginRoot = join(root, 'plugins', 'mattpocock-skills');
+  mkdirSync(join(pluginRoot, '.claude-plugin'), { recursive: true });
+
+  const skillPaths: string[] = [];
+  for (const skill of skills) {
+    let relDir: string;
+    let desc: string;
+    let disableModel = false;
+    if (skill === 'code-review') {
+      relDir = 'skills/engineering/code-review';
+      desc = 'Review code changes';
+      disableModel = true;
+    } else if (skill === 'grilling') {
+      relDir = 'skills/interview/grilling';
+      desc = 'Grill the plan';
+    } else {
+      relDir = `skills/other/${skill}`;
+      desc = `Description for ${skill}`;
+    }
+    skillPaths.push(`./${relDir}`);
+    mkdirSync(join(pluginRoot, relDir), { recursive: true });
+    writeFileSync(
+      join(pluginRoot, relDir, 'SKILL.md'),
+      `---\nname: ${skill}\ndescription: ${desc}\n${disableModel ? 'disable-model-invocation: true\n' : ''}---\n\n${skill} body.\n`,
+    );
+  }
+
+  writeFileSync(
+    join(pluginRoot, '.claude-plugin', 'plugin.json'),
+    JSON.stringify({ name: 'mattpocock-skills', skills: skillPaths }),
+  );
+  writeFileSync(
+    join(root, '.claude-plugin', 'marketplace.json'),
+    JSON.stringify({
+      name: 'matt-marketplace',
+      owner: { name: 'Matt Pocock' },
+      plugins: [
+        { name: 'mattpocock-skills', source: './plugins/mattpocock-skills' },
+      ],
+    }),
+  );
+}
+
+async function registerClaudeMarketplace(env: Env, registrationId: string): Promise<Registration> {
+  const sk = localSourceKey(env.marketplace);
+  const inspection = inspectMarketplaceEntries({
+    id: registrationId,
+    sourceKind: 'local',
+    source: env.marketplace,
+    format: 'claude',
+  });
+  expect(inspection.snapshot).toBeDefined();
+
+  const registration: Registration = {
+    id: registrationId,
+    alias: 'matt-plugins',
+    marketplaceName: 'matt-marketplace',
+    sourceKind: 'local',
+    source: env.marketplace,
+    sourceKey: sk.sourceKey,
+    format: 'claude',
+    validationSnapshot: inspection.treeFingerprint ?? inspection.snapshot!.fingerprint,
+  };
+
+  await commitBridgeState(
+    (state: BridgeState) => ({
+      ...state,
+      registrations: [...state.registrations, registration],
+    }),
+    { agentDir: env.agentDir },
+  );
+  return registration;
+}
+
+describe('Claude plugin full lifecycle & acceptance scenarios (#48)', () => {
+  let env: Env;
+  const REG_ID = 'cccccccc-3333-4333-8333-333333333333';
+
+  beforeEach(() => {
+    env = makeEnv();
+    makeMattPocockMarketplace(env.marketplace);
+  });
+
+  afterEach(() => {
+    try { rmSync(env.root, { recursive: true, force: true }); } catch {}
+  });
+
+  it('Install Disabled creates disabled state; enabling requires fresh validation + Activation Confirmation', async () => {
+    await registerClaudeMarketplace(env, REG_ID);
+
+    // 1. Preflight Plugin Installation
+    const preflight = await preflightPluginInstallation(REG_ID, '/plugins/0', { agentDir: env.agentDir });
+    expect(preflight.ok).toBe(true);
+    if (!preflight.ok) return;
+
+    expect(preflight.preflight.plugin.manifestName).toBe('mattpocock-skills');
+    expect(preflight.preflight.plugin.skills.map((s) => s.name)).toEqual(['code-review', 'grilling']);
+
+    // 2. Install Disabled commits atomically without Activation Confirmation
+    const outcome = await confirmPluginInstallation(preflight.preflight, 'disabled', false, { agentDir: env.agentDir });
+    expect(outcome.status).toBe('completed');
+    if (outcome.status !== 'completed') return;
+
+    expect(outcome.installation.installationState).toBe('disabled');
+    expect(outcome.installation.manifestName).toBe('mattpocock-skills');
+
+    // Verify Bridge State and Effective State
+    const read = await readBridgeState({ agentDir: env.agentDir });
+    expect(read.state?.installations).toHaveLength(1);
+    expect(read.state?.installations[0]?.installationState).toBe('disabled');
+
+    const effective = computeEffectiveState(read.state!);
+    expect(effective.installations).toHaveLength(0);
+
+    const exposure = discoverProjectedSkillPaths({ agentDir: env.agentDir });
+    expect(exposure.skillPaths).toEqual([]);
+    expect(exposure.exposed).toEqual([]);
+
+    // 3. Preflight Enable
+    const enablePreflight = await preflightPluginEnable(outcome.installation.id, { agentDir: env.agentDir });
+    expect(enablePreflight.ok).toBe(true);
+    if (!enablePreflight.ok) return;
+    expect(enablePreflight.preflight.operation).toBe('enable');
+
+    // Confirm Enable with activationConfirmed = false -> Declined (activation confirmation required)
+    const declined = await confirmPluginEnable(enablePreflight.preflight, false, { agentDir: env.agentDir });
+    expect(declined.status).toBe('declined');
+    expect(declined.receipt.summary).toBe('Declined');
+    expect(declined.receipt.findings.some((f) => f.code === 'ACTIVATION_CONFIRMATION_REQUIRED')).toBe(true);
+
+    // Re-verify still disabled
+    const afterDecline = await readBridgeState({ agentDir: env.agentDir });
+    expect(afterDecline.state?.installations[0]?.installationState).toBe('disabled');
+
+    // 4. Preflight and Confirm Enable with activationConfirmed = true
+    const reenablePreflight = await preflightPluginEnable(outcome.installation.id, { agentDir: env.agentDir });
+    expect(reenablePreflight.ok).toBe(true);
+    if (!reenablePreflight.ok) return;
+
+    const enabledOutcome = await confirmPluginEnable(reenablePreflight.preflight, true, { agentDir: env.agentDir });
+    expect(enabledOutcome.status).toBe('completed');
+    if (enabledOutcome.status !== 'completed') return;
+
+    expect(enabledOutcome.installation.installationState).toBe('enabled');
+
+    // Verify Effective State and Skill Exposure now include both Claude skills
+    const afterEnable = await readBridgeState({ agentDir: env.agentDir });
+    const effectiveAfter = computeEffectiveState(afterEnable.state!);
+    expect(effectiveAfter.installations).toHaveLength(1);
+
+    const exposureAfter = discoverProjectedSkillPaths({ agentDir: env.agentDir });
+    expect(exposureAfter.exposed.map((s) => s.name).sort()).toEqual(['code-review', 'grilling']);
+    expect(exposureAfter.skillPaths).toHaveLength(2);
+    for (const p of exposureAfter.skillPaths) {
+      expect(existsSync(join(p, 'SKILL.md'))).toBe(true);
+    }
+  });
+
+  it('completes Runtime Application and projects skills with Pi → Global precedence', async () => {
+    await registerClaudeMarketplace(env, REG_ID);
+    const preflight = await preflightPluginInstallation(REG_ID, '/plugins/0', { agentDir: env.agentDir });
+    expect(preflight.ok).toBe(true);
+    if (!preflight.ok) return;
+
+    // Install and Enable atomically
+    const outcome = await confirmPluginInstallation(preflight.preflight, 'enabled', true, { agentDir: env.agentDir });
+    expect(outcome.status).toBe('completed');
+
+    const state = (await readBridgeState({ agentDir: env.agentDir })).state!;
+    const projection = projectEffectiveState(state, { agentDir: env.agentDir });
+
+    expect(projection.plugins).toHaveLength(1);
+    const plugin = projection.plugins[0]!;
+    expect(plugin.manifestName).toBe('mattpocock-skills');
+    expect(plugin.skills).toHaveLength(2);
+
+    const codeReview = plugin.skills.find((s) => s.name === 'code-review')!;
+    expect(codeReview.status).toBe('projected');
+    expect(codeReview.availability).toBe('snapshot-eligible');
+    expect(codeReview.discoveryPath).toBeDefined();
+    expect(existsSync(codeReview.discoveryPath!)).toBe(true);
+
+    const grilling = plugin.skills.find((s) => s.name === 'grilling')!;
+    expect(grilling.status).toBe('projected');
+    expect(grilling.availability).toBe('snapshot-eligible');
+
+    // Runtime application transitions
+    const pending = await requestRuntimeApplication(async () => false, {
+      stateRevision: state.stateRevision,
+      validationSnapshot: outcome.status === 'completed' ? outcome.installation.validationSnapshot : undefined,
+    });
+    expect(pending.outcome).toBe('pending-application');
+    expect(pending.receipt.summary).toBe('Pending Application');
+
+    const applied = await requestRuntimeApplication(async () => true, {
+      stateRevision: state.stateRevision,
+      validationSnapshot: outcome.status === 'completed' ? outcome.installation.validationSnapshot : undefined,
+    });
+    expect(applied.outcome).toBe('applied');
+    expect(applied.receipt.summary).toBe('Completed');
+  });
+
+  it('resolves Runtime Skill Collision against Pi skills: colliding candidate is unavailable, non-colliding remains projected, plugin classification unaffected', async () => {
+    await registerClaudeMarketplace(env, REG_ID);
+    const preflight = await preflightPluginInstallation(REG_ID, '/plugins/0', { agentDir: env.agentDir });
+    expect(preflight.ok).toBe(true);
+    if (!preflight.ok) return;
+    await confirmPluginInstallation(preflight.preflight, 'enabled', true, { agentDir: env.agentDir });
+
+    const state = (await readBridgeState({ agentDir: env.agentDir })).state!;
+
+    // Pi layer claims 'code-review'
+    const projection = projectEffectiveState(state, {
+      agentDir: env.agentDir,
+      piSkillNames: ['code-review'],
+    });
+
+    expect(projection.plugins).toHaveLength(1); // Plugin remains Compatible and Projected!
+    expect(projection.denied).toHaveLength(0);
+
+    const plugin = projection.plugins[0]!;
+    const codeReview = plugin.skills.find((s) => s.name === 'code-review')!;
+    expect(codeReview.status).toBe('unavailable-collision');
+    expect(codeReview.availability).toBe('unavailable');
+
+    const grilling = plugin.skills.find((s) => s.name === 'grilling')!;
+    expect(grilling.status).toBe('projected');
+    expect(grilling.availability).toBe('snapshot-eligible');
+
+    expect(projection.findings.some((f) => f.code === 'RUNTIME_SKILL_COLLISION' && f.pointer.includes('code-review'))).toBe(true);
+
+    // Exposure only returns the surviving skill
+    const exposure = discoverProjectedSkillPaths({ agentDir: env.agentDir, piSkillNames: ['code-review'] });
+    expect(exposure.exposed.map((s) => s.name)).toEqual(['grilling']);
+    expect(exposure.skillPaths).toHaveLength(1);
+    expect(exposure.skillPaths[0]).toContain('grilling');
+  });
+
+  it('resolves Runtime Skill Collision between two Bridge plugins: both same-layer colliders are unavailable', async () => {
+    await registerClaudeMarketplace(env, REG_ID);
+    const preflight = await preflightPluginInstallation(REG_ID, '/plugins/0', { agentDir: env.agentDir });
+    expect(preflight.ok).toBe(true);
+    if (!preflight.ok) return;
+    await confirmPluginInstallation(preflight.preflight, 'enabled', true, { agentDir: env.agentDir });
+
+    // Create a second marketplace (e.g. Codex or Claude) that also defines 'grilling'
+    const SECOND_REG = 'dddddddd-4444-4444-8444-444444444444';
+    const secondMarketplace = join(env.root, 'marketplace-second');
+    mkdirSync(join(secondMarketplace, '.agents', 'plugins'), { recursive: true });
+    mkdirSync(join(secondMarketplace, 'plugins', 'interview-tools', '.codex-plugin'), { recursive: true });
+    mkdirSync(join(secondMarketplace, 'plugins', 'interview-tools', 'skills', 'grilling'), { recursive: true });
+    writeFileSync(
+      join(secondMarketplace, '.agents', 'plugins', 'marketplace.json'),
+      JSON.stringify({ name: 'interview-marketplace', plugins: [{ name: 'interview-tools', path: './plugins/interview-tools' }] }),
+    );
+    writeFileSync(
+      join(secondMarketplace, 'plugins', 'interview-tools', '.codex-plugin', 'plugin.json'),
+      JSON.stringify({ name: 'interview-tools', skills: './skills/' }),
+    );
+    writeFileSync(
+      join(secondMarketplace, 'plugins', 'interview-tools', 'skills', 'grilling', 'SKILL.md'),
+      '---\nname: grilling\ndescription: Another grilling skill\n---\n\nAnother grill.\n',
+    );
+
+    const inspection2 = inspectMarketplaceEntries({
+      id: SECOND_REG,
+      sourceKind: 'local',
+      source: secondMarketplace,
+      format: 'codex',
+    });
+    await commitBridgeState((s) => ({
+      ...s,
+      registrations: [...s.registrations, {
+        id: SECOND_REG,
+        alias: 'interview-mp',
+        marketplaceName: 'interview-marketplace',
+        sourceKind: 'local',
+        source: secondMarketplace,
+        format: 'codex',
+        validationSnapshot: inspection2.treeFingerprint ?? inspection2.snapshot!.fingerprint,
+      }],
+      installations: [...s.installations, {
+        id: `${SECOND_REG}/interview-marketplace/interview-tools`,
+        pluginId: `${SECOND_REG}/interview-marketplace/interview-tools`,
+        installationState: 'enabled',
+        registrationId: SECOND_REG,
+        marketplaceEntryId: `${SECOND_REG}/interview-marketplace/plugins/0`,
+        validationSnapshot: inspection2.snapshot!.fingerprint,
+        manifestName: 'interview-tools',
+      }],
+    }), { agentDir: env.agentDir });
+
+    const state = (await readBridgeState({ agentDir: env.agentDir })).state!;
+    const projection = projectEffectiveState(state, { agentDir: env.agentDir });
+
+    // Both plugins are ProjectedPlugins!
+    expect(projection.plugins).toHaveLength(2);
+    expect(projection.denied).toHaveLength(0);
+
+    // Both 'grilling' candidates collide in Global layer and become unavailable
+    for (const plugin of projection.plugins) {
+      const g = plugin.skills.find((s) => s.name === 'grilling');
+      expect(g?.status).toBe('unavailable-collision');
+    }
+
+    // 'code-review' does not collide and survives
+    const mattPlugin = projection.plugins.find((p) => p.manifestName === 'mattpocock-skills')!;
+    const cr = mattPlugin.skills.find((s) => s.name === 'code-review')!;
+    expect(cr.status).toBe('projected');
+
+    const exposure = discoverProjectedSkillPaths({ agentDir: env.agentDir });
+    expect(exposure.exposed.map((s) => s.name)).toEqual(['code-review']);
+  });
+
+  it('Refresh on upstream change produces Update Candidate; Apply Update executes Update Plan with all-or-nothing semantics', async () => {
+    await registerClaudeMarketplace(env, REG_ID);
+    const preflight = await preflightPluginInstallation(REG_ID, '/plugins/0', { agentDir: env.agentDir });
+    expect(preflight.ok).toBe(true);
+    if (!preflight.ok) return;
+    const installOutcome = await confirmPluginInstallation(preflight.preflight, 'enabled', true, { agentDir: env.agentDir });
+    expect(installOutcome.status).toBe('completed');
+    if (installOutcome.status !== 'completed') return;
+
+    // Upstream adds a new skill: 'prompt-craft'
+    makeMattPocockMarketplace(env.marketplace, ['code-review', 'grilling', 'prompt-craft']);
+
+    // Marketplace Refresh
+    const refreshOutcome = await refreshRegistration(REG_ID, { agentDir: env.agentDir });
+    expect(refreshOutcome.status).toBe('update-candidate');
+    if (refreshOutcome.status !== 'update-candidate') return;
+
+    expect(refreshOutcome.candidate.format).toBe('claude');
+    expect(refreshOutcome.candidate.marketplaceName).toBe('matt-marketplace');
+
+    const state = (await readBridgeState({ agentDir: env.agentDir })).state!;
+
+    // Build Update Plan without registration confirmation -> rejected
+    const planNoConsent = buildUpdatePlan(refreshOutcome.candidate, state.installations, state.stateRevision, {
+      registrationConfirmed: false,
+      choices: { [installOutcome.installation.id]: 'update' },
+      activationConfirmations: { [installOutcome.installation.id]: true },
+    });
+    expect(planNoConsent.ok).toBe(false);
+
+    // Build Update Plan without activation confirmation for enabled plugin -> rejected
+    const planNoAct = buildUpdatePlan(refreshOutcome.candidate, state.installations, state.stateRevision, {
+      registrationConfirmed: true,
+      choices: { [installOutcome.installation.id]: 'update' },
+      activationConfirmations: { [installOutcome.installation.id]: false },
+    });
+    expect(planNoAct.ok).toBe(false);
+
+    // Complete Update Plan
+    const planResult = buildUpdatePlan(refreshOutcome.candidate, state.installations, state.stateRevision, {
+      registrationConfirmed: true,
+      choices: { [installOutcome.installation.id]: 'update' },
+      activationConfirmations: { [installOutcome.installation.id]: true },
+    });
+    expect(planResult.ok).toBe(true);
+    if (!planResult.ok) return;
+
+    // Apply Update
+    const updateOutcome = await applyUpdate(planResult.plan, { agentDir: env.agentDir });
+    expect(updateOutcome.status).toBe('completed');
+    expect(updateOutcome.receipt.summary).toBe('Completed');
+
+    // All 3 skills are now exposed
+    const exposure = discoverProjectedSkillPaths({ agentDir: env.agentDir });
+    expect(exposure.exposed.map((s) => s.name).sort()).toEqual(['code-review', 'grilling', 'prompt-craft']);
+  });
+
+  it('Registration Removal cascades to all associated Claude Installations', async () => {
+    await registerClaudeMarketplace(env, REG_ID);
+    const preflight = await preflightPluginInstallation(REG_ID, '/plugins/0', { agentDir: env.agentDir });
+    expect(preflight.ok).toBe(true);
+    if (!preflight.ok) return;
+    await confirmPluginInstallation(preflight.preflight, 'enabled', true, { agentDir: env.agentDir });
+
+    const stateBefore = (await readBridgeState({ agentDir: env.agentDir })).state!;
+    expect(stateBefore.registrations).toHaveLength(1);
+    expect(stateBefore.installations).toHaveLength(1);
+
+    // Preflight Registration Removal
+    const removalPreflight = await preflightRegistrationRemoval(REG_ID, { agentDir: env.agentDir });
+    expect(removalPreflight.ok).toBe(true);
+    if (!removalPreflight.ok) return;
+
+    expect(removalPreflight.preflight.affectedInstallations).toHaveLength(1);
+
+    // Confirm Removal
+    const remOutcome = await confirmRegistrationRemoval(removalPreflight.preflight, true, { agentDir: env.agentDir });
+    expect(remOutcome.status).toBe('completed');
+
+    const stateAfter = (await readBridgeState({ agentDir: env.agentDir })).state!;
+    expect(stateAfter.registrations).toHaveLength(0);
+    expect(stateAfter.installations).toHaveLength(0);
+
+    const exposure = discoverProjectedSkillPaths({ agentDir: env.agentDir });
+    expect(exposure.exposed).toEqual([]);
+    expect(exposure.skillPaths).toEqual([]);
+  });
+
+  it('supports Plugin Disablement and Installation Removal for Claude plugins', async () => {
+    await registerClaudeMarketplace(env, REG_ID);
+    const preflight = await preflightPluginInstallation(REG_ID, '/plugins/0', { agentDir: env.agentDir });
+    expect(preflight.ok).toBe(true);
+    if (!preflight.ok) return;
+    const installOutcome = await confirmPluginInstallation(preflight.preflight, 'enabled', true, { agentDir: env.agentDir });
+    expect(installOutcome.status).toBe('completed');
+    if (installOutcome.status !== 'completed') return;
+
+    const instId = installOutcome.installation.id;
+
+    // Disablement
+    const disablePreflight = await preflightPluginDisable(instId, { agentDir: env.agentDir });
+    expect(disablePreflight.ok).toBe(true);
+    if (!disablePreflight.ok) return;
+    const disOutcome = await confirmPluginDisable(disablePreflight.preflight, { agentDir: env.agentDir });
+    expect(disOutcome.status).toBe('completed');
+
+    const stateDisabled = (await readBridgeState({ agentDir: env.agentDir })).state!;
+    expect(stateDisabled.installations[0]?.installationState).toBe('disabled');
+    expect(discoverProjectedSkillPaths({ agentDir: env.agentDir }).skillPaths).toEqual([]);
+
+    // Installation Removal
+    const instRemovalPreflight = await preflightInstallationRemoval(instId, { agentDir: env.agentDir });
+    expect(instRemovalPreflight.ok).toBe(true);
+    if (!instRemovalPreflight.ok) return;
+    const remInstOutcome = await confirmInstallationRemoval(instRemovalPreflight.preflight, true, { agentDir: env.agentDir });
+    expect(remInstOutcome.status).toBe('completed');
+
+    const stateClean = (await readBridgeState({ agentDir: env.agentDir })).state!;
+    expect(stateClean.registrations).toHaveLength(1); // registration retained
+    expect(stateClean.installations).toHaveLength(0); // installation removed
+  });
+});

--- a/tests/unit/extensions/transaction-flows.test.ts
+++ b/tests/unit/extensions/transaction-flows.test.ts
@@ -1578,4 +1578,115 @@ describe('Bridge Ledger transaction flow adapters', () => {
     expect(receipt.marketplaceFormat).toBe('claude');
     expect(notifications.join('\n')).toContain(marketplaceFormatText('claude'));
   });
+
+  it('runs Claude plugin installation and state toggle flows through the transaction sheet seam (#48)', async () => {
+    // 1. Setup local Claude marketplace fixture with mattpocock layout
+    const fixture = join(root, 'matt-install-fixture');
+    mkdirSync(join(fixture, '.claude-plugin'), { recursive: true });
+    const pluginRoot = join(fixture, 'plugins', 'mattpocock-skills');
+    mkdirSync(join(pluginRoot, '.claude-plugin'), { recursive: true });
+    for (const [skillDir, frontmatter] of [
+      ['skills/engineering/code-review', 'name: code-review\ndescription: Review code changes\ndisable-model-invocation: true'],
+      ['skills/interview/grilling', 'name: grilling\ndescription: Grill the plan'],
+    ] as const) {
+      mkdirSync(join(pluginRoot, ...skillDir.split('/')), { recursive: true });
+      writeFileSync(join(pluginRoot, ...skillDir.split('/'), 'SKILL.md'), `---\n${frontmatter}\n---\n\nBody.\n`);
+    }
+    writeFileSync(
+      join(pluginRoot, '.claude-plugin', 'plugin.json'),
+      JSON.stringify({ name: 'mattpocock-skills', skills: ['./skills/engineering/code-review', './skills/interview/grilling'] }),
+    );
+    writeFileSync(
+      join(fixture, '.claude-plugin', 'marketplace.json'),
+      JSON.stringify({
+        name: 'mattpocock-marketplace',
+        owner: { name: 'Matt Pocock' },
+        plugins: [{ name: 'mattpocock-skills', source: './plugins/mattpocock-skills' }],
+      }),
+    );
+
+    const inspection = inspectMarketplaceEntries({
+      id: '55555555-5555-4555-8555-555555555555',
+      sourceKind: 'local',
+      source: fixture,
+      format: 'claude',
+    });
+
+    const regId = '55555555-5555-4555-8555-555555555555';
+    await commitBridgeState((s) => ({
+      ...s,
+      registrations: [...s.registrations, {
+        id: regId,
+        alias: 'mattpocock',
+        marketplaceName: 'mattpocock-marketplace',
+        sourceKind: 'local',
+        source: fixture,
+        format: 'claude',
+        validationSnapshot: inspection.treeFingerprint ?? inspection.snapshot!.fingerprint,
+      }],
+    }), { agentDir });
+
+    const events: string[] = [];
+    const confirmationTitles: string[] = [];
+    const confirmationBodies: string[] = [];
+    const notifications: string[] = [];
+
+    const ctx = {
+      cwd,
+      mode: 'tui',
+      hasUI: true,
+      isProjectTrusted: () => true,
+      ui: {
+        select: async (_prompt: string, choices: string[]) => {
+          // Select available entry or enablement path
+          return choices.find((c) => c.includes(uiText('inst.path.enabled'))) ?? choices[0];
+        },
+        custom: async (factory: any): Promise<unknown> => new Promise((resolve) => {
+          const component = factory({ requestRender: () => {} }, theme, {}, resolve);
+          const rendered = component.render(120).join('\n');
+          const active = TRANSACTION_STEPS.find((step, index) =>
+            rendered.includes(`▸ ${index + 1} ${transactionStepLabel(step)}（${uiText('step.activeSuffix')}）`));
+          if (active) events.push(active);
+          component.handleInput?.('\r');
+        }),
+        confirm: async (title: string, message: string) => {
+          confirmationTitles.push(title);
+          confirmationBodies.push(message);
+          return true;
+        },
+        notify: (message: string) => notifications.push(message),
+      },
+    };
+
+    // 2. Run Plugin Installation Flow for Claude marketplace entry
+    await runPluginInstallationFlow(ctx as never, { registrationId: regId });
+
+    expect(events).toEqual(['Intent', 'Validation', 'Consent', 'Plan', 'Commit', 'Receipt']);
+    expect(confirmationTitles).toHaveLength(1);
+    expect(confirmationTitles[0]).toMatch(/Activation Confirmation/);
+    expect(confirmationBodies[0]).toContain('mattpocock-skills');
+    expect(confirmationBodies[0]).toContain('code-review');
+    expect(confirmationBodies[0]).toContain('grilling');
+
+    const state = await readBridgeState({ agentDir });
+    expect(state.state?.installations).toHaveLength(1);
+    const installation = state.state!.installations[0]!;
+    expect(installation.manifestName).toBe('mattpocock-skills');
+    expect(installation.installationState).toBe('enabled');
+
+    // 3. Disable Plugin via State Flow
+    events.length = 0;
+    await runPluginStateFlow(ctx as never, { installationId: installation.id, desiredState: 'disabled' });
+    const disabledState = await readBridgeState({ agentDir });
+    expect(disabledState.state?.installations[0]?.installationState).toBe('disabled');
+
+    // 4. Re-enable Plugin via State Flow
+    events.length = 0;
+    confirmationTitles.length = 0;
+    await runPluginStateFlow(ctx as never, { installationId: installation.id, desiredState: 'enabled' });
+    expect(confirmationTitles).toHaveLength(1);
+    expect(confirmationTitles[0]).toMatch(/Activation Confirmation/);
+    const reenabledState = await readBridgeState({ agentDir });
+    expect(reenabledState.state?.installations[0]?.installationState).toBe('enabled');
+  });
 });

--- a/tests/unit/projection/exposure.test.ts
+++ b/tests/unit/projection/exposure.test.ts
@@ -293,4 +293,72 @@ describe('Runtime Skill Exposure — passive inspection only', () => {
     expect(result.exposed.map((s) => s.name)).toEqual(['local-skill']);
     expect(realpathSync(result.skillPaths[0]!)).toBe(realpathSync(join(env.marketplace, 'plugins', 'release-helper', 'skills', 'local-skill')));
   });
+
+  it('exposes skills from Claude format registrations using declared skills array paths', async () => {
+    const env = freshEnv();
+    mkdirSync(join(env.marketplace, '.claude-plugin'), { recursive: true });
+    const pluginDir = join(env.marketplace, 'plugins', 'mattpocock-skills');
+    mkdirSync(join(pluginDir, '.claude-plugin'), { recursive: true });
+    mkdirSync(join(pluginDir, 'skills', 'engineering', 'code-review'), { recursive: true });
+    writeFileSync(
+      join(pluginDir, 'skills', 'engineering', 'code-review', 'SKILL.md'),
+      '---\nname: code-review\ndescription: Review code\n---\n\nReview.\n',
+    );
+    mkdirSync(join(pluginDir, 'skills', 'interview', 'grilling'), { recursive: true });
+    writeFileSync(
+      join(pluginDir, 'skills', 'interview', 'grilling', 'SKILL.md'),
+      '---\nname: grilling\ndescription: Grill plan\n---\n\nGrill.\n',
+    );
+    writeFileSync(
+      join(pluginDir, '.claude-plugin', 'plugin.json'),
+      JSON.stringify({ name: 'mattpocock-skills', skills: ['./skills/engineering/code-review', './skills/interview/grilling'] }),
+    );
+    writeFileSync(
+      join(env.marketplace, '.claude-plugin', 'marketplace.json'),
+      JSON.stringify({
+        name: 'matt-marketplace',
+        plugins: [{ name: 'mattpocock-skills', source: './plugins/mattpocock-skills' }],
+      }),
+    );
+
+    await commitBridgeState((state) => ({
+        ...state,
+        registrations: [
+          ...state.registrations,
+          {
+            id: GLOBAL_REG,
+            alias: 'matt-local',
+            marketplaceName: 'matt-marketplace',
+            sourceKind: 'local' as const,
+            source: env.marketplace,
+            format: 'claude',
+          },
+        ],
+        installations: [
+          ...state.installations,
+          {
+            id: `${GLOBAL_REG}/matt-marketplace/mattpocock-skills`,
+            pluginId: `${GLOBAL_REG}/matt-marketplace/mattpocock-skills`,
+            installationState: 'enabled' as const,
+            registrationId: GLOBAL_REG,
+            marketplaceEntryId: `${GLOBAL_REG}/matt-marketplace/plugins/0`,
+            validationSnapshot: 'claude-local-bound-snapshot',
+            manifestName: 'mattpocock-skills',
+          },
+        ],
+      }),
+      { agentDir: env.agentDir },
+    );
+
+    const result = discoverProjectedSkillPaths({ agentDir: env.agentDir });
+    expect(result.exposed.map((s) => s.name).sort()).toEqual(['code-review', 'grilling']);
+    expect(result.skillPaths).toHaveLength(2);
+    expect(realpathSync(result.skillPaths.find((p) => p.includes('code-review'))!)).toBe(
+      realpathSync(join(pluginDir, 'skills', 'engineering', 'code-review')),
+    );
+    expect(realpathSync(result.skillPaths.find((p) => p.includes('grilling'))!)).toBe(
+      realpathSync(join(pluginDir, 'skills', 'interview', 'grilling')),
+    );
+  });
 });
+


### PR DESCRIPTION
Closes #48
Parent: #43

## 摘要

補齊 Claude 外掛安裝與執行的完整生命週期：Install Disabled 建立 disabled 狀態（無須 Activation Confirmation）；啟用經由 `preflightPluginEnable` 重新驗證並要求 `Activation Confirmation`（Default No）；停用/移除/更新與 Refresh 對 Claude Installation 之行為與 Codex 完全一致；Runtime Skill Collision 在 Pi 平坦命名空間如實裁決（Pi 原生優先、Bridge 候選 unavailable-collision、外掛分類保持 Compatible）；以 mattpocock 夾具與 extension transaction-flow 跑完規格驗收劇本。本票完成即達成 R1 出口條件——mattpocock/skills 可安裝。

## 實作

- **`src/projection/exposure.ts`**：
  - `resolvePluginDirInSnapshot` 依 `registration.format`（`catalogContractFor(format)`）動態解析 Claude catalog（`.claude-plugin/marketplace.json`）與 entry plugin 目錄。
  - `skillCandidates` 支援 Claude format：讀取 `.claude-plugin/plugin.json` 中的 `skills` 陣列路徑，以 `resolveContained` 探索各 declared skill 目錄與 `SKILL.md`，動態暴露至 Pi 的 `resources_discover`。
- **`tests/integration/claude-lifecycle.test.ts`（新）**：
  - 完整驗收測試覆蓋：
    1. Install Disabled 建立 disabled 狀態，啟用必須經由 re-validation 與 Activation Confirmation。
    2. Runtime Application 狀態轉換（Pending Application / Applied）與 `Pi → Global` 投影優先序。
    3. 同名碰撞：對應本地既有 Pi skill 的候選如實 unavailable-collision，其餘可用，外掛分類不受影響；同層 Bridge 碰撞兩候選皆 unavailable-collision。
    4. Refresh 上游變更產生 format-bound Update Candidate；Apply Update 遵循 Update Plan 全有全無原子提交。
    5. Registration Removal 級聯同 registration 所有 Installations，Global Scope 其餘註冊不受波及。
    6. Plugin Disablement 與 Installation Removal 運作正常。
- **`tests/unit/projection/exposure.test.ts` & `tests/unit/extensions/transaction-flows.test.ts`**：
  - 補強 Claude 格式 Runtime Skill Exposure 單元測試。
  - 透過 transaction sheet mock 測試 Claude 外掛安裝與狀態切換（Intent → Validation → Consent → Activation Confirm → Plan → Commit → Receipt）完整流程。
- **`CHANGELOG.md`**：記錄 #48 變更。

## 驗收對照

| #48 驗收條件 | 落點 |
|---|---|
| Install Disabled 建立 disabled 狀態；啟用要求新驗證＋Activation Confirmation | `installation/flow.ts` + `claude-lifecycle.test.ts` |
| 安裝啟用後 Runtime Application 完成；global scope、投影優先序與 codex 一致 | `projection/exposure.ts` + `runtime.ts` + `claude-lifecycle.test.ts` |
| 同名碰撞：對應本地既有 skill 的候選如實 unavailable，其餘可用，外掛分類不受影響 | `projection/collision.ts` + `runtime.ts` + `claude-lifecycle.test.ts` |
| Refresh 上游變更產生 Update Candidate；Apply Update 遵循 Update Plan 全有全無語意 | `lifecycle/refresh.ts` + `update-plan.ts` + `update.ts` + `claude-lifecycle.test.ts` |
| Registration Removal 連帶同 scope Installation，其他 scope 不受波及 | `lifecycle/removal.ts` + `claude-lifecycle.test.ts` |
| 驗收劇本測試通過：仿 mattpocock 夾具 1 個 Compatible 外掛、宣告技能全數列出、碰撞如實揭露 | `claude-lifecycle.test.ts` + `transaction-flows.test.ts` |

## 驗證

- `npm run typecheck` ✅
- `npm test`：54 files / **730 tests passed** ✅
- 雙軸 code-review（Standards + Spec 平行子代理）：
  - Spec 審查：6 項驗收標準完全符合，無遺漏或範圍蔓延。
  - Standards 審查：0 hard violations，變更遵循領域模型與 ADR。