### PR TITLE
feat: Entry Acquisition 引擎（git 家族 entry）——github/url/git-subdir 取得、Pin 矩陣、per-entry 快照與預算/信任邊界（#50）

### DIFF
--- a/src/bridge-state/types.ts
+++ b/src/bridge-state/types.ts
@@ -62,6 +62,8 @@ export interface Registration {
   resolvedRevision?: string;
   /** Validation Snapshot fingerprint bound to Registration Confirmation */
   validationSnapshot?: string;
+  /** Per-entry Validation Snapshot fingerprints bound to Registration Confirmation (issue #50). */
+  entrySnapshots?: Record<string, string>;
   /** Bound Compatibility Profile / Ruleset / Budget ids at confirmation time */
   snapshotBinds?: { profile?: string; ruleset?: string; budget?: string };
 }

--- a/src/registration/entry-acquisition.ts
+++ b/src/registration/entry-acquisition.ts
@@ -1,0 +1,854 @@
+/**
+ * Entry Acquisition Engine — Format-neutral non-executing acquisition for external git-family entries.
+ * See CONTEXT.md: Source Acquisition, Acquisition Trust Base, Validation Snapshot, Validation Budget,
+ * Git Selector, Canonical Git Locator, Contained Path, Contained Symlink, Source Drift.
+ *
+ * Supported git entry shapes:
+ * 1. `github`: `{ source: "github", repo: "owner/repo", ... }` or shorthand `"owner/repo"`
+ * 2. `url`: `{ source: "url", url: "https://...", ... }`
+ * 3. `git-subdir`: `{ source: "git-subdir", url: "https://...", path: "sub/dir", ... }`
+ *
+ * Selector mapping:
+ * - `sha` → `commit` selector (full 40/64 hex)
+ * - `ref` → `branch` / `tag` selector
+ * - neither → `default` movable selector
+ * - both `sha` and `ref` → `sha` is effective pin; `ref` is validated for syntax
+ *
+ * Shorthand normalization:
+ * - `owner/repo` shorthand expands to `https://github.com/<owner>/<repo>`
+ * - Embedded credentials and plaintext transports are rejected (Blocking Findings)
+ *
+ * Guarantees:
+ * - Non-executing: never runs hooks, filters, submodules, dependencies, scripts, or components
+ * - Hardened environment & config (core.hooksPath=/dev/null, GIT_LFS_SKIP_SMUDGE=1, StrictHostKeyChecking=yes)
+ * - Per-entry Validation Snapshot with deterministic fingerprint bound for drift detection
+ * - Fail-closed: budget exceeded, host key anomalies, redirect violations produce Blocking Findings;
+ *   batch acquisition cleans up and never returns partial success
+ * - npm / archive / command entries remain disclosed as Unavailable Entries
+ */
+
+import { realpathSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { BUDGET } from './budget.js';
+import { resolveContained } from './contained.js';
+import { CODE, RULE, blocking, sortFindings, type ValidationFinding } from './findings.js';
+import {
+  acquireGitSource,
+  cleanupAcquisition,
+  type AcquisitionTrustOptions,
+  type GitExecutor,
+} from './git-acquisition.js';
+import {
+  normalizeGitLocator,
+  type CanonicalGitLocator,
+} from './git-locator.js';
+import {
+  normalizeGitSelector,
+  type GitSelectorInput,
+  type NormalizedGitSelector,
+} from './git-selector.js';
+import {
+  buildGitSnapshot,
+  type ValidationSnapshot,
+} from './snapshot.js';
+import { gitSourceKey, type SourceKey } from './source-key.js';
+import { SourceCache } from '../cache/source-cache.js';
+
+export type GitEntryShape = 'github' | 'url' | 'git-subdir';
+
+export interface RawGitEntrySource {
+  source?: string;
+  repo?: string;
+  url?: string;
+  path?: string;
+  subpath?: string;
+  ref?: string;
+  sha?: string;
+  branch?: string;
+  tag?: string;
+  commit?: string;
+  [key: string]: unknown;
+}
+
+export interface NormalizedGitEntrySpec {
+  shape: GitEntryShape;
+  locator: CanonicalGitLocator;
+  selector: NormalizedGitSelector;
+  effectivePin: 'sha' | 'ref' | 'default';
+  verifiedRef?: NormalizedGitSelector;
+  subpath?: string;
+  rawSource: unknown;
+}
+
+export interface ParseGitEntryResult {
+  ok: boolean;
+  isGitFamily: boolean;
+  spec?: NormalizedGitEntrySpec;
+  findings: ValidationFinding[];
+  unavailableReason?: string;
+}
+
+export interface AcquireGitEntryOptions {
+  spec: NormalizedGitEntrySpec;
+  entryId: string;
+  trust?: AcquisitionTrustOptions;
+  executor?: GitExecutor;
+  destDir?: string;
+  cache?: SourceCache;
+}
+
+export interface AcquiredGitEntryResult {
+  ok: boolean;
+  entryId: string;
+  spec: NormalizedGitEntrySpec;
+  acquiredPath?: string;
+  entryRootPath?: string;
+  resolvedRevision?: string;
+  snapshot?: ValidationSnapshot;
+  findings: ValidationFinding[];
+  createdTemp?: boolean;
+  stderr?: string;
+}
+
+export interface BatchAcquireOptions {
+  agentDir?: string;
+  trust?: AcquisitionTrustOptions;
+  executor?: GitExecutor;
+  cache?: SourceCache;
+}
+
+export interface EntryAcquisitionRecord {
+  entryId: string;
+  spec: NormalizedGitEntrySpec;
+  resolvedRevision: string;
+  validationSnapshot: string;
+  snapshot: ValidationSnapshot;
+  entryRootPath: string;
+  acquiredPath: string;
+  createdTemp?: boolean;
+}
+
+export interface BatchAcquireResult {
+  ok: boolean;
+  entries: Map<string, EntryAcquisitionRecord>;
+  /** Map of entryId -> snapshot fingerprint for state persistence and drift comparison */
+  entrySnapshots: Record<string, string>;
+  findings: ValidationFinding[];
+  cleanup: () => void;
+}
+
+const GITHUB_SHORTHAND_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+
+function isMapping(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function entryFinding(
+  code: string,
+  rule: string,
+  pointer: string,
+  outcome: string,
+): ValidationFinding {
+  return blocking({
+    code,
+    rule,
+    phase: 'validation',
+    target: 'entry',
+    pointer,
+    outcome,
+  });
+}
+
+/** Check ref name syntax */
+function isValidRefSyntax(ref: string): { ok: boolean; reason?: string } {
+  if (!ref || ref.length === 0) return { ok: false, reason: 'empty ref' };
+  // eslint-disable-next-line no-control-regex
+  if (/[\x00-\x1F\x7F]/.test(ref)) return { ok: false, reason: 'contains control character' };
+  if (/\s/.test(ref)) return { ok: false, reason: 'contains whitespace' };
+  if (ref.startsWith('-')) return { ok: false, reason: 'option-like' };
+  if (ref.includes('\\')) return { ok: false, reason: 'contains backslash' };
+  if (ref.includes('..')) return { ok: false, reason: 'contains double dot ..' };
+  if (ref.includes('//')) return { ok: false, reason: 'contains double slash //' };
+  if (ref.includes('@{')) return { ok: false, reason: 'contains reflog @{' };
+  if (/[~^:?*\[\\]/.test(ref)) return { ok: false, reason: 'contains invalid revision characters ~ ^ : ? * [ \\' };
+  if (ref.startsWith('.') || ref.startsWith('/')) return { ok: false, reason: 'starts with . or /' };
+  if (ref.endsWith('.') || ref.endsWith('/') || ref.endsWith('.lock')) return { ok: false, reason: 'ends with . / or .lock' };
+  if (ref === 'HEAD' || ref === 'head') return { ok: false, reason: 'HEAD is not allowed as ref' };
+  return { ok: true };
+}
+
+/**
+ * Normalize an entry's Git locator.
+ * Expands `owner/repo` shorthand to `https://github.com/owner/repo`.
+ * Enforces HTTPS/SSH, rejects plaintext, credentials, query/fragment, control chars.
+ */
+export function normalizeEntryLocator(
+  rawLocator: string,
+  entryId = '/plugins/0',
+): { ok: boolean; locator?: CanonicalGitLocator; findings: ValidationFinding[]; isShorthand?: boolean } {
+  if (typeof rawLocator !== 'string' || rawLocator.trim().length === 0) {
+    return {
+      ok: false,
+      findings: [entryFinding(CODE.GIT_LOCATOR_INVALID, RULE.GIT_LOCATOR_INVALID, `${entryId}/source`, 'locator is empty')],
+    };
+  }
+
+  const trimmed = rawLocator.trim();
+
+  // Check shorthand owner/repo pattern: no scheme, no @ (not scp), contains 1 slash
+  if (!trimmed.includes('://') && !trimmed.includes('@') && GITHUB_SHORTHAND_RE.test(trimmed)) {
+    const expanded = `https://github.com/${trimmed}`;
+    const res = normalizeGitLocator(expanded);
+    if (!res.ok) {
+      const findings = res.findings.map((f) => entryFinding(f.code, f.rule, `${entryId}/source`, f.outcome));
+      return { ok: false, findings, isShorthand: true };
+    }
+    return { ok: true, locator: res.locator, findings: [], isShorthand: true };
+  }
+
+  // Normal git locator
+  const res = normalizeGitLocator(trimmed);
+  if (!res.ok) {
+    const findings = res.findings.map((f) => entryFinding(f.code, f.rule, `${entryId}/source`, f.outcome));
+    return { ok: false, findings };
+  }
+
+  return { ok: true, locator: res.locator, findings: [] };
+}
+
+/**
+ * Resolve an entry's Git selector and effective pin.
+ * Pin matrix:
+ * - `sha` / `commit` present: commit selector (complete 40/64 hex), effectivePin = 'sha'
+ * - `ref` / `branch` / `tag` present (no sha): branch/tag selector, effectivePin = 'ref'
+ * - neither present: default selector, effectivePin = 'default'
+ * - both `sha` and `ref` present: `sha` is effective pin; `ref` is validated for syntax
+ */
+export function resolveEntrySelector(
+  rawSource: Record<string, unknown>,
+  entryId = '/plugins/0',
+): {
+  ok: boolean;
+  selector?: NormalizedGitSelector;
+  effectivePin: 'sha' | 'ref' | 'default';
+  verifiedRef?: NormalizedGitSelector;
+  findings: ValidationFinding[];
+} {
+  const findings: ValidationFinding[] = [];
+  const rawSha = rawSource.sha ?? rawSource.commit;
+  const rawRef = rawSource.ref ?? rawSource.branch ?? rawSource.tag;
+
+  // 1. If sha / commit is present
+  if (rawSha !== undefined && rawSha !== null && rawSha !== '') {
+    const shaStr = String(rawSha);
+    // Validate commit hex format
+    const selRes = normalizeGitSelector({ kind: 'commit', value: shaStr });
+    if (!selRes.ok) {
+      findings.push(
+        ...selRes.findings.map((f) => entryFinding(f.code, f.rule, `${entryId}/sha`, f.outcome)),
+      );
+      return { ok: false, effectivePin: 'sha', findings };
+    }
+
+    let verifiedRef: NormalizedGitSelector | undefined;
+    // When ref is ALSO present, validate ref for syntax ("並存時 sha 有效、ref 僅驗證不綁定")
+    if (rawRef !== undefined && rawRef !== null && rawRef !== '') {
+      const refStr = String(rawRef);
+      const syntax = isValidRefSyntax(refStr);
+      if (!syntax.ok) {
+        findings.push(
+          entryFinding(
+            CODE.GIT_SELECTOR_INVALID,
+            RULE.GIT_SELECTOR_INVALID,
+            `${entryId}/ref`,
+            `invalid ref '${refStr}': ${syntax.reason}`,
+          ),
+        );
+        return { ok: false, effectivePin: 'sha', findings };
+      }
+
+      // Try normalizing ref
+      if (rawSource.branch !== undefined) {
+        const bRes = normalizeGitSelector({ kind: 'branch', value: String(rawSource.branch) });
+        if (!bRes.ok) {
+          findings.push(...bRes.findings.map((f) => entryFinding(f.code, f.rule, `${entryId}/branch`, f.outcome)));
+          return { ok: false, effectivePin: 'sha', findings };
+        }
+        verifiedRef = bRes.selector;
+      } else if (rawSource.tag !== undefined) {
+        const tRes = normalizeGitSelector({ kind: 'tag', value: String(rawSource.tag) });
+        if (!tRes.ok) {
+          findings.push(...tRes.findings.map((f) => entryFinding(f.code, f.rule, `${entryId}/tag`, f.outcome)));
+          return { ok: false, effectivePin: 'sha', findings };
+        }
+        verifiedRef = tRes.selector;
+      } else {
+        if (refStr.startsWith('refs/heads/')) {
+          verifiedRef = { kind: 'branch', canonical: refStr, raw: refStr };
+        } else if (refStr.startsWith('refs/tags/')) {
+          verifiedRef = { kind: 'tag', canonical: refStr, raw: refStr };
+        } else if (refStr.startsWith('v') && /^[0-9]/.test(refStr.slice(1))) {
+          verifiedRef = { kind: 'tag', canonical: `refs/tags/${refStr}`, raw: refStr };
+        } else {
+          verifiedRef = { kind: 'branch', canonical: `refs/heads/${refStr}`, raw: refStr };
+        }
+      }
+    }
+
+    return {
+      ok: true,
+      selector: selRes.selector!,
+      effectivePin: 'sha',
+      verifiedRef,
+      findings: [],
+    };
+  }
+
+  // 2. If ref / branch / tag is present (without sha)
+  if (rawRef !== undefined && rawRef !== null && rawRef !== '') {
+    if (rawSource.branch !== undefined) {
+      const bRes = normalizeGitSelector({ kind: 'branch', value: String(rawSource.branch) });
+      if (!bRes.ok) {
+        findings.push(...bRes.findings.map((f) => entryFinding(f.code, f.rule, `${entryId}/branch`, f.outcome)));
+        return { ok: false, effectivePin: 'ref', findings };
+      }
+      return { ok: true, selector: bRes.selector!, effectivePin: 'ref', findings: [] };
+    }
+
+    if (rawSource.tag !== undefined) {
+      const tRes = normalizeGitSelector({ kind: 'tag', value: String(rawSource.tag) });
+      if (!tRes.ok) {
+        findings.push(...tRes.findings.map((f) => entryFinding(f.code, f.rule, `${entryId}/tag`, f.outcome)));
+        return { ok: false, effectivePin: 'ref', findings };
+      }
+      return { ok: true, selector: tRes.selector!, effectivePin: 'ref', findings: [] };
+    }
+
+    const refStr = String(rawRef);
+    const syntax = isValidRefSyntax(refStr);
+    if (!syntax.ok) {
+      findings.push(
+        entryFinding(
+          CODE.GIT_SELECTOR_INVALID,
+          RULE.GIT_SELECTOR_INVALID,
+          `${entryId}/ref`,
+          `invalid ref '${refStr}': ${syntax.reason}`,
+        ),
+      );
+      return { ok: false, effectivePin: 'ref', findings };
+    }
+
+    let selector: NormalizedGitSelector;
+    if (refStr.startsWith('refs/heads/')) {
+      selector = { kind: 'branch', canonical: refStr, raw: refStr };
+    } else if (refStr.startsWith('refs/tags/')) {
+      selector = { kind: 'tag', canonical: refStr, raw: refStr };
+    } else if (refStr.startsWith('branch:')) {
+      const bRes = normalizeGitSelector({ kind: 'branch', value: refStr.slice(7) });
+      if (!bRes.ok) {
+        findings.push(...bRes.findings.map((f) => entryFinding(f.code, f.rule, `${entryId}/ref`, f.outcome)));
+        return { ok: false, effectivePin: 'ref', findings };
+      }
+      selector = bRes.selector!;
+    } else if (refStr.startsWith('tag:')) {
+      const tRes = normalizeGitSelector({ kind: 'tag', value: refStr.slice(4) });
+      if (!tRes.ok) {
+        findings.push(...tRes.findings.map((f) => entryFinding(f.code, f.rule, `${entryId}/ref`, f.outcome)));
+        return { ok: false, effectivePin: 'ref', findings };
+      }
+      selector = tRes.selector!;
+    } else if (refStr.startsWith('v') && /^[0-9]/.test(refStr.slice(1))) {
+      selector = { kind: 'tag', canonical: `refs/tags/${refStr}`, raw: refStr };
+    } else {
+      selector = { kind: 'branch', canonical: `refs/heads/${refStr}`, raw: refStr };
+    }
+
+    return { ok: true, selector, effectivePin: 'ref', findings: [] };
+  }
+
+  // 3. Neither sha nor ref: movable default selector
+  return {
+    ok: true,
+    selector: { kind: 'default', canonical: 'default', raw: 'default' },
+    effectivePin: 'default',
+    findings: [],
+  };
+}
+
+/**
+ * Parse and validate a raw entry source into NormalizedGitEntrySpec.
+ * Distinguishes local vs external git vs unavailable forms (npm/archive/command/bare).
+ */
+export function parseGitEntrySpec(entrySource: unknown, entryId = '/plugins/0'): ParseGitEntryResult {
+  const findings: ValidationFinding[] = [];
+
+  if (entrySource === undefined || entrySource === null || entrySource === '') {
+    return {
+      ok: false,
+      isGitFamily: false,
+      findings: [],
+      unavailableReason: 'no source declared',
+    };
+  }
+
+  // Case 1: string source
+  if (typeof entrySource === 'string') {
+    const s = entrySource.trim();
+    if (s.startsWith('./')) {
+      return {
+        ok: false,
+        isGitFamily: false,
+        findings: [],
+      };
+    }
+
+    // Shorthand owner/repo
+    if (GITHUB_SHORTHAND_RE.test(s)) {
+      const locRes = normalizeEntryLocator(s, entryId);
+      if (!locRes.ok) {
+        return { ok: false, isGitFamily: true, findings: locRes.findings };
+      }
+      const spec: NormalizedGitEntrySpec = {
+        shape: 'github',
+        locator: locRes.locator!,
+        selector: { kind: 'default', canonical: 'default', raw: 'default' },
+        effectivePin: 'default',
+        rawSource: entrySource,
+      };
+      return { ok: true, isGitFamily: true, spec, findings: [] };
+    }
+
+    // Full URL or protocol string
+    if (s.includes('://') || s.includes('@')) {
+      const locRes = normalizeEntryLocator(s, entryId);
+      if (!locRes.ok) {
+        return { ok: false, isGitFamily: true, findings: locRes.findings };
+      }
+      const spec: NormalizedGitEntrySpec = {
+        shape: 'url',
+        locator: locRes.locator!,
+        selector: { kind: 'default', canonical: 'default', raw: 'default' },
+        effectivePin: 'default',
+        rawSource: entrySource,
+      };
+      return { ok: true, isGitFamily: true, spec, findings: [] };
+    }
+
+    // Bare name or other unresolvable string
+    if (!s.includes('/')) {
+      return {
+        ok: false,
+        isGitFamily: false,
+        findings: [],
+        unavailableReason: 'bare name source cannot resolve without metadata.pluginRoot, which is unsupported',
+      };
+    }
+
+    return {
+      ok: false,
+      isGitFamily: false,
+      findings: [],
+      unavailableReason: 'source must start with ./ to be locally resolvable',
+    };
+  }
+
+  // Case 2: object source
+  if (isMapping(entrySource)) {
+    const raw = entrySource as RawGitEntrySource;
+    const sourceKind = typeof raw.source === 'string' ? raw.source.toLowerCase() : undefined;
+
+    // npm / archive / command are unavailable
+    if (sourceKind === 'npm') {
+      return { ok: false, isGitFamily: false, findings: [], unavailableReason: 'npm source entries are not supported' };
+    }
+    if (sourceKind === 'archive') {
+      return { ok: false, isGitFamily: false, findings: [], unavailableReason: 'archive source entries are not supported' };
+    }
+    if (sourceKind === 'command') {
+      return { ok: false, isGitFamily: false, findings: [], unavailableReason: 'command source entries are permanently disqualified' };
+    }
+
+    // github shape
+    if (sourceKind === 'github') {
+      if (typeof raw.repo !== 'string' || raw.repo.trim().length === 0) {
+        findings.push(
+          entryFinding(CODE.GIT_LOCATOR_INVALID, RULE.GIT_LOCATOR_INVALID, `${entryId}/repo`, 'github source requires a non-empty repo string'),
+        );
+        return { ok: false, isGitFamily: true, findings };
+      }
+
+      const locRes = normalizeEntryLocator(raw.repo, entryId);
+      if (!locRes.ok) {
+        return { ok: false, isGitFamily: true, findings: locRes.findings };
+      }
+
+      const selRes = resolveEntrySelector(raw, entryId);
+      if (!selRes.ok) {
+        return { ok: false, isGitFamily: true, findings: selRes.findings };
+      }
+
+      const subpath = typeof raw.subpath === 'string' ? raw.subpath : typeof raw.path === 'string' && !raw.path.startsWith('./') ? raw.path : undefined;
+
+      const spec: NormalizedGitEntrySpec = {
+        shape: 'github',
+        locator: locRes.locator!,
+        selector: selRes.selector!,
+        effectivePin: selRes.effectivePin,
+        verifiedRef: selRes.verifiedRef,
+        subpath,
+        rawSource: entrySource,
+      };
+      return { ok: true, isGitFamily: true, spec, findings: [] };
+    }
+
+    // url shape
+    if (sourceKind === 'url') {
+      if (typeof raw.url !== 'string' || raw.url.trim().length === 0) {
+        findings.push(
+          entryFinding(CODE.GIT_LOCATOR_INVALID, RULE.GIT_LOCATOR_INVALID, `${entryId}/url`, 'url source requires a non-empty url string'),
+        );
+        return { ok: false, isGitFamily: true, findings };
+      }
+
+      const locRes = normalizeEntryLocator(raw.url, entryId);
+      if (!locRes.ok) {
+        return { ok: false, isGitFamily: true, findings: locRes.findings };
+      }
+
+      const selRes = resolveEntrySelector(raw, entryId);
+      if (!selRes.ok) {
+        return { ok: false, isGitFamily: true, findings: selRes.findings };
+      }
+
+      const subpath = typeof raw.subpath === 'string' ? raw.subpath : typeof raw.path === 'string' && !raw.path.startsWith('./') ? raw.path : undefined;
+
+      const spec: NormalizedGitEntrySpec = {
+        shape: 'url',
+        locator: locRes.locator!,
+        selector: selRes.selector!,
+        effectivePin: selRes.effectivePin,
+        verifiedRef: selRes.verifiedRef,
+        subpath,
+        rawSource: entrySource,
+      };
+      return { ok: true, isGitFamily: true, spec, findings: [] };
+    }
+
+    // git-subdir shape
+    if (sourceKind === 'git-subdir') {
+      const targetUrl = typeof raw.url === 'string' ? raw.url : typeof raw.repo === 'string' ? raw.repo : undefined;
+      if (!targetUrl || targetUrl.trim().length === 0) {
+        findings.push(
+          entryFinding(CODE.GIT_LOCATOR_INVALID, RULE.GIT_LOCATOR_INVALID, `${entryId}/url`, 'git-subdir requires a non-empty url or repo string'),
+        );
+        return { ok: false, isGitFamily: true, findings };
+      }
+
+      const locRes = normalizeEntryLocator(targetUrl, entryId);
+      if (!locRes.ok) {
+        return { ok: false, isGitFamily: true, findings: locRes.findings };
+      }
+
+      const rawPath = typeof raw.path === 'string' ? raw.path : typeof raw.subpath === 'string' ? raw.subpath : undefined;
+      if (!rawPath || rawPath.trim().length === 0) {
+        findings.push(
+          entryFinding(CODE.PATH_CONTAINMENT_VIOLATION, RULE.PATH_CONTAINMENT_VIOLATION, `${entryId}/path`, 'git-subdir requires a non-empty path string'),
+        );
+        return { ok: false, isGitFamily: true, findings };
+      }
+
+      const selRes = resolveEntrySelector(raw, entryId);
+      if (!selRes.ok) {
+        return { ok: false, isGitFamily: true, findings: selRes.findings };
+      }
+
+      const spec: NormalizedGitEntrySpec = {
+        shape: 'git-subdir',
+        locator: locRes.locator!,
+        selector: selRes.selector!,
+        effectivePin: selRes.effectivePin,
+        verifiedRef: selRes.verifiedRef,
+        subpath: rawPath.trim(),
+        rawSource: entrySource,
+      };
+      return { ok: true, isGitFamily: true, spec, findings: [] };
+    }
+
+    // Codex git kind compatibility: { source: "git", url: "..." }
+    if (sourceKind === 'git') {
+      if (typeof raw.url !== 'string' || raw.url.trim().length === 0) {
+        findings.push(
+          entryFinding(CODE.GIT_LOCATOR_INVALID, RULE.GIT_LOCATOR_INVALID, `${entryId}/url`, 'git source requires a non-empty url string'),
+        );
+        return { ok: false, isGitFamily: true, findings };
+      }
+
+      const locRes = normalizeEntryLocator(raw.url, entryId);
+      if (!locRes.ok) {
+        return { ok: false, isGitFamily: true, findings: locRes.findings };
+      }
+
+      const selRes = resolveEntrySelector(raw, entryId);
+      if (!selRes.ok) {
+        return { ok: false, isGitFamily: true, findings: selRes.findings };
+      }
+
+      const subpath = typeof raw.path === 'string' && !raw.path.startsWith('./') ? raw.path : typeof raw.subpath === 'string' ? raw.subpath : undefined;
+
+      const spec: NormalizedGitEntrySpec = {
+        shape: 'url',
+        locator: locRes.locator!,
+        selector: selRes.selector!,
+        effectivePin: selRes.effectivePin,
+        verifiedRef: selRes.verifiedRef,
+        subpath,
+        rawSource: entrySource,
+      };
+      return { ok: true, isGitFamily: true, spec, findings: [] };
+    }
+
+    // Unknown discriminator
+    return {
+      ok: false,
+      isGitFamily: false,
+      findings: [],
+      unavailableReason: 'unknown entry source kind',
+    };
+  }
+
+  return {
+    ok: false,
+    isGitFamily: false,
+    findings: [],
+    unavailableReason: 'unrecognized source form',
+  };
+}
+
+/**
+ * Acquire one external Git entry non-executingly.
+ * Materializes the repo at the resolved revision, resolves subpath (if any),
+ * and builds the per-entry Validation Snapshot with deterministic fingerprint.
+ */
+export async function acquireGitEntry(opts: AcquireGitEntryOptions): Promise<AcquiredGitEntryResult> {
+  const { spec, entryId } = opts;
+
+  // Non-executing acquisition via existing hardened pipeline
+  const acq = await acquireGitSource({
+    locator: spec.locator,
+    selector: spec.selector,
+    trust: opts.trust,
+    executor: opts.executor,
+    destDir: opts.destDir,
+  });
+
+  if (!acq.ok) {
+    const findings = acq.findings.map((f) =>
+      entryFinding(f.code, f.rule, `${entryId}/source`, f.outcome),
+    );
+    return {
+      ok: false,
+      entryId,
+      spec,
+      findings,
+      stderr: acq.stderr,
+    };
+  }
+
+  const acquiredPath = realpathSync.native(acq.acquiredPath!);
+  const createdTemp = acq.createdTemp ?? false;
+  const resolvedRevision = acq.resolvedRevision!;
+
+  let entryRootPath = acquiredPath;
+
+  // If subpath is specified (e.g. git-subdir), resolve containment inside acquired repo
+  if (spec.subpath) {
+    const relSubpath = spec.subpath.startsWith('./') ? spec.subpath : `./${spec.subpath}`;
+    const res = resolveContained(acquiredPath, relSubpath, 'directory');
+    if (res.outcome.kind === 'blocking') {
+      if (createdTemp) cleanupAcquisition(acquiredPath);
+      const isSymlink = res.outcome.blockClass === 'symlink';
+      return {
+        ok: false,
+        entryId,
+        spec,
+        findings: [
+          entryFinding(
+            isSymlink ? CODE.CONTAINED_SYMLINK_VIOLATION : CODE.PATH_CONTAINMENT_VIOLATION,
+            isSymlink ? RULE.CONTAINED_SYMLINK_VIOLATION : RULE.PATH_CONTAINMENT_VIOLATION,
+            `${entryId}/path`,
+            `${entryId}: ${res.outcome.reason}`,
+          ),
+        ],
+      };
+    }
+    if (res.outcome.kind === 'missing') {
+      if (createdTemp) cleanupAcquisition(acquiredPath);
+      return {
+        ok: false,
+        entryId,
+        spec,
+        findings: [
+          entryFinding(
+            CODE.SOURCE_NOT_EXISTS,
+            RULE.SOURCE_NOT_EXISTS,
+            `${entryId}/path`,
+            `${entryId}: subpath '${spec.subpath}' does not exist in acquired repository`,
+          ),
+        ],
+      };
+    }
+
+    entryRootPath = res.outcome.canonicalPath;
+  }
+
+  // Build per-entry Validation Snapshot
+  const entrySourceKey: SourceKey = gitSourceKey(spec.locator, spec.selector);
+  entrySourceKey.resolvedRevision = resolvedRevision;
+  entrySourceKey.canonicalUrl = spec.locator.canonicalUrl;
+  entrySourceKey.selector = spec.selector.canonical;
+  if (spec.subpath) {
+    entrySourceKey.subpath = spec.subpath;
+  }
+
+  const snapRes = buildGitSnapshot(entryRootPath, entrySourceKey, {
+    canonicalLocator: spec.locator.canonicalUrl,
+    resolvedRevision,
+    selectorCanonical: spec.selector.canonical,
+  });
+
+  if (!snapRes.ok) {
+    if (createdTemp) cleanupAcquisition(acquiredPath);
+    const findings = snapRes.findings.map((f) =>
+      entryFinding(f.code, f.rule, `${entryId}${f.pointer ? `/${f.pointer.replace(/^\//, '')}` : ''}`, f.outcome),
+    );
+    return {
+      ok: false,
+      entryId,
+      spec,
+      findings,
+    };
+  }
+
+  // Cache entry tree when cache provided
+  if (opts.cache) {
+    try {
+      await opts.cache.storeTree(entryRootPath, snapRes.snapshot!.fingerprint);
+      opts.cache.recordIndex({
+        fingerprint: snapRes.snapshot!.fingerprint,
+        resolvedRevision,
+        canonicalLocator: spec.locator.canonicalUrl,
+        selectorCanonical: spec.selector.canonical,
+      });
+    } catch {
+      // Non-authoritative cache failure does not block
+    }
+  }
+
+  return {
+    ok: true,
+    entryId,
+    spec,
+    acquiredPath,
+    entryRootPath,
+    resolvedRevision,
+    snapshot: snapRes.snapshot,
+    findings: snapRes.findings,
+    createdTemp,
+  };
+}
+
+/**
+ * Acquire multiple external git entries in a batch.
+ * If ANY entry fails with a blocking finding, cleans up all created directories and returns ok: false.
+ */
+export async function acquireGitEntries(
+  entries: Array<{ entryId: string; source: unknown; name?: string }>,
+  opts: BatchAcquireOptions = {},
+): Promise<BatchAcquireResult> {
+  const records = new Map<string, EntryAcquisitionRecord>();
+  const entrySnapshots: Record<string, string> = {};
+  const allFindings: ValidationFinding[] = [];
+  const tempPaths: string[] = [];
+
+  const cleanup = () => {
+    for (const p of tempPaths) {
+      cleanupAcquisition(p);
+    }
+    tempPaths.length = 0;
+  };
+
+  for (const entry of entries) {
+    const parsed = parseGitEntrySpec(entry.source, entry.entryId);
+    if (!parsed.isGitFamily) {
+      // Non-git entry (local or npm/archive/command) is skipped by the git acquisition engine
+      continue;
+    }
+
+    if (!parsed.ok || !parsed.spec) {
+      allFindings.push(...parsed.findings);
+      cleanup();
+      return {
+        ok: false,
+        entries: new Map(),
+        entrySnapshots: {},
+        findings: sortFindings(allFindings),
+        cleanup: () => {},
+      };
+    }
+
+    const acq = await acquireGitEntry({
+      spec: parsed.spec,
+      entryId: entry.entryId,
+      trust: opts.trust,
+      executor: opts.executor,
+      cache: opts.cache,
+    });
+
+    if (acq.createdTemp && acq.acquiredPath) {
+      tempPaths.push(acq.acquiredPath);
+    }
+
+    if (!acq.ok || !acq.snapshot) {
+      allFindings.push(...acq.findings);
+      cleanup();
+      return {
+        ok: false,
+        entries: new Map(),
+        entrySnapshots: {},
+        findings: sortFindings(allFindings),
+        cleanup: () => {},
+      };
+    }
+
+    const record: EntryAcquisitionRecord = {
+      entryId: entry.entryId,
+      spec: parsed.spec,
+      resolvedRevision: acq.resolvedRevision!,
+      validationSnapshot: acq.snapshot.fingerprint,
+      snapshot: acq.snapshot,
+      entryRootPath: acq.entryRootPath!,
+      acquiredPath: acq.acquiredPath!,
+      createdTemp: acq.createdTemp,
+    };
+
+    records.set(entry.entryId, record);
+    entrySnapshots[entry.entryId] = acq.snapshot.fingerprint;
+  }
+
+  return {
+    ok: true,
+    entries: records,
+    entrySnapshots,
+    findings: [],
+    cleanup,
+  };
+}
+
+/**
+ * Check whether an entry's current snapshot fingerprint has drifted from the recorded state.
+ * Returns true if drifted.
+ */
+export function checkEntryDrift(currentFingerprint: string, recordedFingerprint: string): boolean {
+  return currentFingerprint !== recordedFingerprint;
+}

--- a/src/registration/index.ts
+++ b/src/registration/index.ts
@@ -13,5 +13,6 @@ export * from './git-locator.js';
 export * from './git-selector.js';
 export * from './git-acquisition.js';
 export * from './git-flow.js';
+export * from './entry-acquisition.js';
 export * from '../compatibility/index.js';
 export * from '../installation/index.js';

--- a/src/registration/source-key.ts
+++ b/src/registration/source-key.ts
@@ -24,6 +24,8 @@ export interface SourceKey {
   canonicalUrl?: string;
   /** Canonical Git selector (for git) */
   selector?: string;
+  /** Subpath inside repository for git-subdir entries */
+  subpath?: string;
   /** Resolved Revision (git, not part of identity but stored for provenance) */
   resolvedRevision?: string;
 }

--- a/tests/integration/entry-acquisition.test.ts
+++ b/tests/integration/entry-acquisition.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, cpSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  acquireGitEntry,
+  acquireGitEntries,
+  parseGitEntrySpec,
+  checkEntryDrift,
+} from '../../src/registration/entry-acquisition.js';
+import type { GitExecutor } from '../../src/registration/git-acquisition.js';
+import { SourceCache } from '../../src/cache/source-cache.js';
+import { CODE } from '../../src/registration/findings.js';
+import { BUDGET } from '../../src/registration/budget.js';
+
+function createMultiRepoFixtures(baseDir: string) {
+  // Repo A: standard plugin
+  const repoADir = join(baseDir, 'repoA');
+  mkdirSync(join(repoADir, 'skills', 'skill-a'), { recursive: true });
+  mkdirSync(join(repoADir, '.claude-plugin'), { recursive: true });
+  writeFileSync(
+    join(repoADir, 'skills', 'skill-a', 'SKILL.md'),
+    '---\nname: skill-a\ndescription: Skill A\n---\nPrompt A',
+  );
+  writeFileSync(
+    join(repoADir, '.claude-plugin', 'plugin.json'),
+    JSON.stringify({ name: 'plugin-a', skills: ['./skills/skill-a'] }),
+  );
+
+  // Repo B: monorepo with multiple subplugins
+  const repoBDir = join(baseDir, 'repoB');
+  mkdirSync(join(repoBDir, 'packages', 'plugin-b1', 'skills', 'skill-b1'), { recursive: true });
+  writeFileSync(
+    join(repoBDir, 'packages', 'plugin-b1', 'skills', 'skill-b1', 'SKILL.md'),
+    '---\nname: skill-b1\ndescription: Skill B1\n---\nPrompt B1',
+  );
+  writeFileSync(
+    join(repoBDir, 'packages', 'plugin-b1', 'plugin.json'),
+    JSON.stringify({ name: 'plugin-b1' }),
+  );
+
+  mkdirSync(join(repoBDir, 'packages', 'plugin-b2', 'skills', 'skill-b2'), { recursive: true });
+  writeFileSync(
+    join(repoBDir, 'packages', 'plugin-b2', 'skills', 'skill-b2', 'SKILL.md'),
+    '---\nname: skill-b2\ndescription: Skill B2\n---\nPrompt B2',
+  );
+  writeFileSync(
+    join(repoBDir, 'packages', 'plugin-b2', 'plugin.json'),
+    JSON.stringify({ name: 'plugin-b2' }),
+  );
+
+  return { repoADir, repoBDir };
+}
+
+function createMultiMockExecutor(repoADir: string, repoBDir: string): GitExecutor {
+  const shaA = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const shaB = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+  return async (args) => {
+    if (args.includes('ls-remote')) {
+      const url = args[args.indexOf('ls-remote') + 1];
+      const ref = args[args.length - 1];
+      const sha = url.includes('repoA') || url.includes('plugin-a') ? shaA : shaB;
+      return { exitCode: 0, stdout: `${sha}\t${ref}\n`, stderr: '' };
+    }
+
+    if (args.includes('clone')) {
+      const url = args[args.indexOf('clone') + 3];
+      const dest = args[args.length - 1];
+      const src = url.includes('repoA') || url.includes('plugin-a') ? repoADir : repoBDir;
+      cpSync(src, dest, { recursive: true });
+      mkdirSync(join(dest, '.git'), { recursive: true });
+      return { exitCode: 0, stdout: '', stderr: '' };
+    }
+
+    if (args.includes('remote') && args.includes('get-url')) {
+      return { exitCode: 0, stdout: 'https://github.com/org/repo\n', stderr: '' };
+    }
+
+    return { exitCode: 0, stdout: '', stderr: '' };
+  };
+}
+
+describe('Entry Acquisition Engine — Integration Scenarios', () => {
+  let tmpRoot: string;
+  let repoADir: string;
+  let repoBDir: string;
+  let executor: GitExecutor;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'entry-acq-integ-'));
+    const fixtures = createMultiRepoFixtures(tmpRoot);
+    repoADir = fixtures.repoADir;
+    repoBDir = fixtures.repoBDir;
+    executor = createMultiMockExecutor(repoADir, repoBDir);
+  });
+
+  afterEach(() => {
+    try {
+      if (existsSync(tmpRoot)) rmSync(tmpRoot, { recursive: true, force: true });
+    } catch {}
+  });
+
+  it('acquires entries from aggregated marketplace mixing github, url, and git-subdir shapes', async () => {
+    const entries = [
+      // Entry 0: local entry (skipped by git engine)
+      { entryId: '/plugins/0', source: './local-plugin' },
+      // Entry 1: github entry (sha-pinned)
+      { entryId: '/plugins/1', source: { source: 'github', repo: 'org/plugin-a', sha: 'a'.repeat(40) } },
+      // Entry 2: git-subdir entry 1 (movable ref)
+      { entryId: '/plugins/2', source: { source: 'git-subdir', url: 'https://github.com/org/repoB.git', path: 'packages/plugin-b1', ref: 'main' } },
+      // Entry 3: git-subdir entry 2 (movable default)
+      { entryId: '/plugins/3', source: { source: 'git-subdir', url: 'https://github.com/org/repoB.git', path: 'packages/plugin-b2' } },
+      // Entry 4: npm entry (unavailable, skipped by git engine)
+      { entryId: '/plugins/4', source: { source: 'npm', package: '@scope/tools' } },
+    ];
+
+    const agentDir = join(tmpRoot, 'agent');
+    const cache = new SourceCache({ agentDir });
+
+    const batch = await acquireGitEntries(entries, { executor, cache, agentDir });
+
+    expect(batch.ok).toBe(true);
+    // Git engine acquired 3 git entries (1, 2, 3)
+    expect(batch.entries.size).toBe(3);
+
+    const rec1 = batch.entries.get('/plugins/1')!;
+    expect(rec1.spec.shape).toBe('github');
+    expect(rec1.resolvedRevision).toBe('a'.repeat(40));
+    expect(rec1.validationSnapshot).toBeDefined();
+    expect(rec1.snapshot.entries.some((e) => e.relPath === 'skills/skill-a/SKILL.md')).toBe(true);
+
+    const rec2 = batch.entries.get('/plugins/2')!;
+    expect(rec2.spec.shape).toBe('git-subdir');
+    expect(rec2.spec.subpath).toBe('packages/plugin-b1');
+    expect(rec2.resolvedRevision).toBe('b'.repeat(40));
+    expect(rec2.snapshot.entries.some((e) => e.relPath === 'skills/skill-b1/SKILL.md')).toBe(true);
+
+    const rec3 = batch.entries.get('/plugins/3')!;
+    expect(rec3.spec.shape).toBe('git-subdir');
+    expect(rec3.spec.subpath).toBe('packages/plugin-b2');
+    expect(rec3.snapshot.entries.some((e) => e.relPath === 'skills/skill-b2/SKILL.md')).toBe(true);
+
+    expect(batch.entrySnapshots['/plugins/1']).toBe(rec1.validationSnapshot);
+    expect(batch.entrySnapshots['/plugins/2']).toBe(rec2.validationSnapshot);
+    expect(batch.entrySnapshots['/plugins/3']).toBe(rec3.validationSnapshot);
+
+    batch.cleanup();
+  });
+
+  it('enforces Validation Budget during entry acquisition: total byte limit exceeded produces Blocking Finding', async () => {
+    const bigRepoDir = join(tmpRoot, 'bigRepo');
+    mkdirSync(bigRepoDir, { recursive: true });
+    // Write a single file exceeding maxTotalBytes (10 MiB)
+    writeFileSync(join(bigRepoDir, 'oversized.bin'), Buffer.alloc(BUDGET.maxTotalBytes + 1024));
+
+    const bigExecutor: GitExecutor = async (args) => {
+      if (args.includes('ls-remote')) {
+        return { exitCode: 0, stdout: `${'f'.repeat(40)}\tHEAD\n`, stderr: '' };
+      }
+      if (args.includes('clone')) {
+        const dest = args[args.length - 1];
+        cpSync(bigRepoDir, dest, { recursive: true });
+        mkdirSync(join(dest, '.git'), { recursive: true });
+        return { exitCode: 0, stdout: '', stderr: '' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    };
+
+    const parsed = parseGitEntrySpec({ source: 'github', repo: 'org/big-repo' });
+    expect(parsed.ok).toBe(true);
+
+    const res = await acquireGitEntry({
+      spec: parsed.spec!,
+      entryId: '/plugins/0',
+      executor: bigExecutor,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.findings.some((f) => f.code === CODE.BUDGET_EXCEEDED)).toBe(true);
+  });
+
+  it('enforces Validation Budget during entry acquisition: tree depth exceeded produces Blocking Finding', async () => {
+    const deepRepoDir = join(tmpRoot, 'deepRepo');
+    let curr = deepRepoDir;
+    for (let i = 0; i <= BUDGET.maxTreeDepth + 2; i++) {
+      curr = join(curr, `d_${i}`);
+    }
+    mkdirSync(curr, { recursive: true });
+    writeFileSync(join(curr, 'deep.txt'), 'deep');
+
+    const deepExecutor: GitExecutor = async (args) => {
+      if (args.includes('ls-remote')) {
+        return { exitCode: 0, stdout: `${'f'.repeat(40)}\tHEAD\n`, stderr: '' };
+      }
+      if (args.includes('clone')) {
+        const dest = args[args.length - 1];
+        cpSync(deepRepoDir, dest, { recursive: true });
+        mkdirSync(join(dest, '.git'), { recursive: true });
+        return { exitCode: 0, stdout: '', stderr: '' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    };
+
+    const parsed = parseGitEntrySpec({ source: 'github', repo: 'org/deep-repo' });
+    expect(parsed.ok).toBe(true);
+
+    const res = await acquireGitEntry({
+      spec: parsed.spec!,
+      entryId: '/plugins/0',
+      executor: deepExecutor,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.findings.some((f) => f.code === CODE.BUDGET_EXCEEDED)).toBe(true);
+  });
+
+  it('binds per-entry snapshot into SourceCache and enables cache hit on exact fingerprint', async () => {
+    const agentDir = join(tmpRoot, 'agent');
+    const cache = new SourceCache({ agentDir });
+
+    const parsed = parseGitEntrySpec({ source: 'github', repo: 'org/plugin-a', sha: 'a'.repeat(40) });
+    const res = await acquireGitEntry({
+      spec: parsed.spec!,
+      entryId: '/plugins/0',
+      executor,
+      cache,
+    });
+
+    expect(res.ok).toBe(true);
+    const fingerprint = res.snapshot!.fingerprint;
+
+    // Verify cache has tree under fingerprint
+    const cached = await cache.hitExact(fingerprint);
+    expect(cached).not.toBeNull();
+    expect(cached!.fingerprint).toBe(fingerprint);
+
+    if (res.createdTemp && res.acquiredPath) {
+      rmSync(res.acquiredPath, { recursive: true, force: true });
+    }
+  });
+
+  it('performs drift comparison on individual entries independently', async () => {
+    const parsedA = parseGitEntrySpec({ source: 'github', repo: 'org/plugin-a', sha: 'a'.repeat(40) });
+    const resA = await acquireGitEntry({ spec: parsedA.spec!, entryId: '/plugins/0', executor });
+    expect(resA.ok).toBe(true);
+
+    const recordedSnapshots = {
+      '/plugins/0': resA.snapshot!.fingerprint,
+      '/plugins/1': 'old-fingerprint-that-drifted-000000000000000000000000000000000000',
+    };
+
+    // Entry 0 has not drifted
+    expect(checkEntryDrift(resA.snapshot!.fingerprint, recordedSnapshots['/plugins/0'])).toBe(false);
+
+    // Entry 1 has drifted
+    expect(checkEntryDrift(resA.snapshot!.fingerprint, recordedSnapshots['/plugins/1'])).toBe(true);
+
+    if (resA.createdTemp && resA.acquiredPath) {
+      rmSync(resA.acquiredPath, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/registration/entry-acquisition.test.ts
+++ b/tests/unit/registration/entry-acquisition.test.ts
@@ -1,0 +1,687 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, cpSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  parseGitEntrySpec,
+  normalizeEntryLocator,
+  resolveEntrySelector,
+  acquireGitEntry,
+  acquireGitEntries,
+  checkEntryDrift,
+  type NormalizedGitEntrySpec,
+} from '../../../src/registration/entry-acquisition.js';
+import type { GitExecutor } from '../../../src/registration/git-acquisition.js';
+import { CODE, RULE } from '../../../src/registration/findings.js';
+
+function makeEntryFixture(root: string, opts: { withSubdir?: string; files?: Record<string, string> } = {}) {
+  const targetDir = opts.withSubdir ? join(root, opts.withSubdir) : root;
+  mkdirSync(targetDir, { recursive: true });
+
+  const files = opts.files ?? {
+    'SKILL.md': '---\nname: my-skill\ndescription: test skill\n---\nHello from skill',
+    '.claude-plugin/plugin.json': JSON.stringify({ name: 'entry-plugin', skills: ['./skills/my-skill'] }),
+  };
+
+  for (const [relPath, content] of Object.entries(files)) {
+    const fullPath = join(targetDir, relPath);
+    mkdirSync(join(fullPath, '..'), { recursive: true });
+    writeFileSync(fullPath, content);
+  }
+}
+
+function makeMockGitExecutor(
+  fixtureRoot: string,
+  opts: {
+    lsRemoteSha?: string;
+    hostKeyError?: 'unknown' | 'changed';
+    redirectError?: boolean;
+    cloneError?: string;
+    record?: { args: string[][]; envs: (Record<string, string> | undefined)[] };
+  } = {},
+): GitExecutor {
+  const record = opts.record ?? { args: [], envs: [] };
+  const sha = opts.lsRemoteSha ?? 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4';
+  return async (args, execOpts) => {
+    record.args.push(args);
+    record.envs.push(execOpts?.env);
+
+    if (args.includes('ls-remote')) {
+      if (opts.hostKeyError) {
+        const msg = opts.hostKeyError === 'changed'
+          ? 'Host key verification failed. Offending key ...'
+          : 'Host key verification failed.';
+        return { exitCode: 1, stdout: '', stderr: msg };
+      }
+      if (opts.redirectError) {
+        return { exitCode: 1, stdout: '', stderr: 'fatal: unable to access ... Redirect ... http.followRedirects=false' };
+      }
+      const ref = args[args.length - 1];
+      return { exitCode: 0, stdout: `${sha}\t${ref}\n`, stderr: '' };
+    }
+
+    if (args.includes('clone')) {
+      if (opts.hostKeyError) {
+        const msg = opts.hostKeyError === 'changed' ? 'Offending ECDSA key' : 'Host key verification failed.';
+        return { exitCode: 1, stdout: '', stderr: msg };
+      }
+      if (opts.cloneError) {
+        return { exitCode: 1, stdout: '', stderr: opts.cloneError };
+      }
+      const dest = args[args.length - 1];
+      cpSync(fixtureRoot, dest, { recursive: true });
+      mkdirSync(join(dest, '.git'), { recursive: true });
+      return { exitCode: 0, stdout: '', stderr: '' };
+    }
+
+    if (args.includes('remote') && args.includes('get-url')) {
+      return { exitCode: 0, stdout: 'https://github.com/owner/repo\n', stderr: '' };
+    }
+
+    if (args.includes('cat-file') || args.includes('checkout') || args.includes('fetch')) {
+      return { exitCode: 0, stdout: '', stderr: '' };
+    }
+
+    return { exitCode: 0, stdout: '', stderr: '' };
+  };
+}
+
+describe('Entry Acquisition Engine — Spec Parsing and Normalization', () => {
+  describe('Shorthand & Locator Normalization (Acceptance Criteria 2)', () => {
+    it('normalizes string owner/repo shorthand to https://github.com/<owner>/<repo>', () => {
+      const res = parseGitEntrySpec('octocat/Hello-World');
+      expect(res.ok).toBe(true);
+      expect(res.isGitFamily).toBe(true);
+      expect(res.spec!.shape).toBe('github');
+      expect(res.spec!.locator.canonicalUrl).toBe('https://github.com/octocat/Hello-World');
+      expect(res.spec!.selector.kind).toBe('default');
+      expect(res.spec!.effectivePin).toBe('default');
+    });
+
+    it('normalizes github object with shorthand repo to https://github.com/<owner>/<repo>', () => {
+      const res = parseGitEntrySpec({ source: 'github', repo: 'samwang/my-plugin' });
+      expect(res.ok).toBe(true);
+      expect(res.isGitFamily).toBe(true);
+      expect(res.spec!.shape).toBe('github');
+      expect(res.spec!.locator.canonicalUrl).toBe('https://github.com/samwang/my-plugin');
+    });
+
+    it('normalizes full URL in url object', () => {
+      const res = parseGitEntrySpec({ source: 'url', url: 'https://gitlab.com/group/project.git' });
+      expect(res.ok).toBe(true);
+      expect(res.isGitFamily).toBe(true);
+      expect(res.spec!.shape).toBe('url');
+      expect(res.spec!.locator.canonicalUrl).toBe('https://gitlab.com/group/project.git');
+    });
+
+    it('normalizes git-subdir object and captures subpath', () => {
+      const res = parseGitEntrySpec({
+        source: 'git-subdir',
+        url: 'https://github.com/org/monorepo.git',
+        path: 'plugins/core-plugin',
+      });
+      expect(res.ok).toBe(true);
+      expect(res.isGitFamily).toBe(true);
+      expect(res.spec!.shape).toBe('git-subdir');
+      expect(res.spec!.locator.canonicalUrl).toBe('https://github.com/org/monorepo.git');
+      expect(res.spec!.subpath).toBe('plugins/core-plugin');
+    });
+
+    it('normalizes git-subdir object with shorthand repo', () => {
+      const res = parseGitEntrySpec({
+        source: 'git-subdir',
+        repo: 'org/monorepo',
+        path: 'packages/plugin-a',
+      });
+      expect(res.ok).toBe(true);
+      expect(res.spec!.shape).toBe('git-subdir');
+      expect(res.spec!.locator.canonicalUrl).toBe('https://github.com/org/monorepo');
+      expect(res.spec!.subpath).toBe('packages/plugin-a');
+    });
+
+    it('supports codex git source kind { source: "git", url: "...", path: "..." }', () => {
+      const res = parseGitEntrySpec({
+        source: 'git',
+        url: 'https://github.com/codex/sample.git',
+        path: 'subplugin',
+      });
+      expect(res.ok).toBe(true);
+      expect(res.isGitFamily).toBe(true);
+      expect(res.spec!.locator.canonicalUrl).toBe('https://github.com/codex/sample.git');
+      expect(res.spec!.subpath).toBe('subplugin');
+    });
+  });
+
+  describe('Security Rejection: Credentials & Plaintext (Acceptance Criteria 2)', () => {
+    it('rejects embedded credentials in https locator with GIT_LOCATOR_CREDENTIAL', () => {
+      const res = parseGitEntrySpec({
+        source: 'github',
+        repo: 'https://token:secret@github.com/owner/repo',
+      });
+      expect(res.ok).toBe(false);
+      expect(res.isGitFamily).toBe(true);
+      expect(res.findings.some((f) => f.code === CODE.GIT_LOCATOR_CREDENTIAL)).toBe(true);
+    });
+
+    it('rejects embedded credentials in ssh locator with GIT_LOCATOR_CREDENTIAL', () => {
+      const res = parseGitEntrySpec({
+        source: 'url',
+        url: 'ssh://user:pass@github.com/owner/repo',
+      });
+      expect(res.ok).toBe(false);
+      expect(res.findings.some((f) => f.code === CODE.GIT_LOCATOR_CREDENTIAL)).toBe(true);
+    });
+
+    it('rejects plaintext http:// transport with GIT_LOCATOR_PLAINTEXT', () => {
+      const res = parseGitEntrySpec({
+        source: 'url',
+        url: 'http://github.com/owner/repo',
+      });
+      expect(res.ok).toBe(false);
+      expect(res.findings.some((f) => f.code === CODE.GIT_LOCATOR_PLAINTEXT)).toBe(true);
+    });
+
+    it('rejects file:// transport with GIT_LOCATOR_PLAINTEXT', () => {
+      const res = parseGitEntrySpec({
+        source: 'url',
+        url: 'file:///etc/passwd',
+      });
+      expect(res.ok).toBe(false);
+      expect(res.findings.some((f) => f.code === CODE.GIT_LOCATOR_PLAINTEXT)).toBe(true);
+    });
+
+    it('rejects ambiguous percent-encoding in locator with GIT_LOCATOR_AMBIGUOUS_ENCODING', () => {
+      const res = parseGitEntrySpec({
+        source: 'url',
+        url: 'https://github.com/owner%2frepo',
+      });
+      expect(res.ok).toBe(false);
+      expect(res.findings.some((f) => f.code === CODE.GIT_LOCATOR_AMBIGUOUS_ENCODING)).toBe(true);
+    });
+
+    it('rejects control characters in locator with GIT_LOCATOR_CONTROL_CHARS', () => {
+      const res = parseGitEntrySpec({
+        source: 'url',
+        url: 'https://github.com/owner\x00/repo',
+      });
+      expect(res.ok).toBe(false);
+      expect(res.findings.some((f) => f.code === CODE.GIT_LOCATOR_CONTROL_CHARS)).toBe(true);
+    });
+
+    it('rejects query parameters or fragment in locator with GIT_LOCATOR_QUERY_FRAGMENT', () => {
+      const res = parseGitEntrySpec({
+        source: 'url',
+        url: 'https://github.com/owner/repo?branch=main',
+      });
+      expect(res.ok).toBe(false);
+      expect(res.findings.some((f) => f.code === CODE.GIT_LOCATOR_QUERY_FRAGMENT)).toBe(true);
+    });
+  });
+
+  describe('Selector Mapping & Pin Matrix (Acceptance Criteria 1)', () => {
+    it('maps 40-hex sha to commit selector with effectivePin = "sha"', () => {
+      const sha = '1234567890abcdef1234567890abcdef12345678';
+      const res = parseGitEntrySpec({ source: 'github', repo: 'owner/repo', sha });
+      expect(res.ok).toBe(true);
+      expect(res.spec!.selector.kind).toBe('commit');
+      expect(res.spec!.selector.canonical).toBe(sha);
+      expect(res.spec!.effectivePin).toBe('sha');
+    });
+
+    it('maps 64-hex sha (SHA-256 object name) to commit selector', () => {
+      const sha = 'a'.repeat(64);
+      const res = parseGitEntrySpec({ source: 'github', repo: 'owner/repo', sha });
+      expect(res.ok).toBe(true);
+      expect(res.spec!.selector.kind).toBe('commit');
+      expect(res.spec!.selector.canonical).toBe(sha);
+      expect(res.spec!.effectivePin).toBe('sha');
+    });
+
+    it('normalizes uppercase sha to lowercase canonical', () => {
+      const sha = '1234567890ABCDEF1234567890ABCDEF12345678';
+      const res = parseGitEntrySpec({ source: 'github', repo: 'owner/repo', sha });
+      expect(res.ok).toBe(true);
+      expect(res.spec!.selector.canonical).toBe(sha.toLowerCase());
+    });
+
+    it('rejects abbreviated commit sha with GIT_SELECTOR_COMMIT_INVALID', () => {
+      const res = parseGitEntrySpec({ source: 'github', repo: 'owner/repo', sha: '1234567' });
+      expect(res.ok).toBe(false);
+      expect(res.findings.some((f) => f.code === CODE.GIT_SELECTOR_COMMIT_INVALID)).toBe(true);
+    });
+
+    it('rejects non-hex sha with GIT_SELECTOR_COMMIT_INVALID', () => {
+      const res = parseGitEntrySpec({ source: 'github', repo: 'owner/repo', sha: 'z'.repeat(40) });
+      expect(res.ok).toBe(false);
+      expect(res.findings.some((f) => f.code === CODE.GIT_SELECTOR_COMMIT_INVALID)).toBe(true);
+    });
+
+    it('maps explicit branch ref to branch selector with effectivePin = "ref"', () => {
+      const res = parseGitEntrySpec({ source: 'github', repo: 'owner/repo', ref: 'refs/heads/feature-x' });
+      expect(res.ok).toBe(true);
+      expect(res.spec!.selector.kind).toBe('branch');
+      expect(res.spec!.selector.canonical).toBe('refs/heads/feature-x');
+      expect(res.spec!.effectivePin).toBe('ref');
+    });
+
+    it('maps explicit tag ref to tag selector with effectivePin = "ref"', () => {
+      const res = parseGitEntrySpec({ source: 'github', repo: 'owner/repo', ref: 'refs/tags/v2.1.0' });
+      expect(res.ok).toBe(true);
+      expect(res.spec!.selector.kind).toBe('tag');
+      expect(res.spec!.selector.canonical).toBe('refs/tags/v2.1.0');
+      expect(res.spec!.effectivePin).toBe('ref');
+    });
+
+    it('maps plain branch name to branch selector', () => {
+      const res = parseGitEntrySpec({ source: 'github', repo: 'owner/repo', ref: 'main' });
+      expect(res.ok).toBe(true);
+      expect(res.spec!.selector.kind).toBe('branch');
+      expect(res.spec!.selector.canonical).toBe('refs/heads/main');
+      expect(res.spec!.effectivePin).toBe('ref');
+    });
+
+    it('maps v-prefixed tag name to tag selector', () => {
+      const res = parseGitEntrySpec({ source: 'github', repo: 'owner/repo', ref: 'v1.0.0' });
+      expect(res.ok).toBe(true);
+      expect(res.spec!.selector.kind).toBe('tag');
+      expect(res.spec!.selector.canonical).toBe('refs/tags/v1.0.0');
+      expect(res.spec!.effectivePin).toBe('ref');
+    });
+
+    it('maps neither sha nor ref to default movable selector with effectivePin = "default"', () => {
+      const res = parseGitEntrySpec({ source: 'github', repo: 'owner/repo' });
+      expect(res.ok).toBe(true);
+      expect(res.spec!.selector.kind).toBe('default');
+      expect(res.spec!.selector.canonical).toBe('default');
+      expect(res.spec!.effectivePin).toBe('default');
+    });
+
+    it('handles coexistence: sha is effective pin; ref is validated for syntax (Acceptance Criteria 1)', () => {
+      const sha = '1234567890abcdef1234567890abcdef12345678';
+      const res = parseGitEntrySpec({
+        source: 'github',
+        repo: 'owner/repo',
+        sha,
+        ref: 'main',
+      });
+      expect(res.ok).toBe(true);
+      expect(res.spec!.effectivePin).toBe('sha');
+      expect(res.spec!.selector.kind).toBe('commit');
+      expect(res.spec!.selector.canonical).toBe(sha);
+      expect(res.spec!.verifiedRef).toMatchObject({
+        kind: 'branch',
+        canonical: 'refs/heads/main',
+      });
+    });
+
+    it('rejects invalid ref syntax even when sha is valid', () => {
+      const sha = '1234567890abcdef1234567890abcdef12345678';
+      const res = parseGitEntrySpec({
+        source: 'github',
+        repo: 'owner/repo',
+        sha,
+        ref: '-option-injection',
+      });
+      expect(res.ok).toBe(false);
+      expect(res.findings.some((f) => f.code === CODE.GIT_SELECTOR_INVALID)).toBe(true);
+    });
+
+    it('rejects ref with revision chars (~^:) or reflog (@{)', () => {
+      for (const badRef of ['main~1', 'main^2', 'main@{yesterday}', 'HEAD', 'main:file']) {
+        const res = parseGitEntrySpec({ source: 'github', repo: 'owner/repo', ref: badRef });
+        expect(res.ok).toBe(false);
+        expect(res.findings.some((f) => f.code === CODE.GIT_SELECTOR_INVALID)).toBe(true);
+      }
+    });
+  });
+
+  describe('Non-git entry forms remain Unavailable', () => {
+    it('discloses npm source as Unavailable with stable reason', () => {
+      const res = parseGitEntrySpec({ source: 'npm', package: '@scope/pkg' });
+      expect(res.ok).toBe(false);
+      expect(res.isGitFamily).toBe(false);
+      expect(res.unavailableReason).toBe('npm source entries are not supported');
+    });
+
+    it('discloses archive source as Unavailable with stable reason', () => {
+      const res = parseGitEntrySpec({ source: 'archive', url: 'https://example.test/a.zip' });
+      expect(res.ok).toBe(false);
+      expect(res.isGitFamily).toBe(false);
+      expect(res.unavailableReason).toBe('archive source entries are not supported');
+    });
+
+    it('discloses command source as permanently disqualified', () => {
+      const res = parseGitEntrySpec({ source: 'command', command: 'make' });
+      expect(res.ok).toBe(false);
+      expect(res.isGitFamily).toBe(false);
+      expect(res.unavailableReason).toBe('command source entries are permanently disqualified');
+    });
+
+    it('identifies local ./path as non-git (handled by local flow)', () => {
+      const res = parseGitEntrySpec('./plugins/local');
+      expect(res.ok).toBe(false);
+      expect(res.isGitFamily).toBe(false);
+    });
+  });
+});
+
+describe('Entry Acquisition Engine — Mock Execution & Snapshot Generation', () => {
+  let fixtureDir: string;
+
+  beforeEach(() => {
+    fixtureDir = mkdtempSync(join(tmpdir(), 'entry-acq-fixture-'));
+    makeEntryFixture(fixtureDir, {
+      files: {
+        'SKILL.md': '---\nname: hello-skill\ndescription: Hello\n---\nBody content',
+        '.claude-plugin/plugin.json': JSON.stringify({ name: 'test-plugin' }),
+      },
+    });
+  });
+
+  afterEach(() => {
+    try {
+      if (existsSync(fixtureDir)) rmSync(fixtureDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  it('acquires a sha-pinned github entry and binds full commit SHA (Acceptance Criteria 1)', async () => {
+    const sha = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4';
+    const parsed = parseGitEntrySpec({ source: 'github', repo: 'owner/repo', sha });
+    expect(parsed.ok).toBe(true);
+
+    const executor = makeMockGitExecutor(fixtureDir, { lsRemoteSha: sha });
+    const res = await acquireGitEntry({
+      spec: parsed.spec!,
+      entryId: '/plugins/0',
+      executor,
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.resolvedRevision).toBe(sha);
+    expect(res.snapshot).toBeDefined();
+    expect(res.snapshot!.resolvedRevision).toBe(sha);
+    expect(res.snapshot!.fingerprint).toHaveLength(64);
+    expect(res.snapshot!.entries.some((e) => e.relPath === 'SKILL.md')).toBe(true);
+
+    if (res.createdTemp && res.acquiredPath) {
+      rmSync(res.acquiredPath, { recursive: true, force: true });
+    }
+  });
+
+  it('acquires a movable ref entry and binds the resolved commit at acquisition time (Acceptance Criteria 1)', async () => {
+    const resolvedSha = 'beefdeadbeefdeadbeefdeadbeefdeadbeefdead';
+    const parsed = parseGitEntrySpec({ source: 'github', repo: 'owner/repo', ref: 'main' });
+    expect(parsed.ok).toBe(true);
+
+    const executor = makeMockGitExecutor(fixtureDir, { lsRemoteSha: resolvedSha });
+    const res = await acquireGitEntry({
+      spec: parsed.spec!,
+      entryId: '/plugins/1',
+      executor,
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.resolvedRevision).toBe(resolvedSha);
+    expect(res.snapshot!.resolvedRevision).toBe(resolvedSha);
+
+    if (res.createdTemp && res.acquiredPath) {
+      rmSync(res.acquiredPath, { recursive: true, force: true });
+    }
+  });
+
+  it('acquires a movable default entry and binds the HEAD commit (Acceptance Criteria 1)', async () => {
+    const defaultSha = 'cafe1234cafe1234cafe1234cafe1234cafe1234';
+    const parsed = parseGitEntrySpec('owner/repo');
+    expect(parsed.ok).toBe(true);
+
+    const executor = makeMockGitExecutor(fixtureDir, { lsRemoteSha: defaultSha });
+    const res = await acquireGitEntry({
+      spec: parsed.spec!,
+      entryId: '/plugins/0',
+      executor,
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.resolvedRevision).toBe(defaultSha);
+
+    if (res.createdTemp && res.acquiredPath) {
+      rmSync(res.acquiredPath, { recursive: true, force: true });
+    }
+  });
+
+  it('acquires a git-subdir entry and sets entryRootPath to the contained subdirectory', async () => {
+    // Add a subdirectory fixture inside fixtureDir
+    const subdir = 'packages/sub-plugin';
+    mkdirSync(join(fixtureDir, subdir), { recursive: true });
+    writeFileSync(join(fixtureDir, subdir, 'SKILL.md'), '---\nname: sub-skill\n---\nSub content');
+    writeFileSync(join(fixtureDir, subdir, 'plugin.json'), '{"name":"sub-plugin"}');
+
+    const sha = '1111222233334444555566667777888899990000';
+    const parsed = parseGitEntrySpec({
+      source: 'git-subdir',
+      url: 'https://github.com/owner/monorepo.git',
+      path: subdir,
+      sha,
+    });
+    expect(parsed.ok).toBe(true);
+
+    const executor = makeMockGitExecutor(fixtureDir, { lsRemoteSha: sha });
+    const res = await acquireGitEntry({
+      spec: parsed.spec!,
+      entryId: '/plugins/2',
+      executor,
+    });
+
+    expect(res.findings).toEqual([]);
+    expect(res.ok).toBe(true);
+    expect(res.entryRootPath).toContain(subdir);
+    expect(res.snapshot!.entries.some((e) => e.relPath === 'SKILL.md')).toBe(true);
+
+    if (res.createdTemp && res.acquiredPath) {
+      rmSync(res.acquiredPath, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects git-subdir with escaping subpath (../) with PATH_CONTAINMENT_VIOLATION', async () => {
+    const sha = '1111222233334444555566667777888899990000';
+    const parsed = parseGitEntrySpec({
+      source: 'git-subdir',
+      url: 'https://github.com/owner/repo.git',
+      path: '../outside',
+      sha,
+    });
+    expect(parsed.ok).toBe(true);
+
+    const executor = makeMockGitExecutor(fixtureDir, { lsRemoteSha: sha });
+    const res = await acquireGitEntry({
+      spec: parsed.spec!,
+      entryId: '/plugins/0',
+      executor,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.findings.some((f) => f.code === CODE.PATH_CONTAINMENT_VIOLATION)).toBe(true);
+  });
+
+  it('rejects git-subdir with non-existent subpath with SOURCE_NOT_EXISTS', async () => {
+    const sha = '1111222233334444555566667777888899990000';
+    const parsed = parseGitEntrySpec({
+      source: 'git-subdir',
+      url: 'https://github.com/owner/repo.git',
+      path: 'non/existent/path',
+      sha,
+    });
+    expect(parsed.ok).toBe(true);
+
+    const executor = makeMockGitExecutor(fixtureDir, { lsRemoteSha: sha });
+    const res = await acquireGitEntry({
+      spec: parsed.spec!,
+      entryId: '/plugins/0',
+      executor,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.findings.some((f) => f.code === CODE.SOURCE_NOT_EXISTS)).toBe(true);
+  });
+});
+
+describe('Entry Acquisition Engine — Trust Base & Fail-Closed Errors (Acceptance Criteria 4)', () => {
+  let fixtureDir: string;
+
+  beforeEach(() => {
+    fixtureDir = mkdtempSync(join(tmpdir(), 'entry-trust-fixture-'));
+    makeEntryFixture(fixtureDir);
+  });
+
+  afterEach(() => {
+    try {
+      if (existsSync(fixtureDir)) rmSync(fixtureDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  it('blocks unknown SSH host key with GIT_TRUST_HOST_KEY_UNKNOWN', async () => {
+    const parsed = parseGitEntrySpec({
+      source: 'url',
+      url: 'ssh://git@github.com/owner/repo.git',
+    });
+    expect(parsed.ok).toBe(true);
+
+    const executor = makeMockGitExecutor(fixtureDir, { hostKeyError: 'unknown' });
+    const res = await acquireGitEntry({
+      spec: parsed.spec!,
+      entryId: '/plugins/0',
+      executor,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.findings.some((f) => f.code === CODE.GIT_TRUST_HOST_KEY_UNKNOWN)).toBe(true);
+  });
+
+  it('blocks changed SSH host key with GIT_TRUST_HOST_KEY_CHANGED', async () => {
+    const parsed = parseGitEntrySpec({
+      source: 'url',
+      url: 'ssh://git@github.com/owner/repo.git',
+    });
+    expect(parsed.ok).toBe(true);
+
+    const executor = makeMockGitExecutor(fixtureDir, { hostKeyError: 'changed' });
+    const res = await acquireGitEntry({
+      spec: parsed.spec!,
+      entryId: '/plugins/0',
+      executor,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.findings.some((f) => f.code === CODE.GIT_TRUST_HOST_KEY_CHANGED)).toBe(true);
+  });
+
+  it('blocks redirect changing locator with GIT_TRUST_REDIRECT', async () => {
+    const parsed = parseGitEntrySpec({
+      source: 'url',
+      url: 'https://github.com/owner/repo.git',
+    });
+    expect(parsed.ok).toBe(true);
+
+    const executor = makeMockGitExecutor(fixtureDir, { redirectError: true });
+    const res = await acquireGitEntry({
+      spec: parsed.spec!,
+      entryId: '/plugins/0',
+      executor,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.findings.some((f) => f.code === CODE.GIT_TRUST_REDIRECT)).toBe(true);
+  });
+
+  it('blocks git clone failure with GIT_ACQUISITION_FAILED', async () => {
+    const parsed = parseGitEntrySpec('owner/repo');
+    expect(parsed.ok).toBe(true);
+
+    const executor = makeMockGitExecutor(fixtureDir, { cloneError: 'fatal: repository not found' });
+    const res = await acquireGitEntry({
+      spec: parsed.spec!,
+      entryId: '/plugins/0',
+      executor,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.findings.some((f) => f.code === CODE.GIT_ACQUISITION_FAILED)).toBe(true);
+  });
+});
+
+describe('Entry Acquisition Engine — Batch Acquisition & Drift Detection (Acceptance Criteria 3 & 4)', () => {
+  let fixtureDir: string;
+
+  beforeEach(() => {
+    fixtureDir = mkdtempSync(join(tmpdir(), 'entry-batch-fixture-'));
+    makeEntryFixture(fixtureDir);
+  });
+
+  afterEach(() => {
+    try {
+      if (existsSync(fixtureDir)) rmSync(fixtureDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  it('acquires multiple git entries in a batch and populates entrySnapshots map (Acceptance Criteria 3)', async () => {
+    const entries = [
+      { entryId: '/plugins/0', source: 'org/plugin-one' },
+      { entryId: '/plugins/1', source: { source: 'url', url: 'https://github.com/org/plugin-two.git', ref: 'main' } },
+      { entryId: '/plugins/2', source: { source: 'github', repo: 'org/plugin-three', sha: 'a'.repeat(40) } },
+    ];
+
+    const executor = makeMockGitExecutor(fixtureDir);
+    const batch = await acquireGitEntries(entries, { executor });
+
+    expect(batch.ok).toBe(true);
+    expect(batch.entries.size).toBe(3);
+    expect(batch.entrySnapshots['/plugins/0']).toBeDefined();
+    expect(batch.entrySnapshots['/plugins/1']).toBeDefined();
+    expect(batch.entrySnapshots['/plugins/2']).toBeDefined();
+    expect(batch.findings).toEqual([]);
+
+    batch.cleanup();
+  });
+
+  it('fails closed when one entry in a batch fails, cleaning up all acquisitions (Acceptance Criteria 4)', async () => {
+    const entries = [
+      { entryId: '/plugins/0', source: 'org/plugin-one' },
+      // Bad entry: embedded credentials
+      { entryId: '/plugins/1', source: { source: 'url', url: 'https://user:pass@github.com/bad.git' } },
+      { entryId: '/plugins/2', source: 'org/plugin-three' },
+    ];
+
+    const executor = makeMockGitExecutor(fixtureDir);
+    const batch = await acquireGitEntries(entries, { executor });
+
+    expect(batch.ok).toBe(false);
+    expect(batch.entries.size).toBe(0);
+    expect(batch.entrySnapshots).toEqual({});
+    expect(batch.findings.some((f) => f.code === CODE.GIT_LOCATOR_CREDENTIAL)).toBe(true);
+  });
+
+  it('detects per-entry drift when recorded snapshot fingerprint differs from current (Acceptance Criteria 3)', async () => {
+    const parsed = parseGitEntrySpec('owner/repo');
+    const executor = makeMockGitExecutor(fixtureDir);
+    const res = await acquireGitEntry({
+      spec: parsed.spec!,
+      entryId: '/plugins/0',
+      executor,
+    });
+
+    expect(res.ok).toBe(true);
+    const originalFingerprint = res.snapshot!.fingerprint;
+
+    // No drift when same
+    expect(checkEntryDrift(originalFingerprint, originalFingerprint)).toBe(false);
+
+    // Drift detected when recorded differs from current
+    const recordedFingerprint = '0'.repeat(64);
+    expect(checkEntryDrift(originalFingerprint, recordedFingerprint)).toBe(true);
+
+    if (res.createdTemp && res.acquiredPath) {
+      rmSync(res.acquiredPath, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Closes #50
Parent: #43

## 摘要

建立格式中立的 Entry 級非執行式取得引擎（Entry Acquisition Engine）：支援指向其他 git repo 的 entry（`github`、`url`、`git-subdir` 三種形態）；實作完整的 Selector 映射與 Pin 矩陣（`sha`→commit、`ref`→branch/tag、皆無→可動 default，並存時 sha 有效、ref 僅驗證不綁定）；`owner/repo` shorthand 一律展開為 HTTPS Canonical Git Locator；嵌入憑證與明文傳輸嚴格拒絕；為每個取得的 entry 建立獨立 Validation Snapshot 綁入註冊驗證狀態；嚴格受限於 Acquisition Trust Base 與 Validation Budget。`npm`/`archive`/`command` 維持 Unavailable 揭露。

## 實作

- **`src/registration/entry-acquisition.ts`（新）**：
  - `parseGitEntrySpec`：格式中立解析 `github` / `url` / `git-subdir` / `git`（Codex 相容）形態，辨識 `npm` / `archive` / `command` 與非 git 來源。
  - `normalizeEntryLocator`：`owner/repo` shorthand 展開為 `https://github.com/<owner>/<repo>`；拒絕明文 `http://` / `file://` 與嵌入憑證（`GIT_LOCATOR_PLAINTEXT`, `GIT_LOCATOR_CREDENTIAL`）。
  - `resolveEntrySelector`：`sha` 映射至 commit selector（40/64 hex）、`ref` 映射至 branch/tag selector、皆無映射至 default selector；並存時以 `sha` 為有效 pin，`ref` 僅驗證語法。
  - `acquireGitEntry`：透過既有 `acquireGitSource` 執行非執行式取得（硬化環境、禁用 hooks/filters/submodules/credentials helper、StrictHostKeyChecking=yes），支援 `git-subdir` 嚴格 containment 驗證（`resolveContained`），並產生 per-entry `ValidationSnapshot`。
  - `acquireGitEntries`：批次取得外部 git entries，任一 entry 失敗則全體 fail-closed，清理所有暫存目錄並回傳 Blocking Findings。
  - `checkEntryDrift`：比對目前 snapshot fingerprint 與記錄值以偵測漂移。
- **`src/registration/source-key.ts`** & **`src/bridge-state/types.ts`**：
  - `SourceKey` 新增 `subpath?: string` 欄位以支援 `git-subdir`。
  - `Registration` 介面擴充 `entrySnapshots?: Record<string, string>` 屬性，保存各 entry 的 snapshot fingerprint。
- **`src/registration/index.ts`**：
  - 導出 `entry-acquisition.ts` 所有型別與核心函式。
- **`tests/unit/registration/entry-acquisition.test.ts`（新，43 tests）**：
  - 覆蓋 shorthand 展開、憑證/明文拒絕、Pin 矩陣、Coexistence、Mock Executor 取得、git-subdir containment、Trust Base（SSH host key、redirect）與漂移比對。
- **`tests/integration/entry-acquisition.test.ts`（新，5 tests）**：
  - 覆蓋混合形態 marketplace 批次取得、Validation Budget 限制（位元組/深度）、SourceCache 快取結合與獨立漂移比對。

## 驗收對照

| #50 驗收條件 | 落點 |
|---|---|
| sha-pinned entry 取得綁定完整 commit；可動 ref entry 綁定解析當下的 commit | `entry-acquisition.ts` + `entry-acquisition.test.ts` |
| shorthand 正規化為 https locator；嵌入憑證/明文傳輸被拒 | `normalizeEntryLocator` + `entry-acquisition.test.ts` |
| per-entry 快照指紋進入註冊驗證狀態，可供漂移比對 | `acquireGitEntry` + `entrySnapshots` + `checkEntryDrift` + 測試 |
| 預算超限、host key 異常等失敗產生 Blocking Finding，而非部分成功 | `acquireGitEntries` + `entry-acquisition.test.ts` + `tests/integration/entry-acquisition.test.ts` |
| mock executor 單元/整合測試覆蓋三種形態與 pin 矩陣 | `tests/unit/registration/entry-acquisition.test.ts` + `tests/integration/entry-acquisition.test.ts` |

## 驗證

- `npm run typecheck` ✅
- `npm test`：56 files / **778 tests passed** ✅