### PR TITLE
feat: add 本機 codex marketplace（格式偵測／重複拒絕／list） (#89)

### DIFF
--- a/src/bridge/command.ts
+++ b/src/bridge/command.ts
@@ -1,11 +1,23 @@
 /**
- * Pure runCommand dispatch seam (#88, #87).
+ * Pure runCommand dispatch seam (#88, #89, #87).
  *
  * Single pure entry point: runCommand(argv) -> { messages, lines, output, reload, stateReset }
  * Does not touch Pi host APIs; safe for direct assertion in pure Node environments.
  */
 
-import { readMinimalBridgeState, type MinimalBridgeState } from './state.js';
+import { randomUUID } from 'node:crypto';
+import { readFileSync, statSync } from 'node:fs';
+import { isAbsolute, join, resolve } from 'node:path';
+
+import { readMinimalBridgeState, writeMinimalBridgeState, type MinimalBridgeState } from './state.js';
+import { BUDGET } from '../registration/budget.js';
+import { localSourceKey } from '../registration/source-key.js';
+import {
+  catalogContractFor,
+  detectMarketplaceFormat,
+  CODEX_MARKETPLACE_CATALOG_RELPATH,
+  CLAUDE_MARKETPLACE_CATALOG_RELPATH,
+} from '../registration/format.js';
 
 export interface CommandOptions {
   statePath?: string;
@@ -87,6 +99,13 @@ function formatOverview(state: MinimalBridgeState): string[] {
   return sections;
 }
 
+function formatCatalogError(findings: { code?: string; outcome?: string; rule?: string; pointer?: string }[]): string {
+  if (findings.length === 0) return 'catalog 解析失敗';
+  const first = findings[0];
+  const detail = first.outcome || first.code || '未知錯誤';
+  return detail;
+}
+
 export async function runCommand(
   argv: string[] | string,
   opts: CommandOptions = {},
@@ -125,16 +144,163 @@ export async function runCommand(
         if (subargs.length === 0) {
           messages.push('用法：/codex-marketplace add <路徑|網址>');
         } else {
-          messages.push(`註冊 marketplace "${subargs[0]}"（骨架建立中，功能即將推出）`);
+          const input = subargs[0];
+          // Resolve input path against cwd for relative paths
+          const cwd = opts.cwd ?? process.cwd();
+          const absoluteInput = isAbsolute(input) ? input : resolve(cwd, input);
+
+          // 1) Resolve Source Key (local realpath)
+          const skRes = localSourceKey(absoluteInput);
+          if (!skRes.ok) {
+            const reason = skRes.error || '無法解析路徑';
+            messages.push(`錯誤：無法解析 marketplace 路徑 "${input}"：${reason}`);
+            break;
+          }
+          const canonicalPath = skRes.sourceKey!.canonicalPath!;
+          const sourceKeyStr = skRes.sourceKey!.key;
+
+          // 2) Duplicate detection (same realpath)
+          const duplicate = state.registrations.find(
+            (r) => r.sourceKind === 'local' && r.source === canonicalPath,
+          );
+          // Also check via key equality in case stored source differs in slash style; canonicalPath comparison is primary.
+          if (duplicate) {
+            void sourceKeyStr; // keep for future git distinctness
+            messages.push(
+              `已註冊過相同來源 "${canonicalPath}"，想更新？\`update\`；想換？先 \`remove\` 再 \`add\``,
+            );
+            break;
+          }
+
+          // 3) Format detection (codex prioritized)
+          const detectedFormat = detectMarketplaceFormat(canonicalPath);
+          if (!detectedFormat) {
+            messages.push(
+              `錯誤：找不到 marketplace catalog（${CODEX_MARKETPLACE_CATALOG_RELPATH} 或 ${CLAUDE_MARKETPLACE_CATALOG_RELPATH}）— catalog 缺失，請確認 marketplace 根目錄包含正確的 catalog 檔案`,
+            );
+            break;
+          }
+
+          const contract = catalogContractFor(detectedFormat);
+          const catalogPath = join(canonicalPath, ...contract.relPath.split('/'));
+
+          // 4) Budget + read catalog file
+          let catalogBytes = 0;
+          try {
+            catalogBytes = statSync(catalogPath).size;
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            messages.push(
+              `錯誤：找不到 marketplace catalog（${contract.relPath}）：${msg} — catalog 缺失`,
+            );
+            break;
+          }
+          if (catalogBytes > BUDGET.maxCatalogBytes) {
+            messages.push(
+              `錯誤：catalog 檔案過大（${catalogBytes} bytes > ${BUDGET.maxCatalogBytes}）— 超過 Validation Budget 上限，catalog 無法解析`,
+            );
+            break;
+          }
+
+          let raw: string;
+          try {
+            raw = readFileSync(catalogPath, 'utf-8');
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            messages.push(`錯誤：無法讀取 catalog（${contract.relPath}）：${msg}`);
+            break;
+          }
+
+          if (raw.trim().length === 0) {
+            messages.push(`錯誤：catalog 解析失敗（${contract.relPath}）：檔案為空 — catalog malformed`);
+            break;
+          }
+
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(raw);
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            messages.push(`錯誤：catalog 解析失敗（${contract.relPath}）：${msg} — catalog malformed，無法解析 JSON`);
+            break;
+          }
+
+          const catalogResult = contract.parse(parsed);
+          if (!catalogResult.ok) {
+            const detail = formatCatalogError(catalogResult.findings as any);
+            const codes = catalogResult.findings.map((f) => f.code).join(', ');
+            messages.push(
+              `錯誤：catalog 解析失敗（${contract.relPath}）：${detail} — catalog malformed${codes ? ` (${codes})` : ''}`,
+            );
+            // Also surface first finding outcome for test diagnosability
+            if (catalogResult.findings.length > 0) {
+              const extra = catalogResult.findings
+                .slice(0, 3)
+                .map((f) => `${f.code} ${f.outcome}`)
+                .join('；');
+              if (extra) messages.push(`詳細：${extra}`);
+            }
+            break;
+          }
+
+          const catalog = catalogResult.catalog!;
+
+          // 5) Persist registration
+          const newReg = {
+            id: randomUUID(),
+            marketplaceName: catalog.name,
+            format: detectedFormat,
+            sourceKind: 'local' as const,
+            source: canonicalPath,
+          };
+
+          state.registrations.push(newReg);
+          try {
+            writeMinimalBridgeState(state, opts);
+          } catch (e) {
+            // Rollback on write failure
+            state.registrations.pop();
+            const msg = e instanceof Error ? e.message : String(e);
+            messages.push(`錯誤：寫入 Bridge State 失敗：${msg}`);
+            break;
+          }
+
+          messages.push(`偵測：${detectedFormat} marketplace · ${catalog.entries.length} plugins`);
+          messages.push(`已註冊 "${catalog.name}"`);
         }
         break;
       }
       case 'list': {
-        if (state.registrations.length === 0 && state.installations.length === 0) {
-          messages.push('尚無可列出的 plugin 或 marketplace。');
-          messages.push(USAGE_LINE);
+        // list [名稱] — filter by marketplace name if provided
+        if (subargs.length > 0) {
+          const filter = subargs[0];
+          const filtered = state.registrations.filter(
+            (r) => r.marketplaceName === filter || r.alias === filter || r.id === filter,
+          );
+          if (filtered.length === 0 && state.registrations.length > 0) {
+            messages.push(`找不到 marketplace "${filter}"`);
+            // Still show all for discoverability
+            messages.push(...formatOverview(state));
+          } else if (filtered.length > 0) {
+            // Show filtered overview (reuse format but only filtered regs)
+            const filteredState: MinimalBridgeState = {
+              ...state,
+              registrations: filtered,
+              installations: state.installations.filter((inst) => filtered.some((r) => r.id === inst.registrationId)),
+            };
+            messages.push(...formatOverview(filteredState));
+          } else {
+            // No registrations at all
+            messages.push('尚無可列出的 plugin 或 marketplace。');
+            messages.push(USAGE_LINE);
+          }
         } else {
-          messages.push(...formatOverview(state));
+          if (state.registrations.length === 0 && state.installations.length === 0) {
+            messages.push('尚無可列出的 plugin 或 marketplace。');
+            messages.push(USAGE_LINE);
+          } else {
+            messages.push(...formatOverview(state));
+          }
         }
         break;
       }

--- a/tests/unit/bridge/command-add.test.ts
+++ b/tests/unit/bridge/command-add.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, symlinkSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { runCommand } from '../../../src/bridge/command.js';
+import { readMinimalBridgeState } from '../../../src/bridge/state.js';
+
+function makeCodexMarketplace(root: string, name: string, plugins: { name: string; path: string }[]) {
+  mkdirSync(join(root, '.agents', 'plugins'), { recursive: true });
+  writeFileSync(join(root, '.agents', 'plugins', 'marketplace.json'), JSON.stringify({ name, plugins }));
+  for (const p of plugins) {
+    const abs = join(root, p.path.replace(/^\.\//, ''));
+    mkdirSync(abs, { recursive: true });
+    writeFileSync(join(abs, 'plugin.json'), JSON.stringify({ name: p.name }));
+  }
+}
+
+function materializePinnedMarketplace(root: string): void {
+  const fixture = JSON.parse(
+    readFileSync(join(import.meta.dirname, '..', '..', 'fixtures', 'pinned', 'codex-plugins-98e78caf.json'), 'utf8'),
+  ) as { commit: string; encoding: string; files: Record<string, string[]> };
+  for (const [relativePath, chunks] of Object.entries(fixture.files)) {
+    const path = join(root, relativePath);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, Buffer.from(chunks.join(''), 'base64'));
+  }
+}
+
+describe('runCommand add/list 本機 codex marketplace (#89)', () => {
+  let tmpDir: string;
+  let statePath: string;
+  let mktRoot: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'bridge-add89-'));
+    statePath = join(tmpDir, 'state.json');
+    mktRoot = mkdtempSync(join(tmpdir(), 'mkt89-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    rmSync(mktRoot, { recursive: true, force: true });
+  });
+
+  it('add 本機 codex marketplace（合成 fixture）→ 偵測與已註冊，且不自動安裝', async () => {
+    makeCodexMarketplace(mktRoot, 'synthetic-marketplace', [
+      { name: 'demo', path: './plugins/demo' },
+      { name: 'demo2', path: './plugins/demo2' },
+    ]);
+
+    const result = await runCommand(['add', mktRoot], { statePath });
+
+    expect(result.reload).toBe(false);
+    expect(result.output).toContain('偵測：codex marketplace');
+    expect(result.output).toMatch(/2 plugins/);
+    expect(result.output).toContain('已註冊');
+    expect(result.output).toContain('synthetic-marketplace');
+
+    const st = readMinimalBridgeState({ statePath });
+    expect(st.state.registrations).toHaveLength(1);
+    expect(st.state.registrations[0].marketplaceName).toBe('synthetic-marketplace');
+    expect(st.state.registrations[0].format).toBe('codex');
+    expect(st.state.registrations[0].sourceKind).toBe('local');
+    expect(st.state.installations).toHaveLength(0);
+  });
+
+  it('add 本機 codex marketplace（真實 pinned fixture）→ 偵測與已註冊', async () => {
+    const pinnedRoot = mkdtempSync(join(tmpdir(), 'mkt89-pinned-'));
+    try {
+      materializePinnedMarketplace(pinnedRoot);
+      const result = await runCommand(['add', pinnedRoot], { statePath });
+
+      expect(result.output).toContain('偵測：codex marketplace');
+      expect(result.output).toMatch(/2 plugins/);
+      expect(result.output).toContain('已註冊');
+      expect(result.output).toContain('samwang');
+
+      const st = readMinimalBridgeState({ statePath });
+      expect(st.state.registrations).toHaveLength(1);
+      expect(st.state.registrations[0].marketplaceName).toBe('samwang');
+      expect(st.state.installations).toHaveLength(0);
+    } finally {
+      rmSync(pinnedRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('重複註冊同 realpath → 拒絕並提示正確下一步', async () => {
+    makeCodexMarketplace(mktRoot, 'demo-marketplace', [{ name: 'demo', path: './plugins/demo' }]);
+
+    const first = await runCommand(['add', mktRoot], { statePath });
+    expect(first.output).toContain('已註冊');
+
+    const dup = await runCommand(['add', mktRoot], { statePath });
+    expect(dup.output).toContain('已註冊過相同來源');
+    expect(dup.output).toContain('想更新？`update`；想換？先 `remove` 再 `add`');
+
+    const st = readMinimalBridgeState({ statePath });
+    expect(st.state.registrations).toHaveLength(1);
+  });
+
+  it('重複註冊同 realpath（經 symlink）→ 同樣拒絕', async () => {
+    makeCodexMarketplace(mktRoot, 'demo-marketplace', [{ name: 'demo', path: './plugins/demo' }]);
+    await runCommand(['add', mktRoot], { statePath });
+
+    const linkPath = join(tmpdir(), `link89-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    symlinkSync(mktRoot, linkPath);
+    try {
+      const dup = await runCommand(['add', linkPath], { statePath });
+      expect(dup.output).toContain('已註冊過相同來源');
+      expect(dup.output).toContain('想更新？`update`；想換？先 `remove` 再 `add`');
+      const st = readMinimalBridgeState({ statePath });
+      expect(st.state.registrations).toHaveLength(1);
+    } finally {
+      rmSync(linkPath, { force: true });
+    }
+  });
+
+  it('list 顯示已註冊 marketplace（名稱／格式／來源）', async () => {
+    makeCodexMarketplace(mktRoot, 'demo-marketplace', [{ name: 'demo', path: './plugins/demo' }]);
+    await runCommand(['add', mktRoot], { statePath });
+
+    const list = await runCommand(['list'], { statePath });
+    expect(list.output).toContain('demo-marketplace');
+    expect(list.output).toContain('codex');
+    expect(list.output).toContain('本地');
+    // source should contain the realpath
+    const st = readMinimalBridgeState({ statePath });
+    expect(list.output).toContain(st.state.registrations[0].source);
+  });
+
+  it('catalog 缺失 → 顯示錯誤、不註冊、不寫入', async () => {
+    // Empty directory without catalog
+    const result = await runCommand(['add', mktRoot], { statePath });
+    expect(result.output).toMatch(/catalog.*缺失|找不到.*catalog/i);
+    const st = readMinimalBridgeState({ statePath });
+    expect(st.state.registrations).toHaveLength(0);
+  });
+
+  it('catalog malformed → 顯示錯誤、不註冊、不寫入', async () => {
+    mkdirSync(join(mktRoot, '.agents', 'plugins'), { recursive: true });
+    writeFileSync(join(mktRoot, '.agents', 'plugins', 'marketplace.json'), '{ malformed json,,');
+    const result = await runCommand(['add', mktRoot], { statePath });
+    expect(result.output).toMatch(/catalog.*解析失敗|catalog.*malformed/i);
+    const st = readMinimalBridgeState({ statePath });
+    expect(st.state.registrations).toHaveLength(0);
+  });
+
+  it('catalog 名稱非法 → 顯示錯誤、不註冊', async () => {
+    mkdirSync(join(mktRoot, '.agents', 'plugins'), { recursive: true });
+    writeFileSync(
+      join(mktRoot, '.agents', 'plugins', 'marketplace.json'),
+      JSON.stringify({ name: 'Bad Name', plugins: [] }),
+    );
+    const result = await runCommand(['add', mktRoot], { statePath });
+    expect(result.output).toMatch(/錯誤.*catalog|解析失敗/i);
+    const st = readMinimalBridgeState({ statePath });
+    expect(st.state.registrations).toHaveLength(0);
+  });
+
+  it('註冊後 state.json 記入一筆 registration 記錄（縫層斷言）', async () => {
+    makeCodexMarketplace(mktRoot, 'seam-market', [{ name: 'p1', path: './plugins/p1' }]);
+    await runCommand(['add', mktRoot], { statePath });
+
+    const raw = readFileSync(statePath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    expect(parsed.registrations).toHaveLength(1);
+    expect(parsed.registrations[0].marketplaceName).toBe('seam-market');
+    expect(parsed.registrations[0].sourceKind).toBe('local');
+    expect(parsed.schemaVersion).toBe(1);
+  });
+
+  it('走 runCommand 縫測試，不經 TUI，且支援相對路徑 via cwd', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'cwd89-'));
+    const inner = join(cwd, 'my-mkt');
+    try {
+      makeCodexMarketplace(inner, 'rel-market', [{ name: 'p', path: './plugins/p' }]);
+      const result = await runCommand(['add', 'my-mkt'], { statePath, cwd });
+      expect(result.output).toContain('已註冊');
+      expect(result.output).toContain('rel-market');
+      const st = readMinimalBridgeState({ statePath });
+      expect(st.state.registrations).toHaveLength(1);
+      expect(st.state.registrations[0].marketplaceName).toBe('rel-market');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Closes #89

Parent #87

本票交付「本地 codex 來源註冊＋重複拒絕＋list 顯示」垂直路徑：

- `add <路徑>`：格式偵測（codex 優先）、解析 catalog，以 local realpath 計算 Source Key，寫入極簡 Bridge State 的 registrations
- 重複註冊同來源 → 拒絕＋提示「想更新？`update`；想換？先 `remove` 再 `add`」
- `list` 顯示已註冊 marketplace（名稱／格式／來源），支援 `list [名稱]` 過濾
- catalog 缺失或 malformed → 顯示錯誤、不註冊、不寫入
- 註冊後 state.json 記入一筆 registration 記錄（縫層斷言）
- 走 runCommand 縫測試，不經 TUI，且不自動安裝

### 驗證

- `npm run typecheck` ✅
- `npm test -- tests/unit/bridge` ✅ (57 tests)
- `npm test -- tests/e2e/bridge-ledger-command.test.ts` ✅
- 新增 `tests/unit/bridge/command-add.test.ts` 10 測試涵蓋：
  - 合成 fixture 與真實 pinned fixture（codex-plugins@98e78caf）皆能註冊，輸出「偵測：codex marketplace · N plugins」「已註冊 <name>」，installations 維持 0
  - 重複（同 realpath 與經 symlink）皆拒絕並含正確提示，state 仍為 1 筆
  - `list` 顯示已註冊 marketplace
  - catalog 缺失／malformed／名稱非法 皆顯示錯誤且不寫入
  - 相對路徑經 cwd 解析
  - state.json 縫層斷言
