### PR TITLE
docs: R2 文件落地——ADR 0005、Entry 術語與 CHANGELOG 記錄（#52）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to `pi-codex-marketplace` are documented here. Format follow
 ## [Unreleased]
 
 ### Added
+- **R2 文件落地（ADR 0005、Entry 術語）** (#52)：
+  - `CONTEXT.md` 新增 `Entry Acquisition` 與 `Entry Pin` 正典詞條，並同步更新 `Marketplace Entry`、`Acquisition Trust Base` 與 `Unavailable Entry` 描述。
+  - 新增架構決策記錄：`ADR 0005`（`0005-entry-acquisition-trust-boundary.md`），詳述 Entry 級取得之信任邊界（重用既有 Acquisition Trust Base）、零執行安全承諾、`command` 來源永久不合格理由、HTTPS shorthand 正規化、Pin 矩陣映射與漂移更新語意。
+- **Entry Acquisition 接入雙格式與 Refresh 流程** (#51)：
+  - 接合 Claude marketplace `github`/`url`/`git-subdir` 與 Codex git-kind 條目取得。
+  - 於 Registration Confirmation 持久化每項 entry 的 `entrySnapshots` 獨立快照。
+  - 整合 Marketplace Refresh：可動 ref 在上游漂移時產生 Update Candidate，sha-pinned 條目不產生 candidate；Update Plan 與 Apply Update 實施原子處置與快取 pin 保留。
+  - `npm`、`archive` 與 `command` 來源一致披露為 Unavailable Entry。
+- **Entry Acquisition 引擎（git 家族 entry）** (#50)：
+  - 實作格式中立的 Entry 級取得引擎（`src/registration/entry-acquisition.ts`）。
+  - 支援 `github`（含 owner/repo shorthand 展開為 canonical HTTPS 定位器）、`url`、`git-subdir`（含子目錄 containment 驗證）。
+  - Selector 映射與 Pin 矩陣：`sha`→commit、`ref`→branch/tag、皆無→可動 default；並存時 `sha` 為有效 pin、`ref` 僅作格式檢驗。
+  - 嚴格 Acquisition Trust Base（`StrictHostKeyChecking=yes`、`core.hooksPath=/dev/null`、`GIT_LFS_SKIP_SMUDGE=1`）與 Validation Budget fail-closed 約束。
+  - 批次取得原子性：任一 entry 失敗或超限即整批 fail-closed 並自動清理暫存目錄。
 - **R1 文件落地（CONTEXT.md、ADR×2、README）** (#49)：
   - `CONTEXT.md` 術語修訂與新增：`Marketplace Catalog` 收編 `.claude-plugin/marketplace.json`、`Compatibility Profile` 改述 v2 雙格式契約、`Marketplace` 與 `Plugin` 去除 Codex-format 限定、`Unavailable Entry` 擴充結構化原因分類表、`Skill Agent Profile` 明示 Codex 專屬（Claude 下視為一般 Skill Resource）、新增 `Marketplace Format` 正典詞條。
   - 新增架構決策記錄：`ADR 0003`（雙格式偵測與 codex 優先）與 `ADR 0004`（統一 Compatibility Profile v2 取代凍結 v1）。

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -77,7 +77,7 @@ The format of a Marketplace Source (`codex` or `claude`), deterministically deri
 _Avoid_: Protocol version, manifest format, adaptive format
 
 **Marketplace Entry**:
-A Marketplace Catalog member that names one Plugin candidate and locates it through a local Contained Path. Other entry source kinds are recognized only as Unavailable Entries rather than recursively acquired.
+A Marketplace Catalog member that names one Plugin candidate and locates it through a local Contained Path or an external git-family locator acquired via Entry Acquisition. Other entry source kinds are recognized only as Unavailable Entries rather than recursively acquired.
 _Avoid_: Marketplace Source, Installed Plugin
 
 **Marketplace Entry ID**:
@@ -100,13 +100,21 @@ _Avoid_: Plugin source, marketplace entry
 The non-executing retrieval of a Git Marketplace Source at a Resolved Revision. It never runs repository-controlled hooks, filters, submodules, dependencies, or Plugin components.
 _Avoid_: Package installation, build, Plugin activation
 
+**Entry Acquisition**:
+The format-neutral, non-executing retrieval of an external git-family Marketplace Entry (`github`, `url`, or `git-subdir`) at its declared Entry Pin. It operates under the existing Acquisition Trust Base and Validation Budget, generates an independent per-entry Validation Snapshot, rejects embedded credentials and plaintext transports, and never executes repository-controlled hooks, scripts, build steps, or components.
+_Avoid_: Plugin installation, package download, dynamic component execution
+
 **Acquisition Trust Base**:
-The constrained host components trusted during Source Acquisition: the selected Git and SSH executables, operating-system certificate authorities, pre-established SSH known-host keys, and approved credential helper or SSH agent. The Bridge Package permits only necessary trust and credential configuration, rejects unknown or changed SSH host keys and canonical-locator-changing redirects, and never extends this trust to repository content or repository-controlled Git configuration.
+The constrained host components trusted during Source Acquisition and Entry Acquisition: the selected Git and SSH executables, operating-system certificate authorities, pre-established SSH known-host keys, and approved credential helper or SSH agent. The Bridge Package permits only necessary trust and credential configuration, rejects unknown or changed SSH host keys and canonical-locator-changing redirects, and never extends this trust to repository content or repository-controlled Git configuration.
 _Avoid_: Project Trust, Plugin trust, sandbox
 
 **Git Selector**:
 The structured `default`, `branch`, `tag`, or `commit` choice attached to a Git Marketplace Source. Branch and tag values obey Git ref-name rules and canonicalize to exact case-sensitive `refs/heads/...` or `refs/tags/...` values; commit values are complete 40- or 64-hex object names canonicalized to lowercase. Ambiguous shorthand, abbreviated object names, generic refs, `HEAD`, revision or reflog expressions, option-like values, whitespace, and control characters are not accepted; default, branch, and tag selectors are movable and every selector resolves to a full commit before confirmation.
 _Avoid_: Resolved Revision, arbitrary Git revision expression
+
+**Entry Pin**:
+The structured locator and revision constraint declared on an external Marketplace Entry, mapping `sha` to a fixed commit, `ref` to a movable branch or tag, and omitting both to the source's movable default ref. When both `sha` and `ref` are present, `sha` is the authoritative pin while `ref` is validated for syntax; movable pins participate in Marketplace Refresh to produce Update Candidates on upstream drift, while fixed commit pins do not.
+_Avoid_: Plugin version, floating tag, arbitrary revision expression
 
 **Resolved Revision**:
 The full Git commit bound to validation and confirmation for a Git Selector. It is a source attribute rather than identity, and a changed resolution requires new validation and confirmation.
@@ -203,7 +211,7 @@ _Avoid_: Marketplace entry name, Plugin path
 **Unavailable Entry**:
 A Marketplace Entry that cannot supply an activatable Plugin because it uses an unsupported source kind, cannot be resolved to a Plugin, yields an Invalid or Incompatible Plugin, or has a Plugin-level identity collision. A Runtime Skill Collision affects skill availability and does not make an otherwise activatable entry unavailable.
 _Reason categories:_
-- _Unsupported source kinds_: non-local or non-contained source forms (such as `npm`, `archive`, external `git`/`github`/`url`/`git-subdir` without entry acquisition, or permanently disqualified `command` sources).
+- _Unsupported source kinds_: non-git source forms (such as `npm`, `archive`, or permanently disqualified `command` sources) or invalid git entry declarations.
 - _Unresolvable sources_: missing sources, bare names, unsupported `metadata.pluginRoot` resolution, or non-`./` relative paths.
 - _Unsupported entry structure_: entry-defined plugins (`strict: false`) lacking an independent authoritative manifest, conflicting source declarations, or malformed entry objects.
 - _Target resolution & validation failures_: missing directory targets, manifest parse failures, Invalid Plugins (e.g., manifest schema/containment violations, duplicate skill names), Incompatible Plugins (requiring active components outside Compatibility Profile v2), or Plugin ID collisions within the snapshot.

--- a/docs/adr/0005-entry-acquisition-trust-boundary.md
+++ b/docs/adr/0005-entry-acquisition-trust-boundary.md
@@ -1,0 +1,25 @@
+# Entry 級取得的信任邊界與定位器正規化 (Entry-level acquisition trust boundary and locator normalization)
+
+Marketplace Catalog（包含 Claude 與 Codex 格式）允許 Marketplace 聚合分散於外部 Git 倉庫的外掛條目（如 `github`、`url`、`git-subdir` 形態）。Bridge 需要在不擴大既有信任基礎與維持「零執行」（Zero-Execution）安全承諾的前提下，取得並驗證這些外部 entry。決定：**Entry 級外部 Git 取得完全遵循頂層 Marketplace 既有的 Acquisition Trust Base 與 Validation Budget 約束；`owner/repo` 簡寫一律決定性正規化為 canonical HTTPS 定位器；`command` 來源永久不合格；外掛宣告以 `sha` 為不可變 pin，而可動 `ref` 於 Refresh 時產生 Update Candidate，確保第三方聚合不擴大信任面與執行邊界。**
+
+## Decisions
+
+- **重用既有 Acquisition Trust Base（No Trust Base Expansion）**：Entry 級取得完全限制在既有信任基礎內（指定的 Git 與 SSH 執行檔、OS CA 憑證、既有 SSH known_hosts、嚴格主機金鑰驗證 `StrictHostKeyChecking=yes`、`core.hooksPath=/dev/null`、`GIT_LFS_SKIP_SMUDGE=1`），絕不將信任延伸至外部 repository 所宣告的 git 設定。
+- **零執行原則（Zero-Execution Acquisition）**：取得外部 entry 過程絕不執行任何 repository 提供的 hooks、filters、submodules、相依套件安裝（如 `npm install`）、建置腳本或外掛元件，確保取得過程純粹為靜態位元組擷取。
+- **拒絕不安全傳輸與憑證嵌入**：明文傳輸（`http://`、`git://`）與嵌入認證資訊（`https://user:pass@...`）一律拒絕並產出 Blocking Finding；重定向亦嚴格禁止變更 canonical locator。
+- **嚴格 Validation Budget 約束與原子批次取得**：每個外部 entry 的下載體積、目錄深度、檔案數量及解析時間均受 Validation Budget 嚴格限制；單一 Marketplace 註冊時所有外部 entry 採原子批次取得，任一 entry 失敗或超限即整批 fail-closed 並自動清理暫存目錄。
+- **`command` 來源永久不合格（Permanent Disqualification）**：任何以 `command`（執行 shell 指令或腳本）形式宣告的 entry 永久不予支援，直接標記為 `Unavailable Entry`。執行任意指令將徹底破壞沙盒與零執行信任邊界，引入未知的供應鏈安全威脅，因此 command 來源屬於永久排除而非暫時性功能缺口。
+- **`npm` / `archive` 來源暫不收編**：npm 與 tarball/zip 壓縮包需要獨立的安全傳輸通道、完整性校驗與解壓縮安全防護（防止 zip-slip / tarbomb），目前維持標記為 `Unavailable Entry`，待後續專屬規格確立。
+- **HTTPS Shorthand 正規化（Deterministic HTTPS Normalization）**：`github: "owner/repo"` 或裸字串 shorthand 一律決定性展開為標準 canonical HTTPS 定位器（`https://github.com/<owner>/<repo>`），不支援 SSH shorthand 猜測或自訂通訊協定，確保定位器語意無歧義且能被標準公開 CA 驗證。
+- **Pin 矩陣與獨立快照（Per-entry Snapshot & Pin Matrix）**：
+  - Selector 映射：`sha` (40/64-hex commit) 映射為固定 `commit` pin；`ref` (branch/tag) 映射為可動 `branch` 或 `tag`；未指定時映射為可動 `default` 分支。
+  - 當 `sha` 與 `ref` 並存時，`sha` 為唯一有效 pin，`ref` 僅作格式合法性檢驗，確保內容不可變性。
+  - 每個外部 entry 產生獨立的 Validation Snapshot 與指紋（`entrySnapshots`），並快取於 Source Cache；Marketplace Refresh 列舉所有 entry，可動 ref 在上游移動時產生 `Update Candidate`，而 `sha` 固定 pin 則不受上游分支漂移影響。
+
+## Considered Options（拒絕）
+
+- **在沙盒或容器中執行 command 來源**：沙盒隔離難以完全消除逃逸與執行階段副作用風險，大幅增加複雜度且背離零執行鐵律。
+- **允許 shorthand 猜測或展開為 SSH 協定**：SSH 金鑰與已知主機設定因人而異，容易導致非預期的連線失敗或隱性認證傳遞，缺乏 HTTPS 公開憑證鏈的確定性。
+- **取得 entry 時自動執行 npm install 或建置**：安裝腳本（如 postinstall）具備任意程式碼執行能力，嚴重違反 Bridge 安全模型。
+- **允許部分 entry 取得失敗的寬鬆註冊（Partial Success）**：會導致 Marketplace 呈現殘缺狀態與快照指紋不完整，破壞 CAS（Compare-And-Swap）一致性保證。
+- **當 sha 與 ref 並存時以 ref 為準**：以可動 ref 覆寫 sha 會使使用者無法鎖定確切版本，喪失供應鏈不可變性防護。


### PR DESCRIPTION
Closes #52
Parent: #43

## 摘要

R2 文件落地：撰寫 ADR 0005（Entry 級取得的信任邊界——信任基礎不擴大、command 永久不合格、HTTPS shorthand 正規化與 Pin 矩陣漂移語意）；`CONTEXT.md` 新增 `Entry Acquisition` 與 `Entry Pin` 正典詞條並修訂相關術語；`CHANGELOG.md` 完整記錄 #52 文件落地與 #50、#51 之 Entry Acquisition 交付項目。

## 變更項目

- **`docs/adr/0005-entry-acquisition-trust-boundary.md`（新）**：
  - 記錄 Entry 級外部 Git 取得重用頂層既有 `Acquisition Trust Base`（零執行原則、不擴大信任面、嚴格 SSH host key 與 redirect 限制、拒絕明文與憑證嵌入）。
  - Validation Budget 嚴格約束與原子批次取得（任一 entry 失敗則全體 fail-closed）。
  - `command` 來源永久不合格之架構理由（執行任意指令破壞零執行邊界與沙盒安全）。
  - HTTPS Shorthand 正規化（`owner/repo` 決定性展開為標準 `https://github.com/<owner>/<repo>` 定位器）。
  - Pin 矩陣與獨立快照：`sha` (40/64-hex) 為固定 pin、`ref` 為可動 ref、並存時 sha 有效；Refresh 列舉所有 entry 並依可動 ref 漂移產生 Update Candidate。
- **`CONTEXT.md`**：
  - 新增 `Entry Acquisition` 與 `Entry Pin` 正典詞條。
  - 同步修訂 `Marketplace Entry`（涵蓋 Entry Acquisition 取得來源）、`Acquisition Trust Base`（涵蓋 Entry Acquisition 信任邊界）與 `Unavailable Entry`（更新非 git 來源與 invalid git entry 說明）。
- **`CHANGELOG.md`**：
  - 於 `[Unreleased]` 記錄 #52 文件落地，並補齊 #50（Entry Acquisition 引擎）與 #51（Entry Acquisition 接入雙格式與 Refresh）條目。

## 驗收對照

| #52 驗收條件 | 落點 |
|---|---|
| ADR 3 依倉庫格式落於 docs | `docs/adr/0005-entry-acquisition-trust-boundary.md` |
| CONTEXT.md 新詞條與交付行為一致 | `CONTEXT.md`（`Entry Acquisition`、`Entry Pin`、`Marketplace Entry` 等） |
| CHANGELOG 條目完成 | `CHANGELOG.md` |

## 驗證

- `npm run typecheck` ✅
- `npm test`：57 files / **783 tests passed** ✅
- 雙軸 code-review（Standards + Spec 平行子代理）：
  - Standards 審查：0 違規，ADR / CONTEXT.md / CHANGELOG 格式與詞彙完全符合。
  - Spec 審查：3 項驗收條件全數具備，無遺漏或範圍蔓延。