### PR TITLE
feat: claude 雙格式 open 政策——未知欄位忽略／unavailable entry／解析錯誤顯示 (#91)

### DIFF
--- a/src/bridge/command.ts
+++ b/src/bridge/command.ts
@@ -21,7 +21,9 @@ import {
   CLAUDE_MARKETPLACE_CATALOG_RELPATH,
 } from '../registration/format.js';
 import { resolveContained } from '../registration/contained.js';
-import type { MarketplaceEntry } from '../registration/catalog.js';
+import { GIT_FAMILY_UNAVAILABLE_REASON, type Catalog, type MarketplaceEntry } from '../registration/catalog.js';
+import type { MarketplaceFormat } from '../bridge-state/types.js';
+import type { ValidationFinding } from '../registration/findings.js';
 
 export interface CommandOptions {
   statePath?: string;
@@ -112,74 +114,144 @@ function formatCatalogError(findings: { code?: string; outcome?: string; rule?: 
   return detail;
 }
 
-// ---- Plugin enumeration helpers (#90) ----
+// ---- Plugin enumeration helpers (#90, #91) ----
 
 interface EnumeratedPlugin {
   number: number;
   reg: MinimalBridgeState['registrations'][number];
   entry: MarketplaceEntry;
   pluginName: string;
-  status: '可安裝' | '已裝啟用' | '已裝停用';
+  status: '可安裝' | '已裝啟用' | '已裝停用' | 'unavailable';
+  unavailableReason?: string;
 }
 
-function getCatalogEntriesForReg(reg: MinimalBridgeState['registrations'][number]): MarketplaceEntry[] {
-  const format = reg.format ?? 'codex';
-  const contract = catalogContractFor(format as any);
-  const catalogPath = join(reg.source, ...contract.relPath.split('/'));
+/**
+ * Whether an entry can supply a locally installable plugin on the command surface. Git-family
+ * and unsupported source kinds are Unavailable Entries (#91): disclosed with a reason, never
+ * silently skipped and never installable.
+ */
+function entryLocallyInstallable(entry: MarketplaceEntry): boolean {
+  return (
+    entry.type === 'local' && entry.available === true && typeof entry.path === 'string' && entry.path.length > 0
+  );
+}
+
+function entryUnavailableReason(entry: MarketplaceEntry): string {
+  if (entry.type === 'git' && entry.available !== false) return GIT_FAMILY_UNAVAILABLE_REASON;
+  return entry.unavailableReason ?? 'unsupported source kind';
+}
+
+interface CatalogReadResult {
+  /** Parsed catalog on success (name + entries); also present for some parse failures. */
+  catalog?: Catalog;
+  /** Structural findings from the format-bound parser (present for parse failures too). */
+  findings: ValidationFinding[];
+  /** Disclosed read failure (catalog 缺失／超上限／malformed); never silently skipped. */
+  error?: string;
+}
+
+/**
+ * The single catalog reader for the command surface: budget-bounded read + format-bound parse.
+ * Read failures produce a disclosed `error` instead of silently skipping (#91).
+ */
+function readCatalogForReg(root: string, format: MarketplaceFormat): CatalogReadResult {
+  const contract = catalogContractFor(format);
+  const catalogPath = join(root, ...contract.relPath.split('/'));
+  let raw: string;
   try {
-    if (!existsSync(catalogPath)) return [];
-    if (statSync(catalogPath).size > BUDGET.maxCatalogBytes) return [];
-    const raw = readFileSync(catalogPath, 'utf-8');
-    if (!raw.trim()) return [];
-    const parsed = JSON.parse(raw);
-    const res = contract.parse(parsed);
-    if (res.catalog) return res.catalog.entries;
-    // Even if not ok, return entries if present (e.g., partial)
-    if ((res as any).catalog?.entries) return (res as any).catalog.entries;
-    return [];
-  } catch {
-    return [];
+    if (!existsSync(catalogPath)) {
+      return { findings: [], error: `catalog 缺失（${contract.relPath}）` };
+    }
+    const size = statSync(catalogPath).size;
+    if (size > BUDGET.maxCatalogBytes) {
+      return {
+        findings: [],
+        error: `catalog 檔案過大（${size} bytes > ${BUDGET.maxCatalogBytes}）— 超過 Validation Budget 上限，catalog 無法解析`,
+      };
+    }
+    raw = readFileSync(catalogPath, 'utf-8');
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { findings: [], error: `catalog 無法讀取：${msg}` };
   }
+  if (!raw.trim()) {
+    return { findings: [], error: `catalog 解析失敗：檔案為空 — catalog malformed` };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { findings: [], error: `catalog 解析失敗：${msg} — catalog malformed` };
+  }
+  const res = contract.parse(parsed);
+  if (!res.ok) {
+    const codes = res.findings.map((f) => f.code).join(', ');
+    return {
+      catalog: res.catalog,
+      findings: res.findings,
+      error: `catalog 解析失敗${codes ? ` (${codes})` : ''} — catalog malformed`,
+    };
+  }
+  return { catalog: res.catalog, findings: res.findings };
 }
 
-function enumeratePlugins(state: MinimalBridgeState): EnumeratedPlugin[] {
+interface Enumeration {
+  plugins: EnumeratedPlugin[];
+  catalogErrors: Array<{ marketplace: string; error: string }>;
+}
+
+function enumeratePlugins(state: MinimalBridgeState): Enumeration {
   const result: EnumeratedPlugin[] = [];
+  const catalogErrors: Enumeration['catalogErrors'] = [];
   let counter = 1;
   for (const reg of state.registrations) {
-    const entries = getCatalogEntriesForReg(reg);
-    for (const entry of entries) {
-      // Only count entries that can supply a plugin? For #90 we include all local entries; but we include all entries for numbering
-      // To keep numbers stable, include every entry regardless of availability? However unavailable entries should still be listed as unavailable?
-      // For now, include all entries; status will reflect可安裝 even if unavailable? But we will include all.
+    const read = readCatalogForReg(reg.source, reg.format ?? 'codex');
+    if (read.error) {
+      // Disclosed read failure (#91): the error line is shown and the marketplace contributes
+      // no entries — a broken catalog never yields installable plugins.
+      catalogErrors.push({ marketplace: reg.marketplaceName || reg.alias || reg.id, error: read.error });
+      continue;
+    }
+    for (const entry of read.catalog?.entries ?? []) {
       const pluginName = entry.name ?? (entry.path ? basename(entry.path) : `plugin-${entry.ordinal}`);
       const inst = state.installations.find(
         (i) => i.registrationId === reg.id && (i.manifestName === pluginName || i.pluginId === pluginName),
       );
       let status: EnumeratedPlugin['status'];
-      if (!inst) status = '可安裝';
+      let unavailableReason: string | undefined;
+      if (!entryLocallyInstallable(entry)) {
+        status = 'unavailable';
+        unavailableReason = entryUnavailableReason(entry);
+      } else if (!inst) status = '可安裝';
       else if (inst.enabled !== false && inst.installationState !== 'disabled') status = '已裝啟用';
       else status = '已裝停用';
-      result.push({ number: counter, reg, entry, pluginName, status });
+      result.push({ number: counter, reg, entry, pluginName, status, unavailableReason });
       counter++;
     }
   }
-  return result;
+  return { plugins: result, catalogErrors };
 }
 
 function formatPluginListLines(state: MinimalBridgeState, filter?: string): string[] {
-  const enumeration = enumeratePlugins(state);
+  const { plugins: enumeration, catalogErrors } = enumeratePlugins(state);
+  const errorLines = catalogErrors.map((e) => `⚠ marketplace [${e.marketplace}] ${e.error}`);
+  if (enumeration.length === 0) {
+    // No plugins at all (e.g., empty catalog, no registrations, or unreadable catalogs):
+    // read failures are disclosed, never silently skipped (#91).
+    return errorLines;
+  }
   let filtered = enumeration;
   if (filter) {
     filtered = enumeration.filter(
       (e) => e.reg.marketplaceName === filter || e.reg.alias === filter || e.reg.id === filter,
     );
-  }
-  if (enumeration.length === 0) {
-    // No plugins at all (e.g., empty catalog or no registrations)
-    return [];
-  }
-  if (filter && filtered.length === 0) {
-    return [`找不到 marketplace "${filter}"`];
+    if (filtered.length === 0) {
+      return [
+        `找不到 marketplace "${filter}"`,
+        ...errorLines.filter((l) => l.includes(`[${filter}]`)),
+      ];
+    }
   }
   const lines: string[] = ['Plugins（編號／所屬 marketplace／狀態）'];
   const show = filter ? filtered : enumeration;
@@ -187,9 +259,10 @@ function formatPluginListLines(state: MinimalBridgeState, filter?: string): stri
     const num = padRight(` ${e.number}`, 4);
     const name = padRight(e.pluginName, 18);
     const mkt = padRight(`[${e.reg.marketplaceName || e.reg.alias || e.reg.id}]`, 20);
-    const status = e.status;
+    const status = e.status === 'unavailable' ? `unavailable（${e.unavailableReason ?? 'unavailable'}）` : e.status;
     lines.push(`${num}${name}${mkt}${status}`);
   }
+  lines.push(...errorLines);
   return lines;
 }
 
@@ -368,59 +441,16 @@ export async function runCommand(
             break;
           }
 
-          const contract = catalogContractFor(detectedFormat);
-          const catalogPath = join(canonicalPath, ...contract.relPath.split('/'));
-
-          // 4) Budget + read catalog file
-          let catalogBytes = 0;
-          try {
-            catalogBytes = statSync(catalogPath).size;
-          } catch (e) {
-            const msg = e instanceof Error ? e.message : String(e);
-            messages.push(
-              `錯誤：找不到 marketplace catalog（${contract.relPath}）：${msg} — catalog 缺失`,
-            );
-            break;
-          }
-          if (catalogBytes > BUDGET.maxCatalogBytes) {
-            messages.push(
-              `錯誤：catalog 檔案過大（${catalogBytes} bytes > ${BUDGET.maxCatalogBytes}）— 超過 Validation Budget 上限，catalog 無法解析`,
-            );
-            break;
-          }
-
-          let raw: string;
-          try {
-            raw = readFileSync(catalogPath, 'utf-8');
-          } catch (e) {
-            const msg = e instanceof Error ? e.message : String(e);
-            messages.push(`錯誤：無法讀取 catalog（${contract.relPath}）：${msg}`);
-            break;
-          }
-
-          if (raw.trim().length === 0) {
-            messages.push(`錯誤：catalog 解析失敗（${contract.relPath}）：檔案為空 — catalog malformed`);
-            break;
-          }
-
-          let parsed: unknown;
-          try {
-            parsed = JSON.parse(raw);
-          } catch (e) {
-            const msg = e instanceof Error ? e.message : String(e);
-            messages.push(`錯誤：catalog 解析失敗（${contract.relPath}）：${msg} — catalog malformed，無法解析 JSON`);
-            break;
-          }
-
-          const catalogResult = contract.parse(parsed);
-          if (!catalogResult.ok) {
-            const detail = formatCatalogError(catalogResult.findings as any);
-            const codes = catalogResult.findings.map((f) => f.code).join(', ');
-            messages.push(
-              `錯誤：catalog 解析失敗（${contract.relPath}）：${detail} — catalog malformed${codes ? ` (${codes})` : ''}`,
-            );
-            // Also surface first finding outcome for test diagnosability
+          // 4) Budget-bounded read + format-bound parse (the single catalog reader)
+          const catalogResult = readCatalogForReg(canonicalPath, detectedFormat);
+          if (catalogResult.error || !catalogResult.catalog) {
+            messages.push(`錯誤：${catalogResult.error ?? 'catalog 解析失敗'}`);
             if (catalogResult.findings.length > 0) {
+              const detail = formatCatalogError(catalogResult.findings as any);
+              messages.push(
+                `錯誤：catalog 解析失敗：${detail} — catalog malformed`,
+              );
+              // Also surface first findings for diagnosability
               const extra = catalogResult.findings
                 .slice(0, 3)
                 .map((f) => `${f.code} ${f.outcome}`)
@@ -430,7 +460,7 @@ export async function runCommand(
             break;
           }
 
-          const catalog = catalogResult.catalog!;
+          const catalog = catalogResult.catalog;
 
           // 5) Persist registration
           const newReg = {
@@ -508,9 +538,13 @@ export async function runCommand(
             messages.push('錯誤：尚未註冊任何 marketplace，請先使用 `/codex-marketplace add <路徑>` 註冊');
             break;
           }
-          const enumeration = enumeratePlugins(state);
+          const { plugins: enumeration, catalogErrors } = enumeratePlugins(state);
+          const pushCatalogErrors = (): void => {
+            for (const e of catalogErrors) messages.push(`⚠ marketplace [${e.marketplace}] ${e.error}`);
+          };
           if (enumeration.length === 0) {
             messages.push('錯誤：目前沒有可安裝的 plugin（marketplace 內無可用 entry）');
+            pushCatalogErrors();
             break;
           }
 
@@ -521,6 +555,7 @@ export async function runCommand(
             target = enumeration.find((e) => e.number === num);
             if (!target) {
               messages.push(`錯誤：找不到編號 ${num} 對應的 plugin（可用編號 1–${enumeration.length}）`);
+              pushCatalogErrors();
               break;
             }
           } else {
@@ -529,6 +564,7 @@ export async function runCommand(
             if (candidates.length === 0) {
               // Also try to match manifestName of already installed? But enumeration already covers all catalog entries.
               messages.push(`錯誤：找不到名稱 "${arg}" 對應的 plugin`);
+              pushCatalogErrors();
               break;
             }
             if (candidates.length > 1) {
@@ -543,12 +579,14 @@ export async function runCommand(
           const targetReg = target.reg;
           const targetEntry = target.entry;
 
-          // ---- Step 1: contained path check ----
-          if (!targetEntry.path) {
-            messages.push(`錯誤：plugin "${target.pluginName}" 沒有可解析的本地路徑，無法安裝（unsupported source kind）`);
+          // ---- Step 1: Unavailable Entry refusal (#91) + contained path check ----
+          if (!entryLocallyInstallable(targetEntry)) {
+            messages.push(
+              `錯誤：plugin "${target.pluginName}" unavailable，無法安裝：${entryUnavailableReason(targetEntry)}`,
+            );
             break;
           }
-          const contained = resolveContained(targetReg.source, targetEntry.path, 'directory');
+          const contained = resolveContained(targetReg.source, targetEntry.path!, 'directory');
           if (contained.outcome.kind === 'blocking') {
             messages.push(`錯誤：plugin 路徑檢查失敗（Contained Path 違規）— ${contained.outcome.reason}`);
             break;

--- a/src/projection/exposure.ts
+++ b/src/projection/exposure.ts
@@ -124,27 +124,30 @@ function resolveEntryPluginDir(snapshotRoot: string, catalog: Catalog, installat
 /** Read each skills/<dir>/SKILL.md descriptor name exactly as Pi resolves it (frontmatter name, else directory name). */
 function skillCandidates(pluginDir: string, format: MarketplaceFormat = 'codex'): Array<{ name: string; skillDir: string }> {
   if (format === 'claude') {
+    // Declared manifest paths win; when absent or yielding nothing, fall through to the shared
+    // skills/ directory scan so convention-structured claude plugins project too (#91).
     const manifestPath = join(pluginDir, '.claude-plugin', 'plugin.json');
-    if (!existsSync(manifestPath) || !statSync(manifestPath).isFile()) return [];
-    let manifest: Record<string, unknown>;
-    try {
-      manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
-    } catch {
-      return [];
+    if (existsSync(manifestPath) && statSync(manifestPath).isFile()) {
+      try {
+        const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as Record<string, unknown>;
+        if (Array.isArray(manifest.skills)) {
+          const found: Array<{ name: string; skillDir: string }> = [];
+          for (const skillDecl of manifest.skills) {
+            if (typeof skillDecl !== 'string') continue;
+            const resolved = resolveContained(pluginDir, skillDecl, 'directory');
+            if (resolved.outcome.kind !== 'ok') continue;
+            const skillDir = resolved.outcome.canonicalPath;
+            const descriptor = join(skillDir, 'SKILL.md');
+            if (!existsSync(descriptor)) continue;
+            const name = descriptorSkillName(skillDir, descriptor);
+            if (name) found.push({ name, skillDir });
+          }
+          if (found.length > 0) return found;
+        }
+      } catch {
+        // fall through to directory scan
+      }
     }
-    if (!Array.isArray(manifest.skills)) return [];
-    const found: Array<{ name: string; skillDir: string }> = [];
-    for (const skillDecl of manifest.skills) {
-      if (typeof skillDecl !== 'string') continue;
-      const resolved = resolveContained(pluginDir, skillDecl, 'directory');
-      if (resolved.outcome.kind !== 'ok') continue;
-      const skillDir = resolved.outcome.canonicalPath;
-      const descriptor = join(skillDir, 'SKILL.md');
-      if (!existsSync(descriptor)) continue;
-      const name = descriptorSkillName(skillDir, descriptor);
-      if (name) found.push({ name, skillDir });
-    }
-    return found;
   }
 
   const skillsDir = join(pluginDir, 'skills');

--- a/src/registration/catalog.ts
+++ b/src/registration/catalog.ts
@@ -12,6 +12,15 @@ import { CODE, RULE, blocking, type ValidationFinding } from './findings.js';
 import { BUDGET } from './budget.js';
 import { parseGitEntrySpec } from './entry-acquisition.js';
 
+/**
+ * The disclosed Unavailable reason for git-family entries on the command surface: the minimal
+ * bridge performs no Entry Acquisition (spec #87 Out of Scope), so github/url/git-subdir entries
+ * are never locally installable. Single literal shared by both format contracts and the command
+ * surface (list display + install refusal).
+ */
+export const GIT_FAMILY_UNAVAILABLE_REASON =
+  'external git-family entry sources (github/url/git-subdir) are not supported yet';
+
 export type EntryType = 'local' | 'git' | 'unsupported';
 
 const LOCAL_KINDS = new Set(['local', 'directory', 'dir', 'file', 'path', 'src']);

--- a/src/registration/claude-catalog.ts
+++ b/src/registration/claude-catalog.ts
@@ -13,16 +13,25 @@
  * become Unavailable Entries with stable reasons; command sources are permanently disqualified.
  * No remote content is fetched anywhere in this module.
  *
- * Fail-closed field policy: every object this parser structurally interprets has a closed member
- * set. Unknown top-level/entry fields are Blocking; known Inert Metadata produces Validation
- * Warnings; named active-component declarations are Unsupported Blocking Findings. The sole
- * exception is the entry-level free-form `metadata` object, which Claude Code documents as
- * unread presentation data and which is therefore inert as a whole.
+ * Open field policy (#87 §7 / #91): unknown fields are always ignored and never block —
+ * including officially released claude fields such as `renames` and inert presentation metadata.
+ * Only the members this parser structurally interprets (`name`, `owner` identity, `metadata`
+ * shape, `plugins`, per-entry `source`/`strict`) are read; everything else is discarded. The
+ * v2 closed-field checks (unknown-field Blocking, inert-field Warnings, named active-component
+ * Blocking) have retired: the minimal install path records and projects skills only and never
+ * executes declared components, so they can neither deny Registration nor mark an entry
+ * Unavailable.
  */
 
-import { CODE, RULE, blocking, warning, type ValidationFinding } from './findings.js';
+import { CODE, RULE, blocking, type ValidationFinding } from './findings.js';
 import { BUDGET } from './budget.js';
-import { KEBAB_NAME_RE, type Catalog, type CatalogResult, type MarketplaceEntry } from './catalog.js';
+import {
+  KEBAB_NAME_RE,
+  GIT_FAMILY_UNAVAILABLE_REASON,
+  type Catalog,
+  type CatalogResult,
+  type MarketplaceEntry,
+} from './catalog.js';
 import { parseGitEntrySpec } from './entry-acquisition.js';
 
 /**
@@ -47,54 +56,13 @@ export const CLAUDE_UNAVAILABLE_REASON = {
   noSource: 'no source declared',
   unrecognizedForm: 'unrecognized source form',
   unknownKind: 'unknown entry source kind',
-  gitFamily: 'external git-family entry sources (github/url/git-subdir) are not supported yet',
+  gitFamily: GIT_FAMILY_UNAVAILABLE_REASON,
   npm: 'npm source entries are not supported',
   archive: 'archive source entries are not supported',
   command: 'command source entries are permanently disqualified',
   strictFalse: 'entry-defined plugin (strict: false) is not supported',
   malformedEntry: 'malformed entry',
 } as const;
-
-/** Closed top-level field set beyond the required name/owner/plugins. */
-const TOP_INERT_FIELDS = new Set(['$schema', 'description', 'version']);
-/** Structural objects descended into by this parser (closed member sets below). */
-const TOP_STRUCTURAL_FIELDS = new Set(['name', 'owner', 'plugins', 'metadata']);
-const METADATA_KNOWN_FIELDS = new Set(['pluginRoot', 'description', 'version']);
-const OWNER_KNOWN_FIELDS = new Set(['name', 'email', 'url']);
-
-/**
- * Entry-level fields that declare active behaviour (component configuration, archive credential
- * execution, or install-time enablement). Named Unsupported Active Components under Profile v2.
- */
-const ENTRY_ACTIVE_FIELDS = new Set([
-  'commands',
-  'agents',
-  'hooks',
-  'mcpServers',
-  'lspServers',
-  'skills',
-  'headers',
-  'headersHelper',
-  'defaultEnabled',
-]);
-
-/** Known inert entry-level presentation metadata (Validation Warning when present). */
-const ENTRY_INERT_FIELDS = new Set([
-  'displayName',
-  'description',
-  'version',
-  'author',
-  'homepage',
-  'repository',
-  'license',
-  'keywords',
-  'category',
-  'tags',
-  'relevance',
-  'metadata',
-]);
-/** Entry fields interpreted by this parser rather than classified as inert/active. */
-const ENTRY_INTERPRETED_FIELDS = new Set(['name', 'source', 'strict']);
 
 function catalogFinding(
   code: string,
@@ -203,13 +171,6 @@ export function parseClaudeCatalog(obj: unknown): CatalogResult {
       catalogFinding(CODE.CATALOG_OWNER_INVALID, RULE.CATALOG_OWNER_INVALID, '/owner', 'declared owner is missing or not an object'),
     );
   } else {
-    for (const key of Object.keys(o.owner)) {
-      if (!OWNER_KNOWN_FIELDS.has(key)) {
-        findings.push(
-          catalogFinding(CODE.CATALOG_UNKNOWN_FIELD, RULE.CATALOG_UNKNOWN_FIELD, `/owner/${key}`, `Unknown owner field '${key}' is fail-closed`),
-        );
-      }
-    }
     if (typeof o.owner.name !== 'string' || o.owner.name.trim().length === 0) {
       findings.push(
         catalogFinding(CODE.CATALOG_OWNER_INVALID, RULE.CATALOG_OWNER_INVALID, '/owner/name', 'owner requires a non-empty name'),
@@ -224,46 +185,9 @@ export function parseClaudeCatalog(obj: unknown): CatalogResult {
         catalogFinding(CODE.CATALOG_MALFORMED, RULE.CATALOG_MALFORMED, '/metadata', 'metadata must be an object when declared'),
       );
     } else {
-      for (const key of Object.keys(o.metadata).sort((a, b) => a.localeCompare(b))) {
-        if (!METADATA_KNOWN_FIELDS.has(key)) {
-          findings.push(
-            catalogFinding(CODE.CATALOG_UNKNOWN_FIELD, RULE.CATALOG_UNKNOWN_FIELD, `/metadata/${key}`, `Unknown metadata field '${key}' is fail-closed`),
-          );
-        } else if (key !== 'pluginRoot') {
-          findings.push(
-            warning({
-              code: CODE.INERT_METADATA_IGNORED,
-              rule: RULE.INERT_METADATA_IGNORED,
-              phase: 'validation',
-              target: 'catalog',
-              pointer: `/metadata/${key}`,
-              outcome: `Ignored Inert Metadata 'metadata.${key}' does not change catalog parsing`,
-            }),
-          );
-        }
-      }
+      // Open policy: only pluginRoot changes parsing; every other member is ignored.
       hasPluginRoot = typeof o.metadata.pluginRoot === 'string' && o.metadata.pluginRoot.length > 0;
     }
-  }
-
-  for (const key of Object.keys(o).sort((a, b) => a.localeCompare(b))) {
-    if (TOP_STRUCTURAL_FIELDS.has(key)) continue;
-    if (TOP_INERT_FIELDS.has(key)) {
-      findings.push(
-        warning({
-          code: CODE.INERT_METADATA_IGNORED,
-          rule: RULE.INERT_METADATA_IGNORED,
-          phase: 'validation',
-          target: 'catalog',
-          pointer: `/${key}`,
-          outcome: `Ignored Inert Metadata '${key}' does not change catalog parsing`,
-        }),
-      );
-      continue;
-    }
-    findings.push(
-      catalogFinding(CODE.CATALOG_UNKNOWN_FIELD, RULE.CATALOG_UNKNOWN_FIELD, `/${key}`, `Unknown catalog field '${key}' is fail-closed`),
-    );
   }
 
   if (!Array.isArray(o.plugins)) {
@@ -294,32 +218,6 @@ export function parseClaudeCatalog(obj: unknown): CatalogResult {
     }
     const e = entryRaw;
     const name = typeof e.name === 'string' ? e.name : undefined;
-
-    // Closed-field policy per entry: active components block, unknown fields block, known inert
-    // fields warn. `strict` is interpreted separately below.
-    for (const key of Object.keys(e).sort((a, b) => a.localeCompare(b))) {
-      if (ENTRY_INTERPRETED_FIELDS.has(key)) continue;
-      if (ENTRY_ACTIVE_FIELDS.has(key)) {
-        findings.push(
-          entryFinding(CODE.UNSUPPORTED_ACTIVE_COMPONENT, RULE.UNSUPPORTED_ACTIVE_COMPONENT, `${entryId}/${key}`, `Compatibility Profile v2 does not support active entry component '${key}'`),
-        );
-      } else if (ENTRY_INERT_FIELDS.has(key)) {
-        findings.push(
-          warning({
-            code: CODE.INERT_METADATA_IGNORED,
-            rule: RULE.INERT_METADATA_IGNORED,
-            phase: 'validation',
-            target: 'entry',
-            pointer: `${entryId}/${key}`,
-            outcome: `Ignored Inert Metadata '${key}' does not change entry availability`,
-          }),
-        );
-      } else {
-        findings.push(
-          entryFinding(CODE.CATALOG_UNKNOWN_FIELD, RULE.CATALOG_UNKNOWN_FIELD, `${entryId}/${key}`, `Unknown entry field '${key}' is fail-closed`),
-        );
-      }
-    }
 
     const resolved = classifySource(e.source, hasPluginRoot, entryId);
     if (resolved.findings && resolved.findings.length > 0) {

--- a/tests/unit/bridge/command-claude.test.ts
+++ b/tests/unit/bridge/command-claude.test.ts
@@ -1,0 +1,356 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { runCommand } from '../../../src/bridge/command.js';
+import { readMinimalBridgeState } from '../../../src/bridge/state.js';
+import { discoverProjectedSkillPaths } from '../../../src/projection/exposure.js';
+
+/** The command surface treats git-family entries as Unavailable (minimal bridge: local only). */
+const GIT_UNAVAILABLE_REASON =
+  'external git-family entry sources (github/url/git-subdir) are not supported yet';
+
+const BARE_NAME_REASON =
+  'bare name source cannot resolve without metadata.pluginRoot, which is unsupported';
+
+interface ClaudePluginSpec {
+  name: string;
+  /** Catalog `source` override (defaults to `./plugins/<name>`). */
+  source?: unknown;
+  /** Extra catalog entry fields (official or unknown — all ignored under the open policy). */
+  entryFields?: Record<string, unknown>;
+  /** Manifest body merged into `.claude-plugin/plugin.json` (defaults to `{ name }`). */
+  manifest?: Record<string, unknown>;
+  /** Declared `skills` array paths in the manifest (claude declared-paths style). */
+  manifestSkills?: string[];
+  /** Convention-based `skills/<name>/SKILL.md` directories. */
+  skills?: string[];
+}
+
+function writeSkill(pluginDir: string, skill: string): void {
+  const sdir = join(pluginDir, 'skills', skill);
+  mkdirSync(sdir, { recursive: true });
+  writeFileSync(
+    join(sdir, 'SKILL.md'),
+    `---\nname: ${skill}\ndescription: Desc for ${skill}\n---\n\nBody for ${skill}\n`,
+  );
+}
+
+/**
+ * Synthetic claude marketplace (#91): canonical `.claude-plugin/marketplace.json` carrying the
+ * officially released fields (`$schema`, `metadata`, `renames`) plus per-entry presentation and
+ * unknown fields — none of which may block registration.
+ */
+function makeClaudeMarketplace(
+  root: string,
+  name: string,
+  plugins: ClaudePluginSpec[],
+  catalogExtra: Record<string, unknown> = {},
+): void {
+  const entries = plugins.map((p) => ({
+    name: p.name,
+    source: p.source ?? `./plugins/${p.name}`,
+    ...(p.entryFields ?? {}),
+  }));
+  mkdirSync(join(root, '.claude-plugin'), { recursive: true });
+  writeFileSync(
+    join(root, '.claude-plugin', 'marketplace.json'),
+    JSON.stringify({
+      $schema: 'https://anthropic.com/claude-code/marketplace.schema.json',
+      name,
+      owner: { name: 'Acme Team', email: 'team@example.test' },
+      metadata: { description: 'synthetic claude marketplace' },
+      renames: { 'legacy-plugin': plugins[0]?.name ?? 'new-plugin' },
+      plugins: entries,
+      ...catalogExtra,
+    }),
+  );
+  for (const p of plugins) {
+    if (typeof p.source === 'string' && !p.source.startsWith('./')) continue;
+    const rel = typeof p.source === 'string' ? p.source : `./plugins/${p.name}`;
+    const abs = join(root, rel.replace(/^\.\//, ''));
+    mkdirSync(join(abs, '.claude-plugin'), { recursive: true });
+    const manifestBody: Record<string, unknown> = { name: p.name, ...(p.manifest ?? {}) };
+    if (p.manifestSkills) manifestBody.skills = p.manifestSkills.map((s) => `./skills/${s}`);
+    writeFileSync(join(abs, '.claude-plugin', 'plugin.json'), JSON.stringify(manifestBody));
+    for (const skill of p.skills ?? []) writeSkill(abs, skill);
+  }
+}
+
+describe('runCommand add/list/install 本機 claude marketplace（#91）', () => {
+  let tmpDir: string;
+  let statePath: string;
+  let mktRoot: string;
+  let agentDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'bridge-claude91-'));
+    statePath = join(tmpDir, 'state.json');
+    mktRoot = mkdtempSync(join(tmpdir(), 'mkt-claude91-'));
+    agentDir = mkdtempSync(join(tmpdir(), 'agent-claude91-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    rmSync(mktRoot, { recursive: true, force: true });
+    rmSync(agentDir, { recursive: true, force: true });
+  });
+
+  it('add 本機 claude marketplace（官方欄位 renames/metadata/$schema＋entry 未知欄位）→ 未知欄位不擋、偵測 claude、已註冊', async () => {
+    makeClaudeMarketplace(mktRoot, 'claude-market', [
+      { name: 'conv-plugin', skills: ['skill-a'] },
+      {
+        name: 'extra-fields',
+        skills: ['skill-b'],
+        entryFields: {
+          description: 'demo entry',
+          version: '1.0.0',
+          author: { name: 'A' },
+          keywords: ['x'],
+          preview: true,
+          defaultBranch: 'main',
+        },
+      },
+    ]);
+
+    const result = await runCommand(['add', mktRoot], { statePath });
+
+    expect(result.output).toContain('偵測：claude marketplace');
+    expect(result.output).toMatch(/2 plugins/);
+    expect(result.output).toContain('已註冊');
+    expect(result.output).toContain('claude-market');
+
+    const st = readMinimalBridgeState({ statePath });
+    expect(st.state.registrations).toHaveLength(1);
+    expect(st.state.registrations[0].marketplaceName).toBe('claude-market');
+    expect(st.state.registrations[0].format).toBe('claude');
+    expect(st.state.registrations[0].sourceKind).toBe('local');
+    expect(st.state.installations).toHaveLength(0);
+  });
+
+  it('list 顯示 claude plugins（編號／所屬 marketplace／可安裝）', async () => {
+    makeClaudeMarketplace(mktRoot, 'claude-market', [
+      { name: 'conv-plugin', skills: ['skill-a'] },
+      { name: 'conv-plugin-2', skills: ['skill-c'] },
+    ]);
+    await runCommand(['add', mktRoot], { statePath });
+
+    const list = await runCommand(['list'], { statePath });
+    expect(list.output).toContain('claude-market');
+    expect(list.output).toMatch(/1\s+conv-plugin\b/);
+    expect(list.output).toMatch(/2\s+conv-plugin-2\b/);
+    expect(list.output).toContain('可安裝');
+  });
+
+  it('install claude plugin（convention skills 目錄）→ 同一條 install 路徑：裝到最新＋自動啟用＋reload', async () => {
+    makeClaudeMarketplace(mktRoot, 'claude-market', [{ name: 'conv-plugin', skills: ['skill-a', 'skill-b'] }]);
+    await runCommand(['add', mktRoot], { statePath });
+
+    const res = await runCommand(['install', '1'], { statePath });
+
+    expect(res.output).toContain('安裝 "conv-plugin"');
+    expect(res.output).toContain('2 skills');
+    expect(res.output).toContain('skill-a');
+    expect(res.output).toContain('已重新載入生效');
+    expect(res.reload).toBe(true);
+
+    const st = readMinimalBridgeState({ statePath });
+    expect(st.state.installations).toHaveLength(1);
+    expect(st.state.installations[0].manifestName).toBe('conv-plugin');
+    expect(st.state.installations[0].skills).toEqual(['skill-a', 'skill-b'].sort());
+    expect(st.state.installations[0].enabled).toBe(true);
+  });
+
+  it('install claude plugin（manifest.skills 宣告路徑）→ 同一條 install 路徑', async () => {
+    makeClaudeMarketplace(mktRoot, 'claude-market', [
+      { name: 'declared-plugin', manifestSkills: ['skill-d'], skills: ['skill-d'] },
+    ]);
+    await runCommand(['add', mktRoot], { statePath });
+
+    const res = await runCommand(['install', 'declared-plugin'], { statePath });
+
+    expect(res.output).toContain('安裝 "declared-plugin"');
+    expect(res.output).toContain('1 skills');
+    expect(res.output).toContain('skill-d');
+    expect(res.output).toContain('已重新載入生效');
+    expect(res.reload).toBe(true);
+  });
+
+  it('claude 衝突清單語意與 codex 一致：同名 skill 列入「未投影（名稱衝突）」', async () => {
+    makeClaudeMarketplace(mktRoot, 'claude-market', [{ name: 'first', skills: ['shared-skill'] }]);
+    await runCommand(['add', mktRoot], { statePath });
+    await runCommand(['install', '1'], { statePath });
+
+    const mktRoot2 = mkdtempSync(join(tmpdir(), 'mkt-claude91-2-'));
+    try {
+      makeClaudeMarketplace(mktRoot2, 'claude-market-2', [{ name: 'second', skills: ['shared-skill', 'other-skill'] }]);
+      await runCommand(['add', mktRoot2], { statePath });
+      const res = await runCommand(['install', '2'], { statePath });
+
+      expect(res.output).toContain('安裝 "second"');
+      expect(res.output).toContain('未投影（名稱衝突）');
+      expect(res.output).toContain('shared-skill');
+      expect(res.output).not.toContain('other-skill 與既有同名');
+
+      const st = readMinimalBridgeState({ statePath });
+      expect(st.state.installations).toHaveLength(2);
+      expect(st.state.installations[1].skills).toContain('other-skill');
+    } finally {
+      rmSync(mktRoot2, { recursive: true, force: true });
+    }
+  });
+
+  it('claude 重複安裝＝重抓最新覆寫，不報錯（語意與 codex 一致）', async () => {
+    makeClaudeMarketplace(mktRoot, 'claude-market', [{ name: 'conv-plugin', skills: ['skill-a'] }]);
+    await runCommand(['add', mktRoot], { statePath });
+    await runCommand(['install', '1'], { statePath });
+
+    writeSkill(join(mktRoot, 'plugins', 'conv-plugin'), 'skill-new');
+    const res = await runCommand(['install', '1'], { statePath });
+
+    expect(res.output).toContain('2 skills');
+    expect(res.output).toContain('skill-new');
+    const st = readMinimalBridgeState({ statePath });
+    expect(st.state.installations).toHaveLength(1);
+    expect(st.state.installations[0].skills).toContain('skill-new');
+  });
+
+  it('e2e：install 後 discoverProjectedSkillPaths 投影 claude skill（convention 目錄與 manifest.skills 兩形皆可）', async () => {
+    makeClaudeMarketplace(mktRoot, 'claude-market', [
+      { name: 'conv-plugin', skills: ['conv-skill'] },
+      { name: 'declared-plugin', manifestSkills: ['declared-skill'], skills: ['declared-skill'] },
+    ]);
+    let res = await runCommand(['add', mktRoot], { agentDir });
+    expect(res.output).toContain('已註冊');
+    res = await runCommand(['install', '1'], { agentDir });
+    expect(res.output).toContain('已重新載入生效');
+    expect(res.reload).toBe(true);
+    res = await runCommand(['install', '2'], { agentDir });
+    expect(res.output).toContain('已重新載入生效');
+
+    const proj = discoverProjectedSkillPaths({ agentDir });
+    expect(proj.skillPaths.some((p) => p.includes('conv-skill'))).toBe(true);
+    expect(proj.skillPaths.some((p) => p.includes('declared-skill'))).toBe(true);
+  });
+
+  it('catalog 內 git 型／不支援 source 型 entry → list 顯示 unavailable＋原因，install 不給裝', async () => {
+    makeClaudeMarketplace(mktRoot, 'claude-unavailable', [
+      { name: 'local-ok', skills: ['skill-a'] },
+      { name: 'git-one', source: { source: 'github', repo: 'owner/repo' } },
+      { name: 'npm-one', source: { source: 'npm', package: '@scope/pkg' } },
+      { name: 'bare-one', source: 'formatter' },
+      { name: 'defined-here', source: './plugins/defined-here', entryFields: { strict: false } },
+    ]);
+    await runCommand(['add', mktRoot], { statePath });
+
+    const list = await runCommand(['list'], { statePath });
+    expect(list.output).toContain('unavailable');
+    expect(list.output).toContain(GIT_UNAVAILABLE_REASON);
+    expect(list.output).toContain('npm source entries are not supported');
+    expect(list.output).toContain(BARE_NAME_REASON);
+    expect(list.output).toContain('entry-defined plugin (strict: false) is not supported');
+    // the local entry stays installable
+    expect(list.output).toMatch(/1\s+local-ok\b[\s\S]*可安裝/);
+
+    // install by name → refused with the disclosed reason
+    const byName = await runCommand(['install', 'git-one'], { statePath });
+    expect(byName.output).toContain('unavailable');
+    expect(byName.output).toContain(GIT_UNAVAILABLE_REASON);
+    expect(byName.reload).toBe(false);
+
+    // install by number → refused with the disclosed reason
+    const byNumber = await runCommand(['install', '3'], { statePath });
+    expect(byNumber.output).toContain('unavailable');
+    expect(byNumber.output).toContain('npm source entries are not supported');
+
+    const st = readMinimalBridgeState({ statePath });
+    expect(st.state.installations).toHaveLength(0);
+  });
+
+  it('catalog 缺失／malformed／超上限／name 非法 → add 顯示錯誤，不註冊', async () => {
+    // missing catalog
+    const missing = await runCommand(['add', mktRoot], { statePath });
+    expect(missing.output).toMatch(/catalog.*缺失|找不到.*catalog/i);
+    expect(readMinimalBridgeState({ statePath }).state.registrations).toHaveLength(0);
+
+    // malformed JSON
+    mkdirSync(join(mktRoot, '.claude-plugin'), { recursive: true });
+    writeFileSync(join(mktRoot, '.claude-plugin', 'marketplace.json'), '{ malformed claude json,,');
+    const malformed = await runCommand(['add', mktRoot], { statePath });
+    expect(malformed.output).toMatch(/解析失敗|malformed/i);
+    expect(readMinimalBridgeState({ statePath }).state.registrations).toHaveLength(0);
+
+    // invalid marketplace name
+    writeFileSync(
+      join(mktRoot, '.claude-plugin', 'marketplace.json'),
+      JSON.stringify({ name: 'Bad Name', owner: { name: 'o' }, plugins: [] }),
+    );
+    const badName = await runCommand(['add', mktRoot], { statePath });
+    expect(badName.output).toMatch(/錯誤.*catalog|解析失敗/i);
+    expect(readMinimalBridgeState({ statePath }).state.registrations).toHaveLength(0);
+
+    // over Validation Budget (entries > 1024)
+    writeFileSync(
+      join(mktRoot, '.claude-plugin', 'marketplace.json'),
+      JSON.stringify({
+        name: 'huge-market',
+        owner: { name: 'o' },
+        plugins: Array.from({ length: 1025 }, (_, i) => ({ name: `p${i}`, source: './p' })),
+      }),
+    );
+    const over = await runCommand(['add', mktRoot], { statePath });
+    expect(over.output).toMatch(/超過.*上限|BUDGET_EXCEEDED|解析失敗/i);
+    expect(readMinimalBridgeState({ statePath }).state.registrations).toHaveLength(0);
+  });
+
+  it('已註冊後 catalog 壞掉 → list/install 顯示錯誤，不靜默略過', async () => {
+    makeClaudeMarketplace(mktRoot, 'claude-market', [{ name: 'conv-plugin', skills: ['skill-a'] }]);
+    await runCommand(['add', mktRoot], { statePath });
+
+    writeFileSync(join(mktRoot, '.claude-plugin', 'marketplace.json'), '{ broken after registration');
+    const list = await runCommand(['list'], { statePath });
+    expect(list.output).toMatch(/解析失敗|malformed/i);
+
+    const inst = await runCommand(['install', '1'], { statePath });
+    expect(inst.output).toMatch(/解析失敗|malformed/i);
+    expect(inst.reload).toBe(false);
+  });
+
+  it('同資料夾雙格式並存 → codex 優先偵測', async () => {
+    makeClaudeMarketplace(mktRoot, 'claude-side', [{ name: 'claude-plugin', skills: ['skill-a'] }]);
+    mkdirSync(join(mktRoot, '.agents', 'plugins'), { recursive: true });
+    writeFileSync(
+      join(mktRoot, '.agents', 'plugins', 'marketplace.json'),
+      JSON.stringify({
+        name: 'codex-side',
+        plugins: [{ name: 'codex-plugin', source: { source: 'local', path: './plugins/codex-plugin' } }],
+      }),
+    );
+    const codexPluginDir = join(mktRoot, 'plugins', 'codex-plugin');
+    mkdirSync(codexPluginDir, { recursive: true });
+    writeFileSync(join(codexPluginDir, 'plugin.json'), JSON.stringify({ name: 'codex-plugin' }));
+
+    const res = await runCommand(['add', mktRoot], { statePath });
+
+    expect(res.output).toContain('偵測：codex marketplace');
+    expect(res.output).toContain('codex-side');
+    const st = readMinimalBridgeState({ statePath });
+    expect(st.state.registrations).toHaveLength(1);
+    expect(st.state.registrations[0].format).toBe('codex');
+    expect(st.state.registrations[0].marketplaceName).toBe('codex-side');
+  });
+
+  it('claude plugin 安裝記錄寫入 state.json（縫層斷言）', async () => {
+    makeClaudeMarketplace(mktRoot, 'claude-market', [{ name: 'conv-plugin', skills: ['skill-a'] }]);
+    await runCommand(['add', mktRoot], { statePath });
+    await runCommand(['install', '1'], { statePath });
+
+    const raw = JSON.parse(readFileSync(statePath, 'utf-8')) as { registrations: unknown[]; installations: Array<Record<string, unknown>> };
+    expect(raw.installations).toHaveLength(1);
+    expect(raw.installations[0].manifestName).toBe('conv-plugin');
+    expect(raw.installations[0].sourceKind).toBe('local');
+    const st = readMinimalBridgeState({ statePath });
+    expect(st.state.installations[0].registrationId).toBe(st.state.registrations[0].id);
+  });
+});

--- a/tests/unit/registration/claude-catalog.test.ts
+++ b/tests/unit/registration/claude-catalog.test.ts
@@ -111,72 +111,58 @@ describe('Claude catalog required fields fail closed (Blocking)', () => {
   }
 });
 
-describe('Unknown catalog fields are fail-closed Blocking', () => {
-  it('blocks unknown top-level fields (including documented-but-unreviewed lifecycle features)', () => {
-    for (const field of ['renames', 'allowCrossMarketplaceDependenciesOn', 'totally-unknown']) {
-      const res = parseClaudeCatalog(validCatalog({ extraTopLevel: { [field]: {} } }));
-      expect(res.ok).toBe(false);
-      expect(res.findings).toEqual([
-        expect.objectContaining({
-          code: 'CATALOG_UNKNOWN_FIELD',
-          classification: 'blocking',
-          phase: 'validation',
-          target: 'catalog',
-          pointer: `/${field}`,
-          rule: 'CAT-05',
-        }),
-      ]);
+describe('Unknown catalog fields are ignored under the open policy (#91)', () => {
+  it('ignores unknown top-level fields including the officially released claude renames field', () => {
+    const fields: Array<[string, unknown]> = [
+      ['renames', { 'old-name': 'new-name' }],
+      ['allowCrossMarketplaceDependenciesOn', true],
+      ['totally-unknown', { nested: { deep: true } }],
+    ];
+    for (const [field, value] of fields) {
+      const res = parseClaudeCatalog(validCatalog({ extraTopLevel: { [field]: value } }));
+      expect(res.ok).toBe(true);
+      expect(res.findings).toEqual([]);
+      expect(res.catalog!.entries[0]).toMatchObject({ available: true, path: './plugins/alpha' });
     }
   });
 
-  it('blocks unknown members inside the structural metadata object', () => {
+  it('ignores unknown members inside the structural metadata object while keeping pluginRoot interpretation', () => {
     const res = parseClaudeCatalog(
-      validCatalog({ extraTopLevel: { metadata: { pluginRoot: './plugins', rogue: true } } }),
-    );
-    expect(res.ok).toBe(false);
-    expect(res.findings).toEqual([
-      expect.objectContaining({
-        code: 'CATALOG_UNKNOWN_FIELD',
-        classification: 'blocking',
-        pointer: '/metadata/rogue',
+      validCatalog({
+        plugins: [
+          { name: 'direct', source: './plugins/direct' },
+          { name: 'bare', source: 'bare' },
+        ],
+        extraTopLevel: { metadata: { pluginRoot: './plugins', rogue: true } },
       }),
-    ]);
+    );
+    expect(res.ok).toBe(true);
+    expect(res.findings).toEqual([]);
+    expect(res.catalog!.entries[1]).toMatchObject({ available: false, unavailableReason: REASON.pluginRoot });
   });
 
-  it('blocks unknown members inside the owner object', () => {
+  it('ignores unknown members inside the owner object', () => {
     const res = parseClaudeCatalog({
       name: 'acme-claude',
       owner: { name: 'Acme', sponsorLink: 'https://example.test' },
       plugins: [],
     });
-    expect(res.ok).toBe(false);
-    expect(res.findings).toEqual([
-      expect.objectContaining({
-        code: 'CATALOG_UNKNOWN_FIELD',
-        classification: 'blocking',
-        pointer: '/owner/sponsorLink',
-      }),
-    ]);
+    expect(res.ok).toBe(true);
+    expect(res.findings).toEqual([]);
   });
 
-  it('blocks unknown entry-level fields', () => {
+  it('ignores unknown entry-level fields', () => {
     const res = parseClaudeCatalog(
-      validCatalog({ plugins: [{ name: 'alpha', source: './a', defaultBranch: 'main' }] }),
+      validCatalog({ plugins: [{ name: 'alpha', source: './a', defaultBranch: 'main', preview: true }] }),
     );
-    expect(res.ok).toBe(false);
-    expect(res.findings).toEqual([
-      expect.objectContaining({
-        code: 'CATALOG_UNKNOWN_FIELD',
-        classification: 'blocking',
-        target: 'entry',
-        pointer: '/plugins/0/defaultBranch',
-      }),
-    ]);
+    expect(res.ok).toBe(true);
+    expect(res.findings).toEqual([]);
+    expect(res.catalog!.entries[0]).toMatchObject({ available: true, path: './a' });
   });
 });
 
-describe('Known Inert Metadata produces Validation Warnings only', () => {
-  it('warns on inert top-level presentation fields and stays non-blocking', () => {
+describe('Known inert fields are silently ignored under the open policy (#91)', () => {
+  it('ignores inert top-level presentation fields without findings', () => {
     const res = parseClaudeCatalog(
       validCatalog({
         extraTopLevel: {
@@ -187,11 +173,10 @@ describe('Known Inert Metadata produces Validation Warnings only', () => {
       }),
     );
     expect(res.ok).toBe(true);
-    expect(res.findings.map((f) => f.code)).toEqual(['INERT_METADATA_IGNORED', 'INERT_METADATA_IGNORED', 'INERT_METADATA_IGNORED']);
-    expect(res.findings.every((f) => f.classification === 'warning')).toBe(true);
+    expect(res.findings).toEqual([]);
   });
 
-  it('warns on inert entry fields (including free-form entry metadata) and stays non-blocking', () => {
+  it('ignores inert entry fields (including free-form entry metadata) without findings', () => {
     const res = parseClaudeCatalog(
       validCatalog({
         plugins: [
@@ -215,36 +200,38 @@ describe('Known Inert Metadata produces Validation Warnings only', () => {
       }),
     );
     expect(res.ok).toBe(true);
-    expect(res.findings.length).toBeGreaterThan(0);
-    expect(res.findings.every((f) => f.code === 'INERT_METADATA_IGNORED' && f.classification === 'warning')).toBe(true);
+    expect(res.findings).toEqual([]);
     expect(res.catalog!.entries[0].available).toBe(true);
   });
 
-  it('does not warn when a claude catalog carries only required fields', () => {
+  it('produces no findings when a claude catalog carries only required fields', () => {
     const res = parseClaudeCatalog(validCatalog());
+    expect(res.ok).toBe(true);
+    expect(res.findings).toEqual([]);
+  });
+
+  it('treats metadata.description/version as ignored backward-compat members', () => {
+    const res = parseClaudeCatalog(
+      validCatalog({ extraTopLevel: { metadata: { description: 'd', version: '2.0.0' } } }),
+    );
     expect(res.ok).toBe(true);
     expect(res.findings).toEqual([]);
   });
 });
 
-describe('Entry active-component declarations are Unsupported Blocking Findings', () => {
+describe('Entry active-component declarations are ignored under the open policy (#91)', () => {
+  // Minimal bridge installs only record and project skills; nothing executes, so entry-level
+  // component declarations neither block Registration nor mark the entry Unavailable.
   const components = ['commands', 'agents', 'hooks', 'mcpServers', 'lspServers', 'skills', 'headers', 'headersHelper', 'defaultEnabled'];
 
   for (const component of components) {
-    it(`blocks entry component '${component}'`, () => {
+    it(`ignores entry component '${component}' and keeps the entry available`, () => {
       const res = parseClaudeCatalog(
         validCatalog({ plugins: [{ name: 'alpha', source: './a', [component]: ['./x'] }] }),
       );
-      expect(res.ok).toBe(false);
-      expect(res.findings).toEqual([
-        expect.objectContaining({
-          code: 'UNSUPPORTED_ACTIVE_COMPONENT',
-          classification: 'blocking',
-          target: 'entry',
-          pointer: `/plugins/0/${component}`,
-          rule: 'COMP-03',
-        }),
-      ]);
+      expect(res.ok).toBe(true);
+      expect(res.findings).toEqual([]);
+      expect(res.catalog!.entries[0]).toMatchObject({ available: true, path: './a' });
     });
   }
 });

--- a/tests/unit/registration/flow.test.ts
+++ b/tests/unit/registration/flow.test.ts
@@ -393,8 +393,8 @@ describe('Marketplace Format detection wiring — local registration', () => {
     if (outcome.status !== 'completed') return;
     expect(outcome.registration.format).toBe('claude');
     expect(outcome.receipt.marketplaceFormat).toBe('claude');
-    // inert entry metadata (description) is disclosed as a Validation Warning
-    expect(outcome.receipt.summary).toBe('Completed with diagnostics');
+    // open policy (#91): inert entry metadata (description) no longer produces a warning
+    expect(outcome.receipt.summary).toBe('Completed');
 
     const state = await readBridgeState({ agentDir: env.agentDir });
     expect(state.state!.registrations[0].format).toBe('claude');
@@ -429,7 +429,7 @@ describe('Marketplace Format detection wiring — local registration', () => {
     expect(res.outcome.findings[0].code).toBe('CATALOG_MISSING');
   });
 
-  it('parses claude catalogs under their fail-closed field policy when format=claude', async () => {
+  it('ignores unknown claude catalog fields under the open policy when format=claude (#91)', async () => {
     makeClaudeMarketplace(root);
     writeFileSync(
       join(root, '.claude-plugin', 'marketplace.json'),
@@ -440,10 +440,9 @@ describe('Marketplace Format detection wiring — local registration', () => {
       }),
     );
     const res = await preflightLocalRegistration(root, opts(env));
-    expect(res.ok).toBe(false);
-    if (res.ok) return;
-    expect(res.outcome.status).toBe('blocked');
-    if (res.outcome.status !== 'blocked') return;
-    expect(res.outcome.findings.some((f) => f.code === 'CATALOG_UNKNOWN_FIELD')).toBe(true);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.preflight.format).toBe('claude');
+    cancelLocalRegistration(res.preflight);
   });
 });

--- a/tests/unit/registration/format.test.ts
+++ b/tests/unit/registration/format.test.ts
@@ -80,11 +80,11 @@ describe('Marketplace Format detection', () => {
     const claude = catalogContractFor('claude');
     expect(claude.relPath).toBe(CLAUDE_MARKETPLACE_CATALOG_RELPATH);
 
-    // The parser dispatch honors the closed field policy of each shape.
+    // The parser dispatch honors the open field policy of each shape (#91): unknown fields never block.
     const claudeParsed = claude.parse({ name: 'acme', owner: { name: 'o' }, plugins: [] });
     expect(claudeParsed.ok).toBe(true);
     const claudeUnknown = claude.parse({ name: 'acme', owner: { name: 'o' }, plugins: [], rogue: 1 });
-    expect(claudeUnknown.ok).toBe(false);
+    expect(claudeUnknown.ok).toBe(true);
 
     const codexParsed = codex.parse({ name: 'acme', plugins: [] });
     expect(codexParsed.ok).toBe(true);


### PR DESCRIPTION
Closes #91
Parent #87

本票交付 claude 雙格式 open 政策：claude marketplace 也能註冊、列出、安裝，雙格式（codex/claude）解析鏈統一輸出、政策統一 open。

- **claude catalog open 欄位政策（#87 §7）**：未知欄位一律忽略、不 block，含 claude 官方已問世的 `renames`、`$schema`、`metadata` 等欄位；v2 closed-field 檢查（未知欄位 Blocking／inert Warning／active component Blocking）整層退場——極簡安裝路徑只記錄與投影 skills、不執行任何元件，欄位既不擋註冊也不標 Unavailable
- **runCommand add/list/install 支援本機 claude marketplace**：與 codex 同一條解析鏈（`catalogContractFor(format)`）與同一條 install 路徑（contained path → manifest name → skills 推導 → 碰撞檢測 → 寫入 enabled installation → `reload` 旗標）
- **unavailable entry 揭露**：catalog 內 git 型／不支援 source 型 entry（npm/archive/command/bare name/`strict:false`）→ `list` 顯示 `unavailable（原因）`、`install` 拒絕不給裝；git-family reason 收斂為單一字面常數 `GIT_FAMILY_UNAVAILABLE_REASON`（雙格式共用）
- **讀取錯誤不靜默**：catalog 缺失／malformed／超上限／name 非法 → `add` 顯示錯誤不註冊；已註冊後 catalog 壞掉 → `list`/`install` 揭露 `⚠ marketplace [x] …` 錯誤行且不給裝（壞 catalog 不再貢獻 entries）
- **雙格式並存 → codex 優先**：`detectMarketplaceFormat` 固定 codex→claude 偵測順序（不變，測試釘住）
- **claude 技能投影補齊**：`exposure.ts` 的 claude 技能推導改為 manifest.skills 宣告優先、缺席時 fallback 掃描 `skills/` 目錄——convention 形 claude plugin 安裝後 `resources_discover` 立即可見（與 install 記錄的 skills 一致）

### 變更項目

- **`src/registration/claude-catalog.ts`**：移除 closed-field 檢查（`CATALOG_UNKNOWN_FIELD`／`INERT_METADATA_IGNORED`／`UNSUPPORTED_ACTIVE_COMPONENT` 全部退場），僅解讀 `name`／`owner` 身分／`metadata` 形狀（`pluginRoot` 解釋保留）／`plugins`／entry `source`/`strict`；其余員一律忽略。結構性阻擋（root 非物件、name 非法、owner 缺失、plugins 非陣列、超上限、entry 非物件）維持不變
- **`src/registration/catalog.ts`**：新增 `GIT_FAMILY_UNAVAILABLE_REASON` 共用常數，`claude-catalog.ts` 的 `gitFamily` reason 改引用
- **`src/bridge/command.ts`**：
  - `readCatalogForReg`：命令面的單一 catalog 讀取器（budget 上限＋格式綁定解析），讀取失敗回傳揭露用 `error`、不再靜默回空
  - `enumeratePlugins`：回傳 plugins＋catalogErrors；`entryLocallyInstallable`／`entryUnavailableReason` 將 git 型／不支援型 entry 統一轉 `unavailable＋原因`
  - `list`：狀態顯示新增 `unavailable（原因）`，錯誤以 `⚠ marketplace [x] …` 行揭露
  - `install`：unavailable entry 拒絕（`錯誤：plugin "x" unavailable，無法安裝：<原因>`）；讀取錯誤隨「找不到」路徑一併揭露
  - `add`：改用共用讀取器，錯誤訊息與 `詳細：` finding 輸出保留
- **`src/projection/exposure.ts`**：claude `skillCandidates` 改為 manifest.skills 宣告優先、無宣告或推導為空時 fallback `skills/` 目錄掃描（與 `collectSkillNames` 一致）
- **`tests/unit/bridge/command-claude.test.ts`（新增 12 測試）**：合成 claude fixture（含 `renames`/`$schema`/`metadata`/entry 未知欄位）add/list/install 全鏈、convention 與 manifest.skills 兩形安裝、衝突清單、覆寫語意、unavailable 矩陣、讀取錯誤、雙格式 codex 優先、e2e 投影

### 驗證

- `npm run typecheck` ✅
- `npm test` ✅ 全套件 62 檔 / 825 tests 全綠（含既有 registration／flow／claude-lifecycle／acceptance／e2e）

### Acceptance criteria 對照

| #91 驗收條件 | 狀態 | 驗證落點 |
|---|---|---|
| 本機 claude marketplace 可 add／list／install（合成 fixture；含官方已問世欄位，未知欄位不擋） | ✅ | `command-claude.test.ts` `add 本機 claude marketplace（官方欄位 renames/metadata/$schema＋entry 未知欄位）…` ＋ `list 顯示 claude plugins…` |
| claude plugin 安裝走同一條 install 路徑（啟用＋投影＋reload＋衝突清單語意一致） | ✅ | `install claude plugin（convention skills 目錄）…`、`manifest.skills 宣告路徑`、`claude 衝突清單語意與 codex 一致`、`claude 重複安裝＝重抓最新覆寫` |
| catalog 內 git 型／不支援 source 型 entry → unavailable＋原因，不給裝 | ✅ | `catalog 內 git 型／不支援 source 型 entry → list 顯示 unavailable＋原因，install 不給裝` |
| catalog 缺失／malformed／超上限／name 非法 → 顯示錯誤，不靜默略過 | ✅ | `catalog 缺失／malformed／超上限／name 非法 → add 顯示錯誤，不註冊` ＋ `已註冊後 catalog 壞掉 → list/install 顯示錯誤` |
| 同資料夾雙格式並存 → codex 優先偵測 | ✅ | `同資料夾雙格式並存 → codex 優先偵測` |
| 走 runCommand 縫測試 | ✅ | 全數經 `runCommand({statePath|agentDir})` 純函式縫，e2e 投影經 `discoverProjectedSkillPaths` |
