### PR TITLE
feat(registration): wire external git entry acquisition to dual formats and refresh

### DIFF
--- a/src/cache/source-cache.ts
+++ b/src/cache/source-cache.ts
@@ -59,6 +59,7 @@ export interface CacheIndexRecord {
 
 export interface PendingUpdateRecord {
   registrationId: string;
+  entryId?: string;
   fingerprint: string;
   recordedAtMs: number;
 }
@@ -254,7 +255,7 @@ export class SourceCache {
   // ---- Pending Update Candidate registry ---------------------------------
 
   recordPendingUpdate(rec: Omit<PendingUpdateRecord, 'recordedAtMs'>): void {
-    const records = this.pendingUpdates().filter((r) => !(r.registrationId === rec.registrationId));
+    const records = this.pendingUpdates().filter((r) => !(r.registrationId === rec.registrationId && r.entryId === rec.entryId));
     records.push({ ...rec, recordedAtMs: this.now() });
     atomicWriteFile(getCachePendingPath(this.root), JSON.stringify(records));
   }

--- a/src/installation/inspection.ts
+++ b/src/installation/inspection.ts
@@ -55,6 +55,10 @@ export interface InspectionOptions {
   format?: MarketplaceFormat;
   agentDir?: string;
   cache?: SourceCache;
+  /** Candidate entry roots from Refresh / Preflight */
+  entryRoots?: Map<string, string>;
+  /** Candidate entry snapshots from Refresh / Preflight */
+  entrySnapshots?: Record<string, string>;
 }
 
 function inspectionFinding(code: string, rule: string, target: ValidationFinding['target'], outcome: string): ValidationFinding {
@@ -167,18 +171,54 @@ export function inspectMarketplaceEntries(registration: Registration, opts: Insp
   const material = createHash('sha256');
   material.update('catalog\u001f').update(catalogRaw).update('\u001e');
   const classifications = new Map<string, ReturnType<typeof classifyPlugin>>();
+  const cache = opts.cache ?? new SourceCache({ agentDir: opts.agentDir });
+
   const draft = parsed.catalog.entries.map((entry) => {
-    if (!entry.available || entry.type !== 'local' || !entry.path) return { entry, findings: [], unavailableReason: entry.unavailableReason ?? 'unsupported source kind' };
-    const contained = resolveContained(root, entry.path, 'directory');
-    if (contained.outcome.kind !== 'ok') return { entry, findings: [], unavailableReason: 'cannot resolve Plugin' };
-    let baseClassification = classifications.get(contained.outcome.canonicalPath);
+    if (!entry.available) {
+      return { entry, findings: [], unavailableReason: entry.unavailableReason ?? 'unsupported source kind' };
+    }
+
+    let entryRoot: string | undefined;
+
+    if (entry.type === 'local') {
+      if (!entry.path) return { entry, findings: [], unavailableReason: 'cannot resolve Plugin: no path declared' };
+      const contained = resolveContained(root, entry.path, 'directory');
+      if (contained.outcome.kind !== 'ok') return { entry, findings: [], unavailableReason: 'cannot resolve Plugin' };
+      entryRoot = contained.outcome.canonicalPath;
+    } else if (entry.type === 'git') {
+      if (opts.entryRoots?.has(entry.entryId)) {
+        entryRoot = opts.entryRoots.get(entry.entryId);
+      } else {
+        const fp = opts.entrySnapshots?.[entry.entryId] ?? registration.entrySnapshots?.[entry.entryId];
+        if (!fp) {
+          return { entry, findings: [], unavailableReason: 'cannot resolve external git entry: no recorded snapshot' };
+        }
+        const hit = cache.hitExactSync(fp);
+        if (!hit) {
+          return {
+            entry,
+            findings: [],
+            unavailableReason: `Git Source Cache miss: entry snapshot '${fp.slice(0, 16)}…' is not retained in Source Cache; Marketplace Refresh or re-acquisition is required`,
+          };
+        }
+        entryRoot = hit.path;
+      }
+    } else {
+      return { entry, findings: [], unavailableReason: entry.unavailableReason ?? 'unsupported source kind' };
+    }
+
+    if (!entryRoot) {
+      return { entry, findings: [], unavailableReason: 'cannot resolve Plugin' };
+    }
+
+    let baseClassification = classifications.get(entryRoot);
     if (!baseClassification) {
-      baseClassification = classifyPlugin(contained.outcome.canonicalPath, {
+      baseClassification = classifyPlugin(entryRoot, {
         marketplaceId,
         marketplaceEntryId: `${marketplaceId}${entry.entryId}`,
         format,
       });
-      classifications.set(contained.outcome.canonicalPath, baseClassification);
+      classifications.set(entryRoot, baseClassification);
     }
     const classification = baseClassification.plugin
       ? { ...baseClassification, plugin: { ...baseClassification.plugin, marketplaceEntryId: `${marketplaceId}${entry.entryId}` } }

--- a/src/lifecycle/refresh.ts
+++ b/src/lifecycle/refresh.ts
@@ -319,8 +319,8 @@ async function refreshLocalRegistration(
         sourceKey: registration.sourceKey,
         entrySnapshots: candidateEntrySnapshots,
       };
-      for (const fp of Object.values(candidateEntrySnapshots)) {
-        cache.recordPendingUpdate({ registrationId: registration.id, fingerprint: fp });
+      for (const [entryId, fp] of Object.entries(candidateEntrySnapshots)) {
+        cache.recordPendingUpdate({ registrationId: registration.id, entryId, fingerprint: fp });
       }
       return {
         status: 'update-candidate',
@@ -518,8 +518,8 @@ async function refreshGitRegistration(
           selectorCanonical: selector.canonical,
         });
         cache.recordPendingUpdate({ registrationId: registration.id, fingerprint: snap.snapshot.fingerprint });
-        for (const fp of Object.values(candidateEntrySnapshots)) {
-          cache.recordPendingUpdate({ registrationId: registration.id, fingerprint: fp });
+        for (const [entryId, fp] of Object.entries(candidateEntrySnapshots)) {
+          cache.recordPendingUpdate({ registrationId: registration.id, entryId, fingerprint: fp });
         }
         return {
           status: 'update-candidate',

--- a/src/lifecycle/refresh.ts
+++ b/src/lifecycle/refresh.ts
@@ -9,12 +9,15 @@
  * Lifecycle Operation bound to a complete Update Plan.
  */
 
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
 import { readBridgeState } from '../bridge-state/store.js';
 import type { BridgeState } from '../bridge-state/types.js';
 import type { MarketplaceFormat, Registration } from '../bridge-state/types.js';
 import type { MarketplaceInspection } from '../installation/inspection.js';
 import { inspectMarketplaceEntries } from '../installation/inspection.js';
-import type { Catalog } from '../registration/catalog.js';
+import type { Catalog, MarketplaceEntry } from '../registration/catalog.js';
 import {
   CODE,
   RULE,
@@ -29,7 +32,7 @@ import {
   type GitExecutor,
 } from '../registration/git-acquisition.js';
 import { SourceCache } from '../cache/source-cache.js';
-import { detectMarketplaceFormat } from '../registration/format.js';
+import { catalogContractFor, detectMarketplaceFormat } from '../registration/format.js';
 import { normalizeGitLocator } from '../registration/git-locator.js';
 import {
   normalizeGitSelector,
@@ -41,7 +44,12 @@ import {
   buildLocalSnapshot,
   type ValidationSnapshot,
 } from '../registration/snapshot.js';
-import type { SourceKey } from '../registration/source-key.js';
+import { gitSourceKey, type SourceKey } from '../registration/source-key.js';
+import {
+  acquireGitEntry,
+  checkEntryDrift,
+  parseGitEntrySpec,
+} from '../registration/entry-acquisition.js';
 
 export interface LifecycleFlowOptions {
   agentDir?: string;
@@ -76,6 +84,8 @@ export interface UpdateCandidate {
   canonicalLocator?: string;
   resolvedRevision?: string;
   selectorCanonical?: string;
+  /** Per-entry candidate Validation Snapshot fingerprints */
+  entrySnapshots?: Record<string, string>;
 }
 
 export type RefreshOutcome =
@@ -87,6 +97,88 @@ const OPERATION = 'Marketplace Refresh';
 
 function finding(code: string, rule: string, target: ValidationFinding['target'], pointer: string, outcome: string): ValidationFinding {
   return blocking({ code, rule, target, pointer, outcome, phase: 'validation' });
+}
+
+async function refreshGitEntries(
+  entries: MarketplaceEntry[],
+  currentEntrySnapshots: Record<string, string>,
+  opts: LifecycleFlowOptions,
+  cache: SourceCache,
+): Promise<{
+  anyMoved: boolean;
+  candidateEntrySnapshots: Record<string, string>;
+  candidateEntryRoots: Map<string, string>;
+  cleanups: Array<() => void>;
+}> {
+  const candidateEntrySnapshots: Record<string, string> = {};
+  const candidateEntryRoots = new Map<string, string>();
+  const cleanups: Array<() => void> = [];
+  let anyMoved = false;
+
+  for (const entry of entries) {
+    if (entry.type !== 'git' || !entry.available) continue;
+    const parsedSpec = parseGitEntrySpec(entry.source, entry.entryId);
+    if (!parsedSpec.ok || !parsedSpec.spec) continue;
+    const spec = parsedSpec.spec;
+    const recordedFp = currentEntrySnapshots[entry.entryId];
+
+    if (spec.effectivePin === 'sha') {
+      // sha-pinned: ref movement upstream DOES NOT produce an update candidate
+      if (recordedFp) {
+        candidateEntrySnapshots[entry.entryId] = recordedFp;
+      } else {
+        const acq = await acquireGitEntry({ spec, entryId: entry.entryId, executor: opts.executor, cache });
+        if (acq.ok && acq.snapshot) {
+          candidateEntrySnapshots[entry.entryId] = acq.snapshot.fingerprint;
+          if (acq.entryRootPath) candidateEntryRoots.set(entry.entryId, acq.entryRootPath);
+          if (acq.acquiredPath && acq.createdTemp) {
+            cleanups.push(() => cleanupAcquisition(acq.acquiredPath!));
+          }
+          if (checkEntryDrift(acq.snapshot.fingerprint, recordedFp ?? '')) {
+            anyMoved = true;
+          }
+        }
+      }
+    } else {
+      // Movable ref or default selector: resolve upstream revision
+      const res = await resolveGitRevision(spec.locator, spec.selector, { executor: opts.executor });
+      if (res.ok) {
+        const resolvedSha = res.sha;
+        let needAcquire = true;
+        if (recordedFp) {
+          const hit = await cache.hitExact(recordedFp);
+          if (hit) {
+            const verified = buildGitSnapshot(hit.path, gitSourceKey(spec.locator, spec.selector), {
+              canonicalLocator: spec.locator.canonicalUrl,
+              resolvedRevision: resolvedSha,
+              selectorCanonical: spec.selector.canonical,
+            });
+            if (verified.ok && verified.snapshot!.fingerprint === recordedFp) {
+              candidateEntrySnapshots[entry.entryId] = recordedFp;
+              candidateEntryRoots.set(entry.entryId, hit.path);
+              needAcquire = false;
+            }
+          }
+        }
+
+        if (needAcquire) {
+          const acq = await acquireGitEntry({ spec, entryId: entry.entryId, executor: opts.executor, cache });
+          if (acq.ok && acq.snapshot) {
+            candidateEntrySnapshots[entry.entryId] = acq.snapshot.fingerprint;
+            if (acq.entryRootPath) candidateEntryRoots.set(entry.entryId, acq.entryRootPath);
+            if (acq.acquiredPath && acq.createdTemp) {
+              cleanups.push(() => cleanupAcquisition(acq.acquiredPath!));
+            }
+            if (!recordedFp || checkEntryDrift(acq.snapshot.fingerprint, recordedFp)) {
+              anyMoved = true;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return { anyMoved, candidateEntrySnapshots, candidateEntryRoots, cleanups };
 }
 
 function blocked(registrationId: string, revision: string, findings: ValidationFinding[], snapshot?: string): RefreshOutcome {
@@ -162,11 +254,11 @@ export async function refreshRegistration(
   return refreshLocalRegistration(registration, revision, opts);
 }
 
-function refreshLocalRegistration(
+async function refreshLocalRegistration(
   registration: Registration,
   revision: string,
   opts: LifecycleFlowOptions,
-): RefreshOutcome {
+): Promise<RefreshOutcome> {
   if (!registration.sourceKey || !registration.source) {
     return blocked(registration.id, revision, [
       finding(CODE.SOURCE_REACQUISITION_REQUIRED, RULE.SOURCE_REACQUISITION_REQUIRED, 'registration', '', 'Registration has no retained local Source Key to revalidate'),
@@ -178,50 +270,87 @@ function refreshLocalRegistration(
     return blocked(registration.id, revision, snap.findings, registration.validationSnapshot);
   }
 
-  if (!registration.validationSnapshot || snap.snapshot.fingerprint !== registration.validationSnapshot) {
-    // The candidate's own format is detected fresh from the live tree — a flipped root can only
-    // reach the Registration through this Update Candidate plus an explicit Apply Update.
-    const liveFormat = detectMarketplaceFormat(registration.source);
-    const inspection = inspectMarketplaceEntries(registration, { ignoreRecordedDrift: true, format: liveFormat ?? undefined });
-    const name = marketplaceNameOf(registration.id, inspection.marketplaceId) || registration.marketplaceName || '';
-    const candidate: UpdateCandidate = {
-      registrationId: registration.id,
-      stateRevision: revision,
-      recordedFingerprint: registration.validationSnapshot,
-      recordedResolvedRevision: registration.resolvedRevision,
-      snapshot: snap.snapshot,
-      marketplaceName: name,
-      format: liveFormat ?? undefined,
-      catalog: { name, entries: inspection.entries.map((item) => item.entry) },
-      inspection,
-      sourceKey: registration.sourceKey,
-    };
+  const liveFormat = detectMarketplaceFormat(registration.source);
+  const contract = catalogContractFor(liveFormat ?? registration.format ?? 'codex');
+  const catalogPath = join(registration.source, ...contract.relPath.split('/'));
+  let catalogRaw: string | undefined;
+  let parsedCatalog: unknown;
+  try {
+    catalogRaw = readFileSync(catalogPath, 'utf8');
+    parsedCatalog = JSON.parse(catalogRaw);
+  } catch {
+    // Handled by inspectMarketplaceEntries
+  }
+  const parsed = parsedCatalog ? contract.parse(parsedCatalog) : undefined;
+  const entries = parsed?.catalog?.entries ?? [];
+
+  const cache = opts.cache ?? new SourceCache({ agentDir: opts.agentDir });
+  const { anyMoved, candidateEntrySnapshots, candidateEntryRoots, cleanups } = await refreshGitEntries(
+    entries,
+    registration.entrySnapshots ?? {},
+    opts,
+    cache,
+  );
+
+  const rootMoved = !registration.validationSnapshot || snap.snapshot.fingerprint !== registration.validationSnapshot;
+
+  try {
+    if (rootMoved || anyMoved) {
+      // The candidate's own format is detected fresh from the live tree — a flipped root can only
+      // reach the Registration through this Update Candidate plus an explicit Apply Update.
+      const inspection = inspectMarketplaceEntries(registration, {
+        ignoreRecordedDrift: true,
+        format: liveFormat ?? undefined,
+        cache,
+        entryRoots: candidateEntryRoots,
+        entrySnapshots: candidateEntrySnapshots,
+      });
+      const name = marketplaceNameOf(registration.id, inspection.marketplaceId) || registration.marketplaceName || '';
+      const candidate: UpdateCandidate = {
+        registrationId: registration.id,
+        stateRevision: revision,
+        recordedFingerprint: registration.validationSnapshot,
+        recordedResolvedRevision: registration.resolvedRevision,
+        snapshot: snap.snapshot,
+        marketplaceName: name,
+        format: liveFormat ?? undefined,
+        catalog: { name, entries: inspection.entries.map((item) => item.entry) },
+        inspection,
+        sourceKey: registration.sourceKey,
+        entrySnapshots: candidateEntrySnapshots,
+      };
+      for (const fp of Object.values(candidateEntrySnapshots)) {
+        cache.recordPendingUpdate({ registrationId: registration.id, fingerprint: fp });
+      }
+      return {
+        status: 'update-candidate',
+        candidate,
+        receipt: createReceipt({
+          operation: OPERATION,
+          trigger: `refresh ${registration.id}`,
+          expectedStateRevision: revision,
+          validationSnapshot: snap.snapshot.fingerprint,
+          summary: 'Completed',
+          findings: inspection.findings,
+          stateChanged: false,
+        }),
+      };
+    }
+
     return {
-      status: 'update-candidate',
-      candidate,
+      status: 'no-change',
       receipt: createReceipt({
         operation: OPERATION,
         trigger: `refresh ${registration.id}`,
         expectedStateRevision: revision,
-        validationSnapshot: snap.snapshot.fingerprint,
+        validationSnapshot: registration.validationSnapshot,
         summary: 'Completed',
-        findings: inspection.findings,
         stateChanged: false,
       }),
     };
+  } finally {
+    for (const cleanup of cleanups) cleanup();
   }
-
-  return {
-    status: 'no-change',
-    receipt: createReceipt({
-      operation: OPERATION,
-      trigger: `refresh ${registration.id}`,
-      expectedStateRevision: revision,
-      validationSnapshot: registration.validationSnapshot,
-      summary: 'Completed',
-      stateChanged: false,
-    }),
-  };
 }
 
 /** Reconstruct the full Source Key for a Registration at an exact Resolved Revision. */
@@ -287,6 +416,10 @@ async function refreshGitRegistration(
 
   const resolvedRevision = resolution.sha;
 
+  let root: string | undefined;
+  let acqToCleanup: string | undefined;
+  let snap: ReturnType<typeof buildGitSnapshot> | undefined;
+
   if (resolvedRevision === registration.resolvedRevision && registration.validationSnapshot) {
     // Same Resolved Revision: exact-fingerprint cache hit avoids a full acquisition.
     const hit = await cache.hitExact(registration.validationSnapshot);
@@ -297,25 +430,112 @@ async function refreshGitRegistration(
         selectorCanonical: selector.canonical,
       });
       if (verified.ok && verified.snapshot!.fingerprint === registration.validationSnapshot) {
-        return { status: 'no-change', receipt: noChangeReceipt() };
+        root = hit.path;
+        snap = verified;
       }
-      // Tampered/evicted-in-place entry: fall through to full acquisition below.
     }
   }
 
-  // Full non-executing acquisition (clone).
-  const acq = await acquireGitSource({
-    locator,
-    selector,
-    executor: opts.executor,
-  });
-  if (!acq.ok) return blocked(registration.id, revision, acq.findings, registration.validationSnapshot);
+  if (!root) {
+    // Full non-executing acquisition (clone).
+    const acq = await acquireGitSource({
+      locator,
+      selector,
+      executor: opts.executor,
+    });
+    if (!acq.ok) return blocked(registration.id, revision, acq.findings, registration.validationSnapshot);
+    root = acq.acquiredPath!;
+    acqToCleanup = root;
+    const newSourceKey: SourceKey = { ...registration.sourceKey, resolvedRevision };
+    snap = buildGitSnapshot(root, newSourceKey, {
+      canonicalLocator: locator.canonicalUrl,
+      resolvedRevision,
+      selectorCanonical: selector.canonical,
+    });
+  }
 
   try {
-    const resolvedRevision = acq.resolvedRevision!;
-    const root = acq.acquiredPath!;
-    if (resolvedRevision === registration.resolvedRevision) {
-      // Cache the re-validated tree under its recorded fingerprint for future exact hits.
+    if (!snap || !snap.ok || !snap.snapshot) {
+      return blocked(registration.id, revision, snap?.findings ?? [], registration.validationSnapshot);
+    }
+
+    const liveFormat = detectMarketplaceFormat(root);
+    const contract = catalogContractFor(liveFormat ?? registration.format ?? 'codex');
+    const catalogPath = join(root, ...contract.relPath.split('/'));
+    let catalogRaw: string | undefined;
+    let parsedCatalog: unknown;
+    try {
+      catalogRaw = readFileSync(catalogPath, 'utf8');
+      parsedCatalog = JSON.parse(catalogRaw);
+    } catch {
+      // Handled by inspectMarketplaceEntries
+    }
+    const parsed = parsedCatalog ? contract.parse(parsedCatalog) : undefined;
+    const entries = parsed?.catalog?.entries ?? [];
+
+    const { anyMoved, candidateEntrySnapshots, candidateEntryRoots, cleanups } = await refreshGitEntries(
+      entries,
+      registration.entrySnapshots ?? {},
+      opts,
+      cache,
+    );
+
+    try {
+      const rootChanged = resolvedRevision !== registration.resolvedRevision || snap.snapshot.fingerprint !== registration.validationSnapshot;
+
+      if (rootChanged || anyMoved) {
+        const inspection = inspectMarketplaceEntries(registration, {
+          root,
+          baseSnapshot: snap.snapshot,
+          ignoreRecordedDrift: true,
+          format: liveFormat ?? undefined,
+          cache,
+          entryRoots: candidateEntryRoots,
+          entrySnapshots: candidateEntrySnapshots,
+        });
+        const name = marketplaceNameOf(registration.id, inspection.marketplaceId) || registration.marketplaceName || '';
+        const candidate: UpdateCandidate = {
+          registrationId: registration.id,
+          stateRevision: revision,
+          recordedFingerprint: registration.validationSnapshot,
+          recordedResolvedRevision: registration.resolvedRevision,
+          snapshot: snap.snapshot,
+          marketplaceName: name,
+          format: liveFormat ?? undefined,
+          catalog: { name, entries: inspection.entries.map((item) => item.entry) },
+          inspection,
+          sourceKey: { ...registration.sourceKey, resolvedRevision },
+          canonicalLocator: locator.canonicalUrl,
+          resolvedRevision,
+          selectorCanonical: selector.canonical,
+          entrySnapshots: candidateEntrySnapshots,
+        };
+        await cache.storeTree(root, snap.snapshot.fingerprint);
+        cache.recordIndex({
+          fingerprint: snap.snapshot.fingerprint,
+          resolvedRevision,
+          canonicalLocator: locator.canonicalUrl,
+          selectorCanonical: selector.canonical,
+        });
+        cache.recordPendingUpdate({ registrationId: registration.id, fingerprint: snap.snapshot.fingerprint });
+        for (const fp of Object.values(candidateEntrySnapshots)) {
+          cache.recordPendingUpdate({ registrationId: registration.id, fingerprint: fp });
+        }
+        return {
+          status: 'update-candidate',
+          candidate,
+          receipt: createReceipt({
+            operation: OPERATION,
+            trigger: `refresh ${registration.id}`,
+            expectedStateRevision: revision,
+            validationSnapshot: snap.snapshot.fingerprint,
+            summary: 'Completed',
+            findings: inspection.findings,
+            stateChanged: false,
+          }),
+        };
+      }
+
       if (registration.validationSnapshot) {
         await cache.storeTree(root, registration.validationSnapshot);
         cache.recordIndex({
@@ -327,74 +547,12 @@ async function refreshGitRegistration(
       }
       return {
         status: 'no-change',
-        receipt: createReceipt({
-          operation: OPERATION,
-          trigger: `refresh ${registration.id}`,
-          expectedStateRevision: revision,
-          validationSnapshot: registration.validationSnapshot,
-          summary: 'Completed',
-          stateChanged: false,
-        }),
+        receipt: noChangeReceipt(),
       };
+    } finally {
+      for (const cleanup of cleanups) cleanup();
     }
-
-    // Resolved Revision changed ⇒ new validation is mandatory before any confirmation.
-    const newSourceKey: SourceKey = { ...registration.sourceKey, resolvedRevision };
-    const snap = buildGitSnapshot(root, newSourceKey, {
-      canonicalLocator: locator.canonicalUrl,
-      resolvedRevision,
-      selectorCanonical: selector.canonical,
-    });
-    if (!snap.ok || !snap.snapshot) {
-      return blocked(registration.id, revision, snap.findings, registration.validationSnapshot);
-    }
-    const liveFormat = detectMarketplaceFormat(root);
-    const inspection = inspectMarketplaceEntries(registration, {
-      root,
-      baseSnapshot: snap.snapshot,
-      ignoreRecordedDrift: true,
-      format: liveFormat ?? undefined,
-    });
-    const name = marketplaceNameOf(registration.id, inspection.marketplaceId) || registration.marketplaceName || '';
-    const candidate: UpdateCandidate = {
-      registrationId: registration.id,
-      stateRevision: revision,
-      recordedFingerprint: registration.validationSnapshot,
-      recordedResolvedRevision: registration.resolvedRevision,
-      snapshot: snap.snapshot,
-      marketplaceName: name,
-      format: liveFormat ?? undefined,
-      catalog: { name, entries: inspection.entries.map((item) => item.entry) },
-      inspection,
-      sourceKey: newSourceKey,
-      canonicalLocator: locator.canonicalUrl,
-      resolvedRevision,
-      selectorCanonical: selector.canonical,
-    };
-    // Persist the candidate tree in the cache and pin its fingerprint as a pending Update
-    // Candidate — pinned entries are never evicted by LRU pruning.
-    await cache.storeTree(root, snap.snapshot!.fingerprint);
-    cache.recordIndex({
-      fingerprint: snap.snapshot!.fingerprint,
-      resolvedRevision,
-      canonicalLocator: locator.canonicalUrl,
-      selectorCanonical: selector.canonical,
-    });
-    cache.recordPendingUpdate({ registrationId: registration.id, fingerprint: snap.snapshot!.fingerprint });
-    return {
-      status: 'update-candidate',
-      candidate,
-      receipt: createReceipt({
-        operation: OPERATION,
-        trigger: `refresh ${registration.id}`,
-        expectedStateRevision: revision,
-        validationSnapshot: snap.snapshot.fingerprint,
-        summary: 'Completed',
-        findings: inspection.findings,
-        stateChanged: false,
-      }),
-    };
   } finally {
-    cleanupAcquisition(acq.acquiredPath!);
+    if (acqToCleanup) cleanupAcquisition(acqToCleanup);
   }
 }

--- a/src/lifecycle/update.ts
+++ b/src/lifecycle/update.ts
@@ -92,6 +92,7 @@ function draftNextState(state: BridgeState, plan: UpdatePlan): BridgeState {
     // disclosed Update Candidate and this explicit atomic commit (never implicitly).
     if (candidate.format) next.format = candidate.format;
     if (candidate.resolvedRevision) next.resolvedRevision = candidate.resolvedRevision;
+    if (candidate.entrySnapshots) next.entrySnapshots = candidate.entrySnapshots;
     if (plan.rebindSource) {
       next.sourceKind = plan.rebindSource.sourceKind;
       next.source = plan.rebindSource.source;
@@ -207,6 +208,19 @@ export async function applyUpdate(plan: UpdatePlan, opts: ApplyUpdateOptions = {
         plan,
         'Cached Git tree no longer hashes to the Update Candidate fingerprint (source drift); run a fresh Marketplace Refresh and rebuild the plan',
       );
+    }
+  }
+
+  if (plan.candidate.entrySnapshots) {
+    const cache = opts.cache ?? new SourceCache({ agentDir: opts.agentDir });
+    for (const [entryId, fp] of Object.entries(plan.candidate.entrySnapshots)) {
+      const hit = await cache.hitExact(fp);
+      if (!hit) {
+        return stale(
+          plan,
+          `No cached tree verifies candidate entry '${entryId}' snapshot (evicted or never retained); run a fresh Marketplace Refresh and rebuild the plan`,
+        );
+      }
     }
   }
 

--- a/src/registration/catalog.ts
+++ b/src/registration/catalog.ts
@@ -10,6 +10,7 @@
 
 import { CODE, RULE, blocking, type ValidationFinding } from './findings.js';
 import { BUDGET } from './budget.js';
+import { parseGitEntrySpec } from './entry-acquisition.js';
 
 export type EntryType = 'local' | 'git' | 'unsupported';
 
@@ -30,6 +31,8 @@ export interface MarketplaceEntry {
   type: EntryType;
   /** Declared `./`-relative Contained Path for local entries. */
   path?: string;
+  /** Declared raw source object/string for git entries. */
+  source?: unknown;
   /** Whether this entry can supply an activatable plugin (else Unavailable). */
   available: boolean;
   /** Human reason when unavailable. */
@@ -176,12 +179,43 @@ export function parseCatalog(obj: unknown): CatalogResult {
     const path = nestedSource ? nestedPath : flatPath;
 
     if (kind.type !== 'local') {
-      // Recognized only as an Unavailable Entry (never recursively acquired). Disclosed, not a finding.
+      const rawSource = nestedSource ?? e.source ?? e;
+      const parsedGit = parseGitEntrySpec(rawSource, entryId);
+      if (parsedGit.isGitFamily) {
+        if (parsedGit.ok) {
+          entries.push({
+            entryId,
+            ordinal: index,
+            name,
+            type: 'git',
+            source: rawSource,
+            path,
+            available: true,
+          });
+          return;
+        }
+        if (parsedGit.findings.length > 0) {
+          findings.push(...parsedGit.findings);
+        }
+        entries.push({
+          entryId,
+          ordinal: index,
+          name,
+          type: 'git',
+          source: rawSource,
+          path,
+          available: false,
+          unavailableReason: parsedGit.unavailableReason ?? 'invalid git entry',
+        });
+        return;
+      }
+      // Recognized only as an Unavailable Entry. Disclosed, not a finding.
       entries.push({
         entryId,
         ordinal: index,
         name,
         type: kind.type,
+        source: rawSource,
         path,
         available: false,
         unavailableReason: 'unsupported source kind',

--- a/src/registration/claude-catalog.ts
+++ b/src/registration/claude-catalog.ts
@@ -23,6 +23,7 @@
 import { CODE, RULE, blocking, warning, type ValidationFinding } from './findings.js';
 import { BUDGET } from './budget.js';
 import { KEBAB_NAME_RE, type Catalog, type CatalogResult, type MarketplaceEntry } from './catalog.js';
+import { parseGitEntrySpec } from './entry-acquisition.js';
 
 /**
  * Snapshot-relative location of the claude Marketplace Catalog within a Marketplace Root.
@@ -113,29 +114,12 @@ function entryFinding(
   return blocking({ code, rule, phase: 'validation', target: 'entry', pointer, outcome });
 }
 
-function unavailable(entryId: string, ordinal: number, name: string | undefined, type: MarketplaceEntry['type'], reason: string): MarketplaceEntry {
-  return { entryId, ordinal, name, type, available: false, unavailableReason: reason };
+function unavailable(entryId: string, ordinal: number, name: string | undefined, type: MarketplaceEntry['type'], reason: string, source?: unknown): MarketplaceEntry {
+  return { entryId, ordinal, name, type, source, available: false, unavailableReason: reason };
 }
 
 function isMapping(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function classifyObjectSource(source: Record<string, unknown>): { type: MarketplaceEntry['type']; reason: string } {
-  switch (source.source) {
-    case 'github':
-    case 'url':
-    case 'git-subdir':
-      return { type: 'git', reason: CLAUDE_UNAVAILABLE_REASON.gitFamily };
-    case 'npm':
-      return { type: 'unsupported', reason: CLAUDE_UNAVAILABLE_REASON.npm };
-    case 'archive':
-      return { type: 'unsupported', reason: CLAUDE_UNAVAILABLE_REASON.archive };
-    case 'command':
-      return { type: 'unsupported', reason: CLAUDE_UNAVAILABLE_REASON.command };
-    default:
-      return { type: 'unsupported', reason: CLAUDE_UNAVAILABLE_REASON.unknownKind };
-  }
 }
 
 /**
@@ -145,7 +129,8 @@ function classifyObjectSource(source: Record<string, unknown>): { type: Marketpl
 function classifySource(
   source: unknown,
   hasPluginRoot: boolean,
-): { type: MarketplaceEntry['type']; path?: string; available: boolean; reason?: string } {
+  entryId = '/plugins/0',
+): { type: MarketplaceEntry['type']; path?: string; source?: unknown; available: boolean; reason?: string; findings?: ValidationFinding[] } {
   if (source === undefined || source === null || source === '') {
     return { type: 'unsupported', available: false, reason: CLAUDE_UNAVAILABLE_REASON.noSource };
   }
@@ -163,8 +148,24 @@ function classifySource(
     return { type: 'unsupported', available: false, reason: CLAUDE_UNAVAILABLE_REASON.notLocalPath };
   }
   if (isMapping(source)) {
-    const kind = classifyObjectSource(source);
-    return { type: kind.type, available: false, reason: kind.reason };
+    const rawKind = typeof source.source === 'string' ? source.source.toLowerCase() : undefined;
+    if (rawKind === 'npm') {
+      return { type: 'unsupported', source, available: false, reason: CLAUDE_UNAVAILABLE_REASON.npm };
+    }
+    if (rawKind === 'archive') {
+      return { type: 'unsupported', source, available: false, reason: CLAUDE_UNAVAILABLE_REASON.archive };
+    }
+    if (rawKind === 'command') {
+      return { type: 'unsupported', source, available: false, reason: CLAUDE_UNAVAILABLE_REASON.command };
+    }
+    const parsed = parseGitEntrySpec(source, entryId);
+    if (parsed.isGitFamily) {
+      if (parsed.ok) {
+        return { type: 'git', source, available: true };
+      }
+      return { type: 'git', source, available: false, reason: parsed.unavailableReason ?? 'invalid git entry', findings: parsed.findings };
+    }
+    return { type: 'unsupported', source, available: false, reason: CLAUDE_UNAVAILABLE_REASON.unknownKind };
   }
   return { type: 'unsupported', available: false, reason: CLAUDE_UNAVAILABLE_REASON.unrecognizedForm };
 }
@@ -320,15 +321,18 @@ export function parseClaudeCatalog(obj: unknown): CatalogResult {
       }
     }
 
-    const resolved = classifySource(e.source, hasPluginRoot);
+    const resolved = classifySource(e.source, hasPluginRoot, entryId);
+    if (resolved.findings && resolved.findings.length > 0) {
+      findings.push(...resolved.findings);
+    }
     if (!resolved.available) {
-      entries.push(unavailable(entryId, index, name, resolved.type, resolved.reason!));
+      entries.push(unavailable(entryId, index, name, resolved.type, resolved.reason!, resolved.source));
       return;
     }
     // Manifest-backed plugins only: an entry-defined plugin (strict:false) cannot supply an
     // activatable Plugin on day 1 even when its local path resolves.
     if (e.strict === false) {
-      entries.push(unavailable(entryId, index, name, resolved.type, CLAUDE_UNAVAILABLE_REASON.strictFalse));
+      entries.push(unavailable(entryId, index, name, resolved.type, CLAUDE_UNAVAILABLE_REASON.strictFalse, resolved.source));
       return;
     }
     entries.push({
@@ -337,6 +341,7 @@ export function parseClaudeCatalog(obj: unknown): CatalogResult {
       name,
       type: resolved.type,
       path: resolved.path,
+      source: resolved.source,
       available: true,
     });
   });

--- a/src/registration/flow.ts
+++ b/src/registration/flow.ts
@@ -24,7 +24,7 @@ import {
   sortFindings,
   type ValidationFinding,
 } from './findings.js';
-import { parseCatalog, type Catalog } from './catalog.js';
+import { parseCatalog, type Catalog, type MarketplaceEntry } from './catalog.js';
 import { catalogContractFor, detectMarketplaceFormat } from './format.js';
 import { resolveContained } from './contained.js';
 import { acquireAttemptFence, type AttemptFenceHandle } from './fence.js';
@@ -47,11 +47,18 @@ import type { SourceKey } from './source-key.js';
 export const MARKETPLACE_CATALOG_RELPATH = CODEX_RELPATH;
 import { CODEX_MARKETPLACE_CATALOG_RELPATH as CODEX_RELPATH } from './format.js';
 
+import { acquireGitEntries, type EntryAcquisitionRecord } from './entry-acquisition.js';
+import type { GitExecutor, AcquisitionTrustOptions } from './git-acquisition.js';
+import { SourceCache } from '../cache/source-cache.js';
+
 export interface RegistrationFlowOptions {
   agentDir?: string;
   /** Deterministic Registration ID for tests; otherwise UUIDv4 allocated before preflight. */
   preallocatedId?: string;
   fenceTimeoutMs?: number;
+  executor?: GitExecutor;
+  trust?: AcquisitionTrustOptions;
+  cache?: SourceCache;
 }
 
 export interface LocalRegistrationPreflight {
@@ -72,6 +79,10 @@ export interface LocalRegistrationPreflight {
   fence: AttemptFenceHandle;
   /** True once confirm/cancel reached a terminal outcome (single terminal per preflight). */
   terminal: boolean;
+  /** Per-entry Validation Snapshot fingerprints bound to Registration Confirmation (issue #50 / #51). */
+  entrySnapshots?: Record<string, string>;
+  acquiredEntries?: Map<string, EntryAcquisitionRecord>;
+  entryCleanup?: () => void;
 }
 
 export type RegistrationOutcome =
@@ -302,18 +313,40 @@ export async function preflightLocalRegistration(
       }
     }
 
+    // External Git entry acquisition (Issue #50 / #51)
+    const gitEntries = catalog.entries.filter((e): e is MarketplaceEntry & { source: unknown } => e.type === 'git' && e.available && e.source !== undefined);
+    let entrySnapshots: Record<string, string> | undefined;
+    let acquiredEntries: Map<string, EntryAcquisitionRecord> | undefined;
+    let entryCleanup: (() => void) | undefined;
+    if (gitEntries.length > 0) {
+      const cache = opts.cache ?? new SourceCache({ agentDir: opts.agentDir });
+      const batchRes = await acquireGitEntries(gitEntries, {
+        trust: opts.trust,
+        executor: opts.executor,
+        cache,
+      });
+      if (!batchRes.ok) {
+        return blockedResult(rootPath, expectedRevision, sortFindings([...findings, ...batchRes.findings]), handle, opts, undefined, detectedFormat);
+      }
+      entrySnapshots = batchRes.entrySnapshots;
+      acquiredEntries = batchRes.entries;
+      entryCleanup = batchRes.cleanup;
+    }
+
     // Validation Snapshot (complete tree + binds)
     const snapshotResult = buildLocalSnapshot(canonicalPath, sourceKey);
     findings.push(...snapshotResult.findings);
 
     const sorted = sortFindings(findings);
     if (hasBlocking(sorted)) {
+      entryCleanup?.();
       return blockedResult(rootPath, expectedRevision, sorted, handle, opts);
     }
 
     // Duplicate detection (same kind + identical Source Key); directs to the existing Registration.
     const dup = findDuplicateRegistration(sourceKey, registrations);
     if (dup.duplicate) {
+      entryCleanup?.();
       return blockedResult(rootPath, expectedRevision, [dup.finding!], handle, opts, dup.existing);
     }
 
@@ -336,6 +369,9 @@ export async function preflightLocalRegistration(
       stateRevision: expectedRevision,
       fence: handle,
       terminal: false,
+      entrySnapshots,
+      acquiredEntries,
+      entryCleanup,
     };
     return { ok: true, preflight };
   } catch (e) {
@@ -405,6 +441,7 @@ export async function confirmLocalRegistration(
     });
     await appendReceipt(receipt, opts);
     release();
+    preflight.entryCleanup?.();
     return { status: 'declined', receipt };
   }
 
@@ -431,6 +468,7 @@ export async function confirmLocalRegistration(
     });
     await appendReceipt(receipt, opts);
     release();
+    preflight.entryCleanup?.();
     return { status: 'persistence-failed', receipt, isIndeterminate: true };
   }
   const currentRevision = fresh.state!.stateRevision;
@@ -457,6 +495,7 @@ export async function confirmLocalRegistration(
     });
     await appendReceipt(receipt, opts);
     release();
+    preflight.entryCleanup?.();
     return { status: 'rejected-as-stale', receipt };
   }
 
@@ -474,6 +513,7 @@ export async function confirmLocalRegistration(
     });
     await appendReceipt(receipt, opts);
     release();
+    preflight.entryCleanup?.();
     return { status: 'blocked', findings: [dup.finding!], receipt, existing: dup.existing };
   }
 
@@ -502,6 +542,7 @@ export async function confirmLocalRegistration(
     });
     await appendReceipt(receipt, opts);
     release();
+    preflight.entryCleanup?.();
     return { status: 'rejected-as-stale', receipt };
   }
 
@@ -514,6 +555,7 @@ export async function confirmLocalRegistration(
     source: preflight.canonicalPath,
     sourceKey: preflight.sourceKey,
     validationSnapshot: preflight.snapshot.fingerprint,
+    entrySnapshots: preflight.entrySnapshots,
     snapshotBinds: snapshotBinds(preflight.snapshot),
   };
 
@@ -547,6 +589,7 @@ export async function confirmLocalRegistration(
     });
     await appendReceipt(receipt, opts);
     release();
+    preflight.entryCleanup?.();
     return { status: 'persistence-failed', receipt, isIndeterminate: write.isIndeterminate ?? false };
   }
 
@@ -566,6 +609,7 @@ export async function confirmLocalRegistration(
   });
   await appendReceipt(receipt, opts);
   release();
+  preflight.entryCleanup?.();
   return { status: 'completed', registration, receipt, newRevision: targetRevision };
 }
 
@@ -574,6 +618,7 @@ export function cancelLocalRegistration(preflight: LocalRegistrationPreflight): 
   if (preflight.terminal) return;
   preflight.terminal = true;
   preflight.fence.release();
+  preflight.entryCleanup?.();
 }
 
 /**

--- a/src/registration/git-flow.ts
+++ b/src/registration/git-flow.ts
@@ -15,7 +15,7 @@ import { commitBridgeState, readBridgeState } from '../bridge-state/store.js';
 import type { MarketplaceFormat, Registration } from '../bridge-state/types.js';
 import { BUDGET } from './budget.js';
 import { CODE, RULE, blocking, hasBlocking, sortFindings, type ValidationFinding } from './findings.js';
-import type { Catalog } from './catalog.js';
+import type { Catalog, MarketplaceEntry } from './catalog.js';
 import { catalogContractFor, detectMarketplaceFormat } from './format.js';
 import { resolveContained } from './contained.js';
 import { acquireAttemptFence, type AttemptFenceHandle } from './fence.js';
@@ -27,6 +27,7 @@ import { gitSourceKey, type SourceKey } from './source-key.js';
 import { normalizeGitLocator, type CanonicalGitLocator } from './git-locator.js';
 import { normalizeGitSelector, parseGitSelectorString, type GitSelectorInput, type NormalizedGitSelector } from './git-selector.js';
 import { acquireGitSource, cleanupAcquisition, type GitExecutor, type AcquisitionTrustOptions } from './git-acquisition.js';
+import { acquireGitEntries, type EntryAcquisitionRecord } from './entry-acquisition.js';
 import { SourceCache } from '../cache/source-cache.js';
 import { CODEX_MARKETPLACE_CATALOG_RELPATH as MARKETPLACE_CATALOG_RELPATH } from './format.js';
 
@@ -64,6 +65,10 @@ export interface GitRegistrationPreflight {
   /** Temp acquisition path (cleaned on cancel/confirm, not persisted) */
   acquiredPath?: string;
   createdTemp?: boolean;
+  /** Per-entry Validation Snapshot fingerprints bound to Registration Confirmation (issue #50 / #51). */
+  entrySnapshots?: Record<string, string>;
+  acquiredEntries?: Map<string, EntryAcquisitionRecord>;
+  entryCleanup?: () => void;
 }
 
 export type GitRegistrationOutcome =
@@ -342,6 +347,26 @@ export async function preflightGitRegistration(
       }
     }
 
+    // External Git entry acquisition (Issue #50 / #51)
+    const gitEntries = catalog.entries.filter((e): e is MarketplaceEntry & { source: unknown } => e.type === 'git' && e.available && e.source !== undefined);
+    let entrySnapshots: Record<string, string> | undefined;
+    let acquiredEntries: Map<string, EntryAcquisitionRecord> | undefined;
+    let entryCleanup: (() => void) | undefined;
+    if (gitEntries.length > 0) {
+      const batchRes = await acquireGitEntries(gitEntries, {
+        trust: opts.trust,
+        executor: opts.executor,
+        cache: opts.cache,
+      });
+      if (!batchRes.ok) {
+        if (acquiredPath) cleanupAcquisition(acquiredPath);
+        return blockedResult(locatorInput, selCanonical, expectedRevision, sortFindings([...findings, ...batchRes.findings]), handle, opts, undefined, detectedFormat);
+      }
+      entrySnapshots = batchRes.entrySnapshots;
+      acquiredEntries = batchRes.entries;
+      entryCleanup = batchRes.cleanup;
+    }
+
     const snapshotResult = buildGitSnapshot(acquiredPath, sourceKey, {
       canonicalLocator: locator.canonicalUrl,
       resolvedRevision,
@@ -351,6 +376,7 @@ export async function preflightGitRegistration(
 
     const sorted = sortFindings(findings);
     if (hasBlocking(sorted)) {
+      entryCleanup?.();
       cleanupAcquisition(acquiredPath);
       return blockedResult(locatorInput, selCanonical, expectedRevision, sorted, handle, opts);
     }
@@ -394,6 +420,9 @@ export async function preflightGitRegistration(
       terminal: false,
       acquiredPath,
       createdTemp,
+      entrySnapshots,
+      acquiredEntries,
+      entryCleanup,
     };
     return { ok: true, preflight };
   } catch (e) {
@@ -449,6 +478,7 @@ export async function confirmGitRegistration(
   const release = () => {
     fence.release();
     if (preflight.acquiredPath) cleanupAcquisition(preflight.acquiredPath);
+    preflight.entryCleanup?.();
   };
 
   if (!yes) {
@@ -546,6 +576,7 @@ export async function confirmGitRegistration(
     gitSelector: { kind: preflight.selector.kind, canonical: preflight.selector.canonical, raw: preflight.selector.raw },
     resolvedRevision: preflight.resolvedRevision,
     validationSnapshot: preflight.snapshot.fingerprint,
+    entrySnapshots: preflight.entrySnapshots,
     snapshotBinds: snapshotBinds(preflight.snapshot),
   };
 
@@ -606,6 +637,7 @@ export function cancelGitRegistration(preflight: GitRegistrationPreflight): void
   preflight.terminal = true;
   preflight.fence.release();
   if (preflight.acquiredPath) cleanupAcquisition(preflight.acquiredPath);
+  preflight.entryCleanup?.();
 }
 
 export function disclosureSummaryGit(preflight: GitRegistrationPreflight): string {

--- a/src/registration/git-flow.ts
+++ b/src/registration/git-flow.ts
@@ -353,10 +353,11 @@ export async function preflightGitRegistration(
     let acquiredEntries: Map<string, EntryAcquisitionRecord> | undefined;
     let entryCleanup: (() => void) | undefined;
     if (gitEntries.length > 0) {
+      const cache = opts.cache ?? new SourceCache({ agentDir: opts.agentDir });
       const batchRes = await acquireGitEntries(gitEntries, {
         trust: opts.trust,
         executor: opts.executor,
-        cache: opts.cache,
+        cache,
       });
       if (!batchRes.ok) {
         if (acquiredPath) cleanupAcquisition(acquiredPath);

--- a/tests/integration/entry-acquisition-wiring.test.ts
+++ b/tests/integration/entry-acquisition-wiring.test.ts
@@ -1,0 +1,392 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, cpSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { readBridgeState } from '../../src/bridge-state/store.js';
+import {
+  preflightLocalRegistration,
+  confirmLocalRegistration,
+} from '../../src/registration/flow.js';
+import {
+  preflightPluginInstallation,
+  confirmPluginInstallation,
+} from '../../src/installation/flow.js';
+import { inspectMarketplaceEntries } from '../../src/installation/inspection.js';
+import { refreshRegistration } from '../../src/lifecycle/refresh.js';
+import { buildUpdatePlan } from '../../src/lifecycle/update-plan.js';
+import { applyUpdate } from '../../src/lifecycle/update.js';
+import { SourceCache } from '../../src/cache/source-cache.js';
+import type { GitExecutor } from '../../src/registration/git-acquisition.js';
+
+function makeFixture(root: string, opts: { subpath?: string; pluginName: string; skillName: string; isCodex?: boolean }) {
+  const targetDir = opts.subpath ? join(root, opts.subpath) : root;
+  mkdirSync(targetDir, { recursive: true });
+  mkdirSync(join(targetDir, 'skills', opts.skillName), { recursive: true });
+
+  writeFileSync(
+    join(targetDir, 'skills', opts.skillName, 'SKILL.md'),
+    `---\nname: ${opts.skillName}\ndescription: Test skill for ${opts.pluginName}\n---\nHello from ${opts.skillName}`,
+  );
+  if (opts.isCodex) {
+    mkdirSync(join(targetDir, '.codex-plugin'), { recursive: true });
+    writeFileSync(
+      join(targetDir, '.codex-plugin', 'plugin.json'),
+      JSON.stringify({ name: opts.pluginName, skills: './skills/' }),
+    );
+  } else {
+    mkdirSync(join(targetDir, '.claude-plugin'), { recursive: true });
+    writeFileSync(
+      join(targetDir, '.claude-plugin', 'plugin.json'),
+      JSON.stringify({ name: opts.pluginName, skills: [`./skills/${opts.skillName}`] }),
+    );
+  }
+}
+
+function makeMockGitExecutor(fixtures: Record<string, { root: string; sha: string }>): GitExecutor {
+  return async (args, execOpts) => {
+    if (args.includes('ls-remote')) {
+      const url = args.find((a) => a.startsWith('https://') || a.startsWith('git://') || a.includes('@')) ?? '';
+      const matched = Object.entries(fixtures).find(([key]) => url.includes(key));
+      const sha = matched ? matched[1].sha : '1111111111111111111111111111111111111111';
+      const ref = args[args.length - 1];
+      return { exitCode: 0, stdout: `${sha}\t${ref}\n`, stderr: '' };
+    }
+
+    if (args.includes('clone')) {
+      const url = args.find((a) => a.startsWith('https://') || a.startsWith('git://') || a.includes('@')) ?? '';
+      const matched = Object.entries(fixtures).find(([key]) => url.includes(key));
+      const dest = args[args.length - 1];
+      if (matched) {
+        cpSync(matched[1].root, dest, { recursive: true });
+      } else {
+        mkdirSync(dest, { recursive: true });
+      }
+      mkdirSync(join(dest, '.git'), { recursive: true });
+      return { exitCode: 0, stdout: '', stderr: '' };
+    }
+
+    return { exitCode: 0, stdout: '', stderr: '' };
+  };
+}
+
+describe('Entry Acquisition Wiring Integration Tests (#51)', () => {
+  let tmpRoot: string;
+  let agentDir: string;
+  let cache: SourceCache;
+
+  let ghFixtureRoot: string;
+  let urlFixtureRoot: string;
+  let monoFixtureRoot: string;
+  let codexGitFixtureRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'entry-acq-test-'));
+    agentDir = join(tmpRoot, 'agent');
+    cache = new SourceCache({ agentDir });
+
+    ghFixtureRoot = join(tmpRoot, 'fixtures', 'gh-plugin');
+    makeFixture(ghFixtureRoot, { pluginName: 'gh-plugin', skillName: 'gh-skill' });
+
+    urlFixtureRoot = join(tmpRoot, 'fixtures', 'url-plugin');
+    makeFixture(urlFixtureRoot, { pluginName: 'url-plugin', skillName: 'url-skill' });
+
+    monoFixtureRoot = join(tmpRoot, 'fixtures', 'mono-repo');
+    makeFixture(monoFixtureRoot, { subpath: 'packages/sub-plugin', pluginName: 'subdir-plugin', skillName: 'sub-skill' });
+
+    codexGitFixtureRoot = join(tmpRoot, 'fixtures', 'codex-git');
+    makeFixture(codexGitFixtureRoot, { pluginName: 'codex-git-plugin', skillName: 'codex-git-skill', isCodex: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('AC1 & AC5: Claude marketplace with github/url/git-subdir entries acquires, browses, installs, and keeps npm/archive/command unavailable', async () => {
+    const marketplaceRoot = join(tmpRoot, 'claude-marketplace');
+    mkdirSync(join(marketplaceRoot, '.claude-plugin'), { recursive: true });
+
+    writeFileSync(
+      join(marketplaceRoot, '.claude-plugin', 'marketplace.json'),
+      JSON.stringify({
+        name: 'claude-hub',
+        owner: { name: 'Acme' },
+        plugins: [
+          { name: 'gh-tool', source: { source: 'github', repo: 'samwang/gh-tool' } },
+          { name: 'url-tool', source: { source: 'url', url: 'https://example.test/url-tool.git' } },
+          { name: 'sub-tool', source: { source: 'git-subdir', url: 'https://example.test/mono.git', path: 'packages/sub-plugin' } },
+          { name: 'npm-tool', source: { source: 'npm', package: '@scope/pkg' } },
+          { name: 'arch-tool', source: { source: 'archive', url: 'https://example.test/tool.zip' } },
+          { name: 'cmd-tool', source: { source: 'command', command: 'make build' } },
+        ],
+      }),
+    );
+
+    const fixtures = {
+      'samwang/gh-tool': { root: ghFixtureRoot, sha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' },
+      'url-tool.git': { root: urlFixtureRoot, sha: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' },
+      'mono.git': { root: monoFixtureRoot, sha: 'cccccccccccccccccccccccccccccccccccccccc' },
+    };
+    const executor = makeMockGitExecutor(fixtures);
+
+    // 1. Preflight
+    const preRes = await preflightLocalRegistration(marketplaceRoot, {
+      agentDir,
+      executor,
+      cache,
+    });
+    expect(preRes.ok).toBe(true);
+    if (!preRes.ok) throw new Error('preflight failed');
+    const preflight = preRes.preflight;
+    expect(preflight.format).toBe('claude');
+    expect(preflight.entrySnapshots).toBeDefined();
+    expect(Object.keys(preflight.entrySnapshots!)).toEqual(['/plugins/0', '/plugins/1', '/plugins/2']);
+
+    // 2. Confirm registration
+    const confRes = await confirmLocalRegistration(preflight, true, { agentDir });
+    expect(confRes.status).toBe('completed');
+    if (confRes.status !== 'completed') throw new Error('conf failed');
+    const reg = confRes.registration;
+    expect(reg.entrySnapshots).toEqual(preflight.entrySnapshots);
+
+    // 3. Inspect marketplace
+    const inspection = inspectMarketplaceEntries(reg, { agentDir, cache });
+    expect(inspection.entries).toHaveLength(6);
+
+    // Git entries are available and classified as compatible plugins
+    expect(inspection.entries[0].entry.available).toBe(true);
+    expect(inspection.entries[0].plugin?.manifestName).toBe('gh-plugin');
+    expect(inspection.entries[0].classification).toBe('compatible');
+
+    expect(inspection.entries[1].entry.available).toBe(true);
+    expect(inspection.entries[1].plugin?.manifestName).toBe('url-plugin');
+
+    expect(inspection.entries[2].entry.available).toBe(true);
+    expect(inspection.entries[2].plugin?.manifestName).toBe('subdir-plugin');
+
+    // npm, archive, command entries are permanently / consistently unavailable (AC5)
+    expect(inspection.entries[3].entry.available).toBe(false);
+    expect(inspection.entries[3].unavailableReason).toMatch(/npm/i);
+
+    expect(inspection.entries[4].entry.available).toBe(false);
+    expect(inspection.entries[4].unavailableReason).toMatch(/archive/i);
+
+    expect(inspection.entries[5].entry.available).toBe(false);
+    expect(inspection.entries[5].unavailableReason).toMatch(/command/i);
+
+    // 4. Install gh-plugin
+    const installPreRes = await preflightPluginInstallation(reg.id, '/plugins/0', { agentDir, cache });
+    expect(installPreRes.ok).toBe(true);
+    if (!installPreRes.ok) throw new Error('inst pre failed');
+    const installConfRes = await confirmPluginInstallation(installPreRes.preflight, 'enabled', true, {
+      agentDir,
+    });
+    expect(installConfRes.status).toBe('completed');
+    if (installConfRes.status !== 'completed') throw new Error('inst conf failed');
+    expect(installConfRes.installation.installationState).toBe('enabled');
+    expect(installConfRes.installation.manifestName).toBe('gh-plugin');
+
+    const state = (await readBridgeState({ agentDir })).state!;
+    expect(state.installations).toHaveLength(1);
+    expect(state.installations[0].manifestName).toBe('gh-plugin');
+  });
+
+  it('AC2: Codex marketplace with git-kind entry acquires and installs symmetrically', async () => {
+    const marketplaceRoot = join(tmpRoot, 'codex-marketplace');
+    mkdirSync(join(marketplaceRoot, '.agents', 'plugins'), { recursive: true });
+
+    // Local plugin
+    const localDir = join(marketplaceRoot, 'plugins', 'local-p');
+    mkdirSync(localDir, { recursive: true });
+    mkdirSync(join(localDir, '.codex-plugin'), { recursive: true });
+    mkdirSync(join(localDir, 'skills', 'local-s'), { recursive: true });
+    writeFileSync(join(localDir, '.codex-plugin', 'plugin.json'), JSON.stringify({ name: 'local-plugin', skills: './skills/' }));
+    writeFileSync(join(localDir, 'skills', 'local-s', 'SKILL.md'), '---\nname: local-s\ndescription: local skill\n---\nLocal');
+
+    writeFileSync(
+      join(marketplaceRoot, '.agents', 'plugins', 'marketplace.json'),
+      JSON.stringify({
+        name: 'codex-hub',
+        plugins: [
+          { name: 'remote-git', source: { source: 'git', url: 'https://example.test/codex-git.git' } },
+          { name: 'local-tool', source: { source: 'local', path: './plugins/local-p' } },
+        ],
+      }),
+    );
+
+    const fixtures = {
+      'codex-git.git': { root: codexGitFixtureRoot, sha: 'dddddddddddddddddddddddddddddddddddddddd' },
+    };
+    const executor = makeMockGitExecutor(fixtures);
+
+    const preRes = await preflightLocalRegistration(marketplaceRoot, {
+      agentDir,
+      executor,
+      cache,
+    });
+    expect(preRes.ok).toBe(true);
+    if (!preRes.ok) throw new Error('pre failed');
+    expect(preRes.preflight.format).toBe('codex');
+    expect(preRes.preflight.entrySnapshots).toHaveProperty('/plugins/0');
+
+    const confRes = await confirmLocalRegistration(preRes.preflight, true, { agentDir });
+    expect(confRes.status).toBe('completed');
+    if (confRes.status !== 'completed') throw new Error('conf failed');
+    const reg = confRes.registration;
+
+    const inspection = inspectMarketplaceEntries(reg, { agentDir, cache });
+    expect(inspection.entries).toHaveLength(2);
+    expect(inspection.entries[0].entry.available).toBe(true);
+    expect(inspection.entries[0].plugin?.manifestName).toBe('codex-git-plugin');
+    expect(inspection.entries[1].entry.available).toBe(true);
+    expect(inspection.entries[1].plugin?.manifestName).toBe('local-plugin');
+
+    // Install external git plugin
+    const installPreRes = await preflightPluginInstallation(reg.id, '/plugins/0', { agentDir, cache });
+    expect(installPreRes.ok).toBe(true);
+    if (!installPreRes.ok) throw new Error('inst pre failed');
+    const installConfRes = await confirmPluginInstallation(installPreRes.preflight, 'enabled', true, {
+      agentDir,
+    });
+    expect(installConfRes.status).toBe('completed');
+    if (installConfRes.status !== 'completed') throw new Error('inst conf failed');
+    expect(installConfRes.installation.manifestName).toBe('codex-git-plugin');
+  });
+
+  it('AC3 & AC4: Movable ref produces Update Candidate on upstream drift; SHA-pinned does not; Apply Update enforces disposition', async () => {
+    const marketplaceRoot = join(tmpRoot, 'mixed-marketplace');
+    mkdirSync(join(marketplaceRoot, '.claude-plugin'), { recursive: true });
+
+    writeFileSync(
+      join(marketplaceRoot, '.claude-plugin', 'marketplace.json'),
+      JSON.stringify({
+        name: 'mixed-hub',
+        owner: { name: 'Acme' },
+        plugins: [
+          { name: 'movable-entry', source: { source: 'github', repo: 'samwang/movable', ref: 'main' } },
+          { name: 'pinned-entry', source: { source: 'github', repo: 'samwang/pinned', sha: '1111111111111111111111111111111111111111' } },
+        ],
+      }),
+    );
+
+    const movableRoot = join(tmpRoot, 'fixtures', 'movable');
+    makeFixture(movableRoot, { pluginName: 'movable-plugin', skillName: 'movable-skill' });
+
+    const pinnedRoot = join(tmpRoot, 'fixtures', 'pinned');
+    makeFixture(pinnedRoot, { pluginName: 'pinned-plugin', skillName: 'pinned-skill' });
+
+    let movableSha = '2222222222222222222222222222222222222222';
+    const fixtures: Record<string, { root: string; sha: string }> = {
+      'samwang/movable': { root: movableRoot, get sha() { return movableSha; } },
+      'samwang/pinned': { root: pinnedRoot, sha: '1111111111111111111111111111111111111111' },
+    };
+    const executor = makeMockGitExecutor(fixtures);
+
+    // Initial Registration
+    const preRes = await preflightLocalRegistration(marketplaceRoot, { agentDir, executor, cache });
+    expect(preRes.ok).toBe(true);
+    if (!preRes.ok) throw new Error('pre failed');
+    const confRes = await confirmLocalRegistration(preRes.preflight, true, { agentDir });
+    if (confRes.status !== 'completed') throw new Error('conf failed');
+    const reg = confRes.registration;
+
+    // Install movable-plugin
+    const instPre = await preflightPluginInstallation(reg.id, '/plugins/0', { agentDir, cache });
+    if (!instPre.ok) throw new Error('inst pre failed');
+    const instConf = await confirmPluginInstallation(instPre.preflight, 'enabled', true, { agentDir });
+    if (instConf.status !== 'completed') throw new Error('inst conf failed');
+    const inst = instConf.installation;
+
+    // 1. Refresh when upstream has NOT moved -> no-change
+    const ref1 = await refreshRegistration(reg.id, { agentDir, executor, cache });
+    expect(ref1.status).toBe('no-change');
+
+    // 2. Upstream moves for movable ref entry
+    movableSha = '3333333333333333333333333333333333333333';
+    // Modify content in movable fixture so tree snapshot actually changes
+    writeFileSync(join(movableRoot, 'skills', 'movable-skill', 'SKILL.md'), '---\nname: movable-skill\ndescription: v2\n---\nUpdated content');
+
+    const ref2 = await refreshRegistration(reg.id, { agentDir, executor, cache });
+    expect(ref2.status).toBe('update-candidate');
+    const candidate = (ref2 as { candidate: any }).candidate;
+    expect(candidate.entrySnapshots['/plugins/0']).not.toEqual(reg.entrySnapshots?.['/plugins/0']);
+    // Pinned entry snapshot stayed unchanged
+    expect(candidate.entrySnapshots['/plugins/1']).toEqual(reg.entrySnapshots?.['/plugins/1']);
+
+    // 3. Build Update Plan without confirming -> fails closed (AC4)
+    const planFail = buildUpdatePlan(candidate, [inst], candidate.stateRevision, {
+      registrationConfirmed: false,
+      choices: { [inst.id]: 'update' },
+    });
+    expect(planFail.ok).toBe(false);
+
+    // 4. Build Update Plan with update choice and activation confirmation
+    const planRes = buildUpdatePlan(candidate, [inst], candidate.stateRevision, {
+      registrationConfirmed: true,
+      choices: { [inst.id]: 'update' },
+      activationConfirmations: { [inst.id]: true },
+    });
+    expect(planRes.ok).toBe(true);
+    if (!planRes.ok) throw new Error('plan failed');
+
+    // 5. Apply Update
+    const applyRes = await applyUpdate(planRes.plan, { agentDir, cache });
+    expect(applyRes.status).toBe('completed');
+    expect((applyRes as { receipt: any }).receipt.stateChanged).toBe(true);
+
+    // Verify durable state
+    const postState = (await readBridgeState({ agentDir })).state!;
+    const updatedReg = postState.registrations.find((r) => r.id === reg.id)!;
+    expect(updatedReg.entrySnapshots).toEqual(candidate.entrySnapshots);
+    const updatedInst = postState.installations.find((i) => i.id === inst.id)!;
+    expect(updatedInst.installationState).toBe('enabled');
+    expect(updatedInst.validationSnapshot).toBeDefined();
+  });
+
+  it('AC6: Transaction flow scenario — aggregated marketplace end-to-end registration and installation', async () => {
+    const marketplaceRoot = join(tmpRoot, 'agg-marketplace');
+    mkdirSync(join(marketplaceRoot, '.claude-plugin'), { recursive: true });
+
+    writeFileSync(
+      join(marketplaceRoot, '.claude-plugin', 'marketplace.json'),
+      JSON.stringify({
+        name: 'agg-hub',
+        owner: { name: 'Acme' },
+        plugins: [
+          { name: 'agg-gh', source: { source: 'github', repo: 'samwang/agg-gh' } },
+        ],
+      }),
+    );
+
+    const aggFixture = join(tmpRoot, 'fixtures', 'agg-gh');
+    makeFixture(aggFixture, { pluginName: 'agg-gh-plugin', skillName: 'agg-skill' });
+
+    const fixtures = {
+      'samwang/agg-gh': { root: aggFixture, sha: '9999999999999999999999999999999999999999' },
+    };
+    const executor = makeMockGitExecutor(fixtures);
+
+    // Preflight registration with executor
+    const regPre = await preflightLocalRegistration(marketplaceRoot, { agentDir, executor, cache });
+    expect(regPre.ok).toBe(true);
+    if (!regPre.ok) throw new Error('reg pre failed');
+    const regConf = await confirmLocalRegistration(regPre.preflight, true, { agentDir });
+    expect(regConf.status).toBe('completed');
+    if (regConf.status !== 'completed') throw new Error('reg conf failed');
+    const registration = regConf.registration;
+
+    // Preflight installation for external git entry
+    const instPre = await preflightPluginInstallation(registration.id, '/plugins/0', { agentDir, cache });
+    expect(instPre.ok).toBe(true);
+    if (!instPre.ok) throw new Error('inst pre failed');
+    const instConf = await confirmPluginInstallation(instPre.preflight, 'enabled', true, { agentDir });
+    expect(instConf.status).toBe('completed');
+    if (instConf.status !== 'completed') throw new Error('inst conf failed');
+    expect(instConf.installation.pluginId).toBe(`${registration.id}/agg-hub/agg-gh-plugin`);
+
+    const state = (await readBridgeState({ agentDir })).state!;
+    expect(state.registrations).toHaveLength(1);
+    expect(state.installations).toHaveLength(1);
+    expect(state.installations[0].manifestName).toBe('agg-gh-plugin');
+  });
+});

--- a/tests/integration/entry-acquisition-wiring.test.ts
+++ b/tests/integration/entry-acquisition-wiring.test.ts
@@ -9,6 +9,10 @@ import {
   confirmLocalRegistration,
 } from '../../src/registration/flow.js';
 import {
+  preflightGitRegistration,
+  confirmGitRegistration,
+} from '../../src/registration/git-flow.js';
+import {
   preflightPluginInstallation,
   confirmPluginInstallation,
 } from '../../src/installation/flow.js';
@@ -388,5 +392,45 @@ describe('Entry Acquisition Wiring Integration Tests (#51)', () => {
     expect(state.registrations).toHaveLength(1);
     expect(state.installations).toHaveLength(1);
     expect(state.installations[0].manifestName).toBe('agg-gh-plugin');
+  });
+
+  it('preflightGitRegistration without opts.cache initializes SourceCache fallback and stores entry trees', async () => {
+    const gitMarketplaceFixture = join(tmpRoot, 'fixtures', 'remote-git-marketplace');
+    mkdirSync(join(gitMarketplaceFixture, '.claude-plugin'), { recursive: true });
+    writeFileSync(
+      join(gitMarketplaceFixture, '.claude-plugin', 'marketplace.json'),
+      JSON.stringify({
+        name: 'remote-hub',
+        owner: { name: 'Acme' },
+        plugins: [
+          { name: 'gh-tool', source: { source: 'github', repo: 'samwang/gh-tool' } },
+        ],
+      }),
+    );
+
+    const fixtures = {
+      'remote-hub.git': { root: gitMarketplaceFixture, sha: '8888888888888888888888888888888888888888' },
+      'samwang/gh-tool': { root: ghFixtureRoot, sha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' },
+    };
+    const executor = makeMockGitExecutor(fixtures);
+
+    // Call preflightGitRegistration WITHOUT opts.cache — must initialize fallback cache from agentDir
+    const preRes = await preflightGitRegistration('https://github.com/example/remote-hub.git', 'refs/heads/main', {
+      agentDir,
+      executor,
+    });
+    expect(preRes.ok).toBe(true);
+    if (!preRes.ok) throw new Error('git pre failed');
+    expect(preRes.preflight.entrySnapshots).toHaveProperty('/plugins/0');
+
+    const confRes = await confirmGitRegistration(preRes.preflight, true, { agentDir });
+    expect(confRes.status).toBe('completed');
+    if (confRes.status !== 'completed') throw new Error('git conf failed');
+
+    // Inspect marketplace using a new SourceCache instance with the same agentDir — entry snapshot must hit!
+    const inspectCache = new SourceCache({ agentDir });
+    const inspection = inspectMarketplaceEntries(confRes.registration, { agentDir, cache: inspectCache });
+    expect(inspection.entries[0].entry.available).toBe(true);
+    expect(inspection.entries[0].plugin?.manifestName).toBe('gh-plugin');
   });
 });

--- a/tests/unit/cache/source-cache.test.ts
+++ b/tests/unit/cache/source-cache.test.ts
@@ -124,9 +124,10 @@ describe('SourceCache (Git-only, fingerprint-addressed)', () => {
 
   it('records and clears pending Update Candidate fingerprints', () => {
     cache.recordPendingUpdate({ registrationId: 'reg-1', fingerprint: FP_A });
-    cache.recordPendingUpdate({ registrationId: 'reg-1', fingerprint: FP_B }); // replaces
+    cache.recordPendingUpdate({ registrationId: 'reg-1', fingerprint: FP_B }); // replaces root
+    cache.recordPendingUpdate({ registrationId: 'reg-1', entryId: '/plugins/0', fingerprint: FP_A }); // keeps entry 0
     cache.recordPendingUpdate({ registrationId: 'reg-2', fingerprint: FP_C });
-    expect(cache.pendingUpdates().map((r) => r.fingerprint).sort()).toEqual([FP_B, FP_C].sort());
+    expect(cache.pendingUpdates().map((r) => r.fingerprint).sort()).toEqual([FP_A, FP_B, FP_C].sort());
     cache.clearPendingUpdate('reg-1');
     expect(cache.pendingUpdates().map((r) => r.fingerprint)).toEqual([FP_C]);
   });

--- a/tests/unit/registration/claude-catalog.test.ts
+++ b/tests/unit/registration/claude-catalog.test.ts
@@ -261,19 +261,19 @@ describe('Entry source-form dispatch marks non-local forms as Unavailable Entrie
       expected: { type: 'local', available: true },
     },
     {
-      label: 'github object is Unavailable (phase 2 acquisition)',
+      label: 'github object is available (Issue #50 / #51 acquisition)',
       plugin: { name: 'gh', source: { source: 'github', repo: 'owner/repo' } },
-      expected: { type: 'git', available: false, reason: REASON.gitFamily },
+      expected: { type: 'git', available: true },
     },
     {
-      label: 'url object is Unavailable (phase 2 acquisition)',
+      label: 'url object is available (Issue #50 / #51 acquisition)',
       plugin: { name: 'url', source: { source: 'url', url: 'https://example.test/r.git' } },
-      expected: { type: 'git', available: false, reason: REASON.gitFamily },
+      expected: { type: 'git', available: true },
     },
     {
-      label: 'git-subdir object is Unavailable (phase 2 acquisition)',
+      label: 'git-subdir object is available (Issue #50 / #51 acquisition)',
       plugin: { name: 'sub', source: { source: 'git-subdir', url: 'https://example.test/r.git', path: 'pkg' } },
-      expected: { type: 'git', available: false, reason: REASON.gitFamily },
+      expected: { type: 'git', available: true },
     },
     {
       label: 'npm object is Unavailable',


### PR DESCRIPTION
## Summary

Wired external git-family marketplace entry acquisition across dual catalog formats (Claude and Codex), integrated lifecycle inspection and marketplace refresh, and added end-to-end integration and transaction scenario tests.

- **Dual-format Catalog Parsing**: Claude `github`, `url`, and `git-subdir` entries and Codex `git` sources are parsed into valid `GitEntrySpec` and classified as available git entries.
- **Entry Acquisition & Cache Pinning**: Preflight acquires external git entries concurrently into `SourceCache` and captures per-entry validation snapshot fingerprints into durable `Registration.entrySnapshots`.
- **Marketplace Entry Inspection**: Inspects external git entries by querying `SourceCache` by fingerprint, correctly evaluating and classifying contained plugin trees.
- **Refresh & Update Candidate Isolation**: Separates movable refs (branches/tags) from sha-pinned entries; movable refs generate `UpdateCandidate` on upstream revision drift, while sha-pinned entries do not.
- **Update Plan & Apply Update**: Enforces disposition on affected installations and atomically updates `Registration.entrySnapshots` and pinned cache trees upon apply.
- **Unavailable Entry Kinds**: Keeps `npm`, `archive`, and `command` sources exposed as unavailable with deterministic reason findings.
- **Integration Tests**: Added comprehensive integration test suite covering all 6 acceptance criteria and transaction flow scenarios.

Closes #51