### PR TITLE
feat: disable/enable/remove/forget＋總覽狀態 (#93)

### DIFF
--- a/src/bridge/command.ts
+++ b/src/bridge/command.ts
@@ -142,7 +142,7 @@ function formatOverview(state: MinimalBridgeState): string[] {
       const mktPadded = padRight(mkt, 18);
       const skillCount = inst.skills ? inst.skills.length : 0;
       const skillsStr = `${skillCount} skills`;
-      const isEnabled = inst.enabled !== false && inst.installationState !== 'disabled';
+      const isEnabled = isInstallationEnabled(inst as any);
       const stateStr = isEnabled ? '啟用' : '停用';
       installedLines.push(`${name}${mktPadded}${skillsStr} · ${stateStr}`);
     });
@@ -282,7 +282,7 @@ function enumeratePlugins(state: MinimalBridgeState, opts: CommandOptions = {}):
         status = 'unavailable';
         unavailableReason = entryUnavailableReason(entry);
       } else if (!inst) status = '可安裝';
-      else if (inst.enabled !== false && inst.installationState !== 'disabled') status = '已裝啟用';
+      else if (isInstallationEnabled(inst as any)) status = '已裝啟用';
       else status = '已裝停用';
       result.push({ number: counter, reg, entry, pluginName, status, unavailableReason });
       counter++;
@@ -322,6 +322,101 @@ function formatPluginListLines(state: MinimalBridgeState, filter?: string, opts:
   }
   lines.push(...errorLines);
   return lines;
+}
+
+// ---- Lifecycle helpers (#93 maintainability, P0/P1) ----
+
+function isInstallationEnabled(inst: MinimalBridgeState['installations'][number]): boolean {
+  return (inst as any).enabled !== false && (inst as any).installationState !== 'disabled';
+}
+
+function setInstallationEnabled(inst: MinimalBridgeState['installations'][number], enabled: boolean): void {
+  (inst as any).enabled = enabled;
+  (inst as any).installationState = enabled ? 'enabled' : 'disabled';
+}
+
+function matchesInstallation(inst: MinimalBridgeState['installations'][number], name: string): boolean {
+  return inst.manifestName === name || inst.pluginId === name || inst.id === name;
+}
+
+function matchesRegistration(reg: MinimalBridgeState['registrations'][number], name: string): boolean {
+  return reg.marketplaceName === name || reg.alias === name || reg.id === name;
+}
+
+function findInstallationIndex(state: MinimalBridgeState, name: string): number {
+  return state.installations.findIndex((i) => matchesInstallation(i, name));
+}
+
+function findInstallationsByName(state: MinimalBridgeState, name: string): MinimalBridgeState['installations'] {
+  return state.installations.filter((i) => matchesInstallation(i, name));
+}
+
+function findRegistrationsByName(state: MinimalBridgeState, name: string): MinimalBridgeState['registrations'] {
+  return state.registrations.filter((r) => matchesRegistration(r, name));
+}
+
+function findRegistrationIndex(state: MinimalBridgeState, name: string): number {
+  return state.registrations.findIndex((r) => matchesRegistration(r, name));
+}
+
+/**
+ * Best-effort refresh for enable: mirrors install Step1-3 (sourceRoot -> catalogRoot -> readCatalog -> entry -> resolveContained -> collectSkillNames).
+ * Returns undefined on any missing cache/catalog/entry/path — caller falls back to stored skills.
+ * Pure-logic branches (find/entry.path/resolveContained outcome) do not throw; only I/O (readCatalogForReg/collectSkillNames) is try/catch guarded.
+ */
+function tryRefreshSkills(
+  reg: MinimalBridgeState['registrations'][number],
+  inst: MinimalBridgeState['installations'][number],
+  opts: CommandOptions,
+): string[] | undefined {
+  const sourceRoot = sourceRootForReg(reg, opts);
+  const catalogRoot = catalogRootForReg(reg, opts);
+  if (!sourceRoot || !catalogRoot) return undefined;
+  let read: CatalogReadResult | undefined;
+  try {
+    read = readCatalogForReg(catalogRoot, reg.format ?? 'codex');
+  } catch {
+    // best-effort: catalog 讀取/解析失敗（cache 缺失或損毀）則沿用舊 skills
+    return undefined;
+  }
+  if (read.error || !read.catalog) return undefined;
+  const entry =
+    read.catalog.entries.find((e) => e.name === inst.manifestName && e.type === 'local' && e.path) ??
+    read.catalog.entries.find((e) => e.name === inst.manifestName && e.path) ??
+    read.catalog.entries.find((e) => e.path && basename(e.path) === inst.manifestName && e.type === 'local');
+  if (!entry?.path) return undefined;
+  const contained = resolveContained(sourceRoot, entry.path, 'directory');
+  if (contained.outcome.kind !== 'ok') return undefined;
+  try {
+    return collectSkillNames(contained.outcome.canonicalPath, (reg.format ?? 'codex') as 'codex' | 'claude');
+  } catch {
+    // best-effort: 目錄掃描失敗則沿用舊 skills
+    return undefined;
+  }
+}
+
+function detectCollidingSkills(
+  skillList: string[],
+  installations: MinimalBridgeState['installations'],
+  isExcluded?: (inst: MinimalBridgeState['installations'][number]) => boolean,
+): string[] {
+  const existing = new Map<string, number>();
+  for (const other of installations) {
+    if (isExcluded?.(other)) continue;
+    if (!isInstallationEnabled(other)) continue;
+    for (const s of (other as any).skills ?? []) existing.set(s, (existing.get(s) ?? 0) + 1);
+  }
+  return [...new Set(skillList.filter((s) => existing.has(s)))].sort((a, b) => a.localeCompare(b));
+}
+
+function tryWriteState(state: MinimalBridgeState, opts: CommandOptions): string | undefined {
+  try {
+    writeMinimalBridgeState(state, opts);
+    return undefined;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return msg;
+  }
 }
 
 // ---- Skill discovery helpers ----
@@ -797,35 +892,20 @@ export async function runCommand(
           const skillNames = collectSkillNames(pluginDir, format);
 
           // ---- Step 4: collision detection (同名衝突) ----
-          // Collect existing skill names from other enabled installations
-          const existingSkillCounts = new Map<string, number>();
-          // Also include other installations' skills
-          for (const inst of state.installations) {
-            const isEnabled = inst.enabled !== false && inst.installationState !== 'disabled';
-            if (!isEnabled) continue;
-            // For re-install of same plugin, exclude self from collision count temporarily
-            if (inst.registrationId === targetReg.id && (inst.manifestName === manifestName || inst.pluginId === manifestName)) {
-              continue;
-            }
-            if (!inst.skills) continue;
-            for (const s of inst.skills) {
-              existingSkillCounts.set(s, (existingSkillCounts.get(s) ?? 0) + 1);
-            }
-          }
-          // Now for the new plugin's skills, determine colliding ones
-          const colliding: string[] = [];
-          const projectedForThisInstall: string[] = [];
+          // 以 helper 收斂重複邏輯：僅純邏輯，排除同 plugin 的重裝自身
+          const colliding = detectCollidingSkills(
+            skillNames,
+            state.installations,
+            (other) =>
+              other.registrationId === targetReg.id &&
+              (other.manifestName === manifestName || other.pluginId === manifestName),
+          );
+          // 同 plugin 內重複 skill 亦視為衝突（全拒）
           for (const s of skillNames) {
-            if (existingSkillCounts.has(s)) {
-              colliding.push(s);
-            } else {
-              // also check duplicate within same plugin? Collect within-plugin duplicates as colliding (all denied)
-              // For now, if skillNames has duplicates, treat as colliding.
-              const dupInSelf = skillNames.filter((x) => x === s).length > 1;
-              if (dupInSelf) colliding.push(s);
-              else projectedForThisInstall.push(s);
-            }
+            const dupInSelf = skillNames.filter((x) => x === s).length > 1;
+            if (dupInSelf && !colliding.includes(s)) colliding.push(s);
           }
+          colliding.sort((a, b) => a.localeCompare(b));
           // For all-denied policy, if a new skill collides, existing holder also becomes denied, but we only list new's colliding.
 
           // ---- Step 5: write enabled installation record (重抓最新覆寫) ----
@@ -904,27 +984,27 @@ export async function runCommand(
           messages.push('用法：/codex-marketplace disable <名稱>');
         } else {
           const name = subargs[0];
-          const idx = state.installations.findIndex(
-            (i) => i.manifestName === name || i.pluginId === name || i.id === name,
-          );
-          if (idx === -1) {
+          const matches = findInstallationsByName(state, name);
+          if (matches.length === 0) {
             messages.push(`錯誤：找不到已安裝的 plugin "${name}"`);
+          } else if (matches.length > 1) {
+            const list = matches.map((m) => `${m.manifestName}[${m.registrationId}]`).join('、');
+            messages.push(`錯誤：名稱 "${name}" 對應多個已安裝 plugin（${list}），請改用更精確的識別`);
           } else {
-            const inst = state.installations[idx];
-            const isDisabled = inst.enabled === false || inst.installationState === 'disabled';
-            if (isDisabled) {
+            const target = matches[0];
+            const idx = state.installations.indexOf(target);
+            const inst = target;
+            if (!isInstallationEnabled(inst as any)) {
               messages.push(`"${name}" 已是停用狀態`);
             } else {
               const backup = { ...inst };
-              (inst as any).enabled = false;
-              (inst as any).installationState = 'disabled';
-              try {
-                writeMinimalBridgeState(state, opts);
+              setInstallationEnabled(inst as any, false);
+              const writeErr = tryWriteState(state, opts);
+              if (!writeErr) {
                 messages.push(`已停用 "${name}"`);
-              } catch (e) {
+              } else {
                 state.installations[idx] = backup as any;
-                const msg = e instanceof Error ? e.message : String(e);
-                messages.push(`錯誤：寫入 Bridge State 失敗：${msg}`);
+                messages.push(`錯誤：寫入 Bridge State 失敗：${writeErr}`);
               }
             }
           }
@@ -936,73 +1016,41 @@ export async function runCommand(
           messages.push('用法：/codex-marketplace enable <名稱>');
         } else {
           const name = subargs[0];
-          const idx = state.installations.findIndex(
-            (i) => i.manifestName === name || i.pluginId === name || i.id === name,
-          );
-          if (idx === -1) {
+          const matches = findInstallationsByName(state, name);
+          if (matches.length === 0) {
             messages.push(`錯誤：找不到已安裝的 plugin "${name}"`);
+          } else if (matches.length > 1) {
+            const list = matches.map((m) => `${m.manifestName}[${m.registrationId}]`).join('、');
+            messages.push(`錯誤：名稱 "${name}" 對應多個已安裝 plugin（${list}），請改用更精確的識別`);
           } else {
-            const inst = state.installations[idx];
-            const isEnabled = inst.enabled !== false && inst.installationState !== 'disabled';
-            if (isEnabled) {
+            const target = matches[0];
+            const idx = state.installations.indexOf(target);
+            const inst = target;
+            if (isInstallationEnabled(inst as any)) {
               messages.push(`"${name}" 已是啟用狀態`);
             } else {
               const reg = state.registrations.find((r) => r.id === inst.registrationId);
-              let refreshedSkills: string[] | undefined;
-              if (reg) {
-                const sourceRoot = sourceRootForReg(reg, opts);
-                if (sourceRoot) {
-                  try {
-                    const catalogRoot = catalogRootForReg(reg, opts);
-                    if (catalogRoot) {
-                      const read = readCatalogForReg(catalogRoot, reg.format ?? 'codex');
-                      if (!read.error && read.catalog) {
-                        const entry =
-                          read.catalog.entries.find((e) => e.name === inst.manifestName && e.type === 'local' && e.path) ??
-                          read.catalog.entries.find((e) => e.name === inst.manifestName && e.path);
-                        if (entry && entry.path) {
-                          const contained = resolveContained(sourceRoot, entry.path, 'directory');
-                          if (contained.outcome.kind === 'ok') {
-                            const pluginDir = contained.outcome.canonicalPath;
-                            const fmt = (reg.format ?? 'codex') as 'codex' | 'claude';
-                            refreshedSkills = collectSkillNames(pluginDir, fmt);
-                          }
-                        }
-                      }
-                    }
-                  } catch {
-                    // best-effort refresh
-                  }
-                }
-              }
+              // 收斂 best-effort 邊界：僅 I/O 包 try/catch，純邏輯不拋；失敗則沿用舊 skills
+              const refreshedSkills = reg ? tryRefreshSkills(reg as any, inst as any, opts) : undefined;
               const backup = { ...inst };
-              (inst as any).enabled = true;
-              (inst as any).installationState = 'enabled';
+              setInstallationEnabled(inst as any, true);
               if (refreshedSkills) (inst as any).skills = refreshedSkills;
               const skillList = (refreshedSkills ?? inst.skills ?? []) as string[];
-              const existing = new Map<string, number>();
-              for (const other of state.installations) {
-                if (other === inst) continue;
-                const otherEnabled = (other as any).enabled !== false && (other as any).installationState !== 'disabled';
-                if (!otherEnabled) continue;
-                for (const s of (other as any).skills ?? []) existing.set(s, (existing.get(s) ?? 0) + 1);
-              }
-              const colliding = skillList.filter((s) => existing.has(s));
-              try {
-                writeMinimalBridgeState(state, opts);
+              const colliding = detectCollidingSkills(skillList, state.installations, (other) => other.id === inst.id);
+              const writeErr = tryWriteState(state, opts);
+              if (!writeErr) {
                 reload = true;
                 if (skillList.length === 0) {
                   messages.push(`已啟用 "${name}"（0 skills）· 已重新載入生效`);
                 } else {
                   messages.push(`已啟用 "${name}"（${skillList.length} skills：${skillList.join(', ')}）· 已重新載入生效`);
                 }
-                for (const c of [...new Set(colliding)].sort((a, b) => a.localeCompare(b))) {
+                for (const c of colliding) {
                   messages.push(`⚠ skill "${c}" 與既有同名，未投影（名稱衝突）`);
                 }
-              } catch (e) {
+              } else {
                 state.installations[idx] = backup as any;
-                const msg = e instanceof Error ? e.message : String(e);
-                messages.push(`錯誤：寫入 Bridge State 失敗：${msg}`);
+                messages.push(`錯誤：寫入 Bridge State 失敗：${writeErr}`);
               }
             }
           }
@@ -1014,9 +1062,7 @@ export async function runCommand(
           messages.push('用法：/codex-marketplace remove <名稱>');
         } else {
           const name = subargs[0];
-          const matches = state.installations.filter(
-            (i) => i.manifestName === name || i.pluginId === name || i.id === name,
-          );
+          const matches = findInstallationsByName(state, name);
           if (matches.length === 0) {
             messages.push(`錯誤：找不到已安裝的 plugin "${name}"`);
           } else if (matches.length > 1) {
@@ -1027,13 +1073,12 @@ export async function runCommand(
             const idx = state.installations.indexOf(target);
             const backup = state.installations.slice();
             state.installations.splice(idx, 1);
-            try {
-              writeMinimalBridgeState(state, opts);
+            const writeErr = tryWriteState(state, opts);
+            if (!writeErr) {
               messages.push(`已移除 "${name}"`);
-            } catch (e) {
+            } else {
               state.installations = backup as any;
-              const msg = e instanceof Error ? e.message : String(e);
-              messages.push(`錯誤：寫入 Bridge State 失敗：${msg}`);
+              messages.push(`錯誤：寫入 Bridge State 失敗：${writeErr}`);
             }
           }
         }
@@ -1044,30 +1089,31 @@ export async function runCommand(
           messages.push('用法：/codex-marketplace forget <名稱>');
         } else {
           const name = subargs[0];
-          const regIdx = state.registrations.findIndex(
-            (r) => r.marketplaceName === name || r.alias === name || r.id === name,
-          );
-          if (regIdx === -1) {
+          const matches = findRegistrationsByName(state, name);
+          if (matches.length === 0) {
             messages.push(`錯誤：找不到 marketplace "${name}"`);
+          } else if (matches.length > 1) {
+            const list = matches.map((r) => `${r.marketplaceName || r.alias || r.id}[${r.id}]`).join('、');
+            messages.push(`錯誤：名稱 "${name}" 對應多個 marketplace（${list}），請改用更精確的識別`);
           } else {
-            const reg = state.registrations[regIdx];
+            const reg = matches[0];
+            const regIdx = state.registrations.indexOf(reg);
             const relatedCount = state.installations.filter((i) => i.registrationId === reg.id).length;
             const backupRegs = state.registrations.slice();
             const backupInsts = state.installations.slice();
             state.registrations.splice(regIdx, 1);
             state.installations = state.installations.filter((i) => i.registrationId !== reg.id);
-            try {
-              writeMinimalBridgeState(state, opts);
+            const writeErr = tryWriteState(state, opts);
+            if (!writeErr) {
               if (relatedCount > 0) {
                 messages.push(`已移除 marketplace "${name}"（含 ${relatedCount} 個安裝）`);
               } else {
                 messages.push(`已移除 marketplace "${name}"`);
               }
-            } catch (e) {
+            } else {
               state.registrations = backupRegs as any;
               state.installations = backupInsts as any;
-              const msg = e instanceof Error ? e.message : String(e);
-              messages.push(`錯誤：寫入 Bridge State 失敗：${msg}`);
+              messages.push(`錯誤：寫入 Bridge State 失敗：${writeErr}`);
             }
           }
         }

--- a/src/bridge/command.ts
+++ b/src/bridge/command.ts
@@ -903,7 +903,31 @@ export async function runCommand(
         if (subargs.length === 0) {
           messages.push('用法：/codex-marketplace disable <名稱>');
         } else {
-          messages.push(`停用 "${subargs[0]}"（骨架建立中，功能即將推出）`);
+          const name = subargs[0];
+          const idx = state.installations.findIndex(
+            (i) => i.manifestName === name || i.pluginId === name || i.id === name,
+          );
+          if (idx === -1) {
+            messages.push(`錯誤：找不到已安裝的 plugin "${name}"`);
+          } else {
+            const inst = state.installations[idx];
+            const isDisabled = inst.enabled === false || inst.installationState === 'disabled';
+            if (isDisabled) {
+              messages.push(`"${name}" 已是停用狀態`);
+            } else {
+              const backup = { ...inst };
+              (inst as any).enabled = false;
+              (inst as any).installationState = 'disabled';
+              try {
+                writeMinimalBridgeState(state, opts);
+                messages.push(`已停用 "${name}"`);
+              } catch (e) {
+                state.installations[idx] = backup as any;
+                const msg = e instanceof Error ? e.message : String(e);
+                messages.push(`錯誤：寫入 Bridge State 失敗：${msg}`);
+              }
+            }
+          }
         }
         break;
       }
@@ -911,7 +935,77 @@ export async function runCommand(
         if (subargs.length === 0) {
           messages.push('用法：/codex-marketplace enable <名稱>');
         } else {
-          messages.push(`啟用 "${subargs[0]}"（骨架建立中，功能即將推出）`);
+          const name = subargs[0];
+          const idx = state.installations.findIndex(
+            (i) => i.manifestName === name || i.pluginId === name || i.id === name,
+          );
+          if (idx === -1) {
+            messages.push(`錯誤：找不到已安裝的 plugin "${name}"`);
+          } else {
+            const inst = state.installations[idx];
+            const isEnabled = inst.enabled !== false && inst.installationState !== 'disabled';
+            if (isEnabled) {
+              messages.push(`"${name}" 已是啟用狀態`);
+            } else {
+              const reg = state.registrations.find((r) => r.id === inst.registrationId);
+              let refreshedSkills: string[] | undefined;
+              if (reg) {
+                const sourceRoot = sourceRootForReg(reg, opts);
+                if (sourceRoot) {
+                  try {
+                    const catalogRoot = catalogRootForReg(reg, opts);
+                    if (catalogRoot) {
+                      const read = readCatalogForReg(catalogRoot, reg.format ?? 'codex');
+                      if (!read.error && read.catalog) {
+                        const entry =
+                          read.catalog.entries.find((e) => e.name === inst.manifestName && e.type === 'local' && e.path) ??
+                          read.catalog.entries.find((e) => e.name === inst.manifestName && e.path);
+                        if (entry && entry.path) {
+                          const contained = resolveContained(sourceRoot, entry.path, 'directory');
+                          if (contained.outcome.kind === 'ok') {
+                            const pluginDir = contained.outcome.canonicalPath;
+                            const fmt = (reg.format ?? 'codex') as 'codex' | 'claude';
+                            refreshedSkills = collectSkillNames(pluginDir, fmt);
+                          }
+                        }
+                      }
+                    }
+                  } catch {
+                    // best-effort refresh
+                  }
+                }
+              }
+              const backup = { ...inst };
+              (inst as any).enabled = true;
+              (inst as any).installationState = 'enabled';
+              if (refreshedSkills) (inst as any).skills = refreshedSkills;
+              const skillList = (refreshedSkills ?? inst.skills ?? []) as string[];
+              const existing = new Map<string, number>();
+              for (const other of state.installations) {
+                if (other === inst) continue;
+                const otherEnabled = (other as any).enabled !== false && (other as any).installationState !== 'disabled';
+                if (!otherEnabled) continue;
+                for (const s of (other as any).skills ?? []) existing.set(s, (existing.get(s) ?? 0) + 1);
+              }
+              const colliding = skillList.filter((s) => existing.has(s));
+              try {
+                writeMinimalBridgeState(state, opts);
+                reload = true;
+                if (skillList.length === 0) {
+                  messages.push(`已啟用 "${name}"（0 skills）· 已重新載入生效`);
+                } else {
+                  messages.push(`已啟用 "${name}"（${skillList.length} skills：${skillList.join(', ')}）· 已重新載入生效`);
+                }
+                for (const c of [...new Set(colliding)].sort((a, b) => a.localeCompare(b))) {
+                  messages.push(`⚠ skill "${c}" 與既有同名，未投影（名稱衝突）`);
+                }
+              } catch (e) {
+                state.installations[idx] = backup as any;
+                const msg = e instanceof Error ? e.message : String(e);
+                messages.push(`錯誤：寫入 Bridge State 失敗：${msg}`);
+              }
+            }
+          }
         }
         break;
       }
@@ -919,7 +1013,29 @@ export async function runCommand(
         if (subargs.length === 0) {
           messages.push('用法：/codex-marketplace remove <名稱>');
         } else {
-          messages.push(`移除 "${subargs[0]}"（骨架建立中，功能即將推出）`);
+          const name = subargs[0];
+          const matches = state.installations.filter(
+            (i) => i.manifestName === name || i.pluginId === name || i.id === name,
+          );
+          if (matches.length === 0) {
+            messages.push(`錯誤：找不到已安裝的 plugin "${name}"`);
+          } else if (matches.length > 1) {
+            const list = matches.map((m) => `${m.manifestName}[${m.registrationId}]`).join('、');
+            messages.push(`錯誤：名稱 "${name}" 對應多個已安裝 plugin（${list}），請改用更精確的識別`);
+          } else {
+            const target = matches[0];
+            const idx = state.installations.indexOf(target);
+            const backup = state.installations.slice();
+            state.installations.splice(idx, 1);
+            try {
+              writeMinimalBridgeState(state, opts);
+              messages.push(`已移除 "${name}"`);
+            } catch (e) {
+              state.installations = backup as any;
+              const msg = e instanceof Error ? e.message : String(e);
+              messages.push(`錯誤：寫入 Bridge State 失敗：${msg}`);
+            }
+          }
         }
         break;
       }
@@ -927,7 +1043,33 @@ export async function runCommand(
         if (subargs.length === 0) {
           messages.push('用法：/codex-marketplace forget <名稱>');
         } else {
-          messages.push(`移除 marketplace "${subargs[0]}"（骨架建立中，功能即將推出）`);
+          const name = subargs[0];
+          const regIdx = state.registrations.findIndex(
+            (r) => r.marketplaceName === name || r.alias === name || r.id === name,
+          );
+          if (regIdx === -1) {
+            messages.push(`錯誤：找不到 marketplace "${name}"`);
+          } else {
+            const reg = state.registrations[regIdx];
+            const relatedCount = state.installations.filter((i) => i.registrationId === reg.id).length;
+            const backupRegs = state.registrations.slice();
+            const backupInsts = state.installations.slice();
+            state.registrations.splice(regIdx, 1);
+            state.installations = state.installations.filter((i) => i.registrationId !== reg.id);
+            try {
+              writeMinimalBridgeState(state, opts);
+              if (relatedCount > 0) {
+                messages.push(`已移除 marketplace "${name}"（含 ${relatedCount} 個安裝）`);
+              } else {
+                messages.push(`已移除 marketplace "${name}"`);
+              }
+            } catch (e) {
+              state.registrations = backupRegs as any;
+              state.installations = backupInsts as any;
+              const msg = e instanceof Error ? e.message : String(e);
+              messages.push(`錯誤：寫入 Bridge State 失敗：${msg}`);
+            }
+          }
         }
         break;
       }

--- a/src/bridge/command.ts
+++ b/src/bridge/command.ts
@@ -530,7 +530,19 @@ export async function runCommand(
     rawArgs.shift();
   }
 
-  const { state, wasReset, resetReason } = readMinimalBridgeState(opts);
+  let state: MinimalBridgeState;
+  let wasReset = false;
+  let resetReason: string | undefined;
+  try {
+    const read = readMinimalBridgeState(opts);
+    state = read.state;
+    wasReset = read.wasReset;
+    resetReason = read.resetReason;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    const messages = [`錯誤：讀取 Bridge State 失敗：${msg}`];
+    return { messages, lines: messages, output: messages.join('\n\n'), reload: false, stateReset: false };
+  }
 
   const messages: string[] = [];
   if (wasReset) {

--- a/src/bridge/state.ts
+++ b/src/bridge/state.ts
@@ -97,9 +97,11 @@ export function writeMinimalBridgeState(
 
   const timeoutMs = opts.lockTimeoutMs ?? 5000;
   const res = atomicWriteWithLockSync(statePath, data, lockPath, timeoutMs);
-  if (!res.success) {
-    // Fallback direct atomic write
-    atomicWriteFile(statePath, data);
+  if (res.success && res.verified) return;
+  // Fail-closed: lock 路徑失敗時 fallback 至直寫，但必須驗證成功否則拋出，讓呼叫端的 try/catch 能捕獲並回滾（避免 ENOSPC 時誤報成功）
+  const fallback = atomicWriteFile(statePath, data);
+  if (!fallback.success || !fallback.verified) {
+    throw new Error(fallback.error ?? res.error ?? 'Bridge State 寫入失敗：Persistence Indeterminate');
   }
 }
 

--- a/tests/unit/bridge/command-lifecycle93.test.ts
+++ b/tests/unit/bridge/command-lifecycle93.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runCommand } from '../../../src/bridge/command.js';
+import { readMinimalBridgeState } from '../../../src/bridge/state.js';
+import { discoverProjectedSkillPaths } from '../../../src/projection/exposure.js';
+
+function makeCodexMarketplace(root: string, name: string, plugins: { name: string; path: string; skills?: string[] }[]) {
+  mkdirSync(join(root, '.agents', 'plugins'), { recursive: true });
+  writeFileSync(join(root, '.agents', 'plugins', 'marketplace.json'), JSON.stringify({ name, plugins: plugins.map(p=>({name:p.name, source:{source:'local', path:p.path}})) }));
+  for (const p of plugins) {
+    const abs = join(root, p.path.replace(/^\.\//, ''));
+    mkdirSync(abs, { recursive: true });
+    mkdirSync(join(abs, '.codex-plugin'), { recursive: true });
+    writeFileSync(join(abs, '.codex-plugin', 'plugin.json'), JSON.stringify({ name: p.name }));
+    writeFileSync(join(abs, 'plugin.json'), JSON.stringify({ name: p.name }));
+    if (p.skills) {
+      for (const skill of p.skills) {
+        const sdir = join(abs, 'skills', skill);
+        mkdirSync(sdir, { recursive: true });
+        writeFileSync(join(sdir, 'SKILL.md'), `---\nname: ${skill}\ndescription: Desc for ${skill}\n---\n\nBody for ${skill}\n`);
+      }
+    }
+  }
+}
+
+describe('lifecycle 93 disable/enable/remove/forget', () => {
+  let tmpDir: string;
+  let statePath: string;
+  let mktRoot: string;
+  let agentDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'bridge93-'));
+    statePath = join(tmpDir, 'state.json');
+    mktRoot = mkdtempSync(join(tmpdir(), 'mkt93-'));
+    agentDir = mkdtempSync(join(tmpdir(), 'agent93-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    rmSync(mktRoot, { recursive: true, force: true });
+    rmSync(agentDir, { recursive: true, force: true });
+  });
+
+  it('disable 後輸出確認；縫層斷言該 installation 不再進入投影（與 enable 的增減成對）', async () => {
+    makeCodexMarketplace(mktRoot, 'demo-marketplace', [
+      { name: 'demo', path: './plugins/demo', skills: ['skill-a', 'skill-b'] },
+    ]);
+    await runCommand(['add', mktRoot], { statePath, agentDir });
+    await runCommand(['install', '1'], { statePath, agentDir });
+    // projection should contain
+    let proj = discoverProjectedSkillPaths({ agentDir });
+    // Note: need to use same agentDir as statePath? install used statePath but projection reads agentDir's state? We used agentDir for both add/install, so state is at agentDir. For this test we used statePath separate; but projection reads from agentDir, not statePath. So we need to use agentDir consistently.
+    // Let's redo with agentDir only
+    const mkt2 = mkdtempSync(join(tmpdir(), 'mkt93b-'));
+    try {
+      makeCodexMarketplace(mkt2, 'mkt-b', [{ name: 'p1', path: './plugins/p1', skills: ['s1'] }]);
+      let res = await runCommand(['add', mkt2], { agentDir });
+      expect(res.output).toContain('已註冊');
+      res = await runCommand(['install', '1'], { agentDir });
+      expect(res.reload).toBe(true);
+      proj = discoverProjectedSkillPaths({ agentDir });
+      expect(proj.skillPaths.some(p=>p.includes('s1'))).toBe(true);
+
+      res = await runCommand(['disable', 'p1'], { agentDir });
+      expect(res.output).toContain('已停用');
+      expect(res.reload).toBe(false);
+      const st = readMinimalBridgeState({ agentDir });
+      expect(st.state.installations[0].enabled).toBe(false);
+      proj = discoverProjectedSkillPaths({ agentDir });
+      expect(proj.skillPaths.some(p=>p.includes('s1'))).toBe(false);
+
+      res = await runCommand(['enable', 'p1'], { agentDir });
+      expect(res.output).toContain('已啟用');
+      expect(res.output).toContain('已重新載入生效');
+      expect(res.reload).toBe(true);
+      proj = discoverProjectedSkillPaths({ agentDir });
+      expect(proj.skillPaths.some(p=>p.includes('s1'))).toBe(true);
+
+      // overview should reflect
+      res = await runCommand([], { agentDir });
+      expect(res.output).toContain('啟用');
+      // after disable again, overview should show 停用
+      await runCommand(['disable', 'p1'], { agentDir });
+      res = await runCommand([], { agentDir });
+      expect(res.output).toContain('停用');
+    } finally {
+      rmSync(mkt2, { recursive: true, force: true });
+    }
+  });
+
+  it('remove 單支：marketplace 與來源資料不動、安裝記錄移除；remove 後可再 install', async () => {
+    makeCodexMarketplace(mktRoot, 'demo-marketplace', [
+      { name: 'demo', path: './plugins/demo', skills: ['skill-a'] },
+      { name: 'other', path: './plugins/other', skills: ['skill-x'] },
+    ]);
+    await runCommand(['add', mktRoot], { agentDir });
+    await runCommand(['install', '1'], { agentDir });
+    let st = readMinimalBridgeState({ agentDir });
+    expect(st.state.installations).toHaveLength(1);
+    // source file still exists
+    expect(existsSync(join(mktRoot, 'plugins/demo'))).toBe(true);
+
+    let res = await runCommand(['remove', 'demo'], { agentDir });
+    expect(res.output).toContain('已移除');
+    st = readMinimalBridgeState({ agentDir });
+    expect(st.state.installations).toHaveLength(0);
+    expect(st.state.registrations).toHaveLength(1);
+    expect(existsSync(join(mktRoot, 'plugins/demo'))).toBe(true);
+    // list should show 可安裝 again
+    res = await runCommand(['list'], { agentDir });
+    expect(res.output).toContain('可安裝');
+    // re-install should succeed
+    res = await runCommand(['install', 'demo'], { agentDir });
+    expect(res.output).toContain('已重新載入生效');
+    st = readMinimalBridgeState({ agentDir });
+    expect(st.state.installations).toHaveLength(1);
+  });
+
+  it('forget：marketplace 及其全部安裝一併移除', async () => {
+    makeCodexMarketplace(mktRoot, 'demo-marketplace', [
+      { name: 'demo', path: './plugins/demo', skills: ['skill-a'] },
+      { name: 'other', path: './plugins/other', skills: ['skill-x'] },
+    ]);
+    await runCommand(['add', mktRoot], { agentDir });
+    await runCommand(['install', '1'], { agentDir });
+    await runCommand(['install', '2'], { agentDir });
+    let st = readMinimalBridgeState({ agentDir });
+    expect(st.state.installations).toHaveLength(2);
+    expect(st.state.registrations).toHaveLength(1);
+
+    const res = await runCommand(['forget', 'demo-marketplace'], { agentDir });
+    expect(res.output).toContain('已移除 marketplace');
+    expect(res.output).toContain('2');
+    st = readMinimalBridgeState({ agentDir });
+    expect(st.state.registrations).toHaveLength(0);
+    expect(st.state.installations).toHaveLength(0);
+    // marketplace source still exists on filesystem
+    expect(existsSync(join(mktRoot, '.agents/plugins/marketplace.json'))).toBe(true);
+    // projection should be empty
+    const proj = discoverProjectedSkillPaths({ agentDir });
+    expect(proj.skillPaths.some(p=>p.includes('skill-a'))).toBe(false);
+  });
+
+  it('總覽顯示停用／啟用狀態', async () => {
+    makeCodexMarketplace(mktRoot, 'demo-marketplace', [
+      { name: 'demo', path: './plugins/demo', skills: ['skill-a'] },
+    ]);
+    await runCommand(['add', mktRoot], { agentDir });
+    await runCommand(['install', '1'], { agentDir });
+    let res = await runCommand([], { agentDir });
+    expect(res.output).toContain('啟用');
+    expect(res.output).toContain('demo');
+    await runCommand(['disable', 'demo'], { agentDir });
+    res = await runCommand([], { agentDir });
+    expect(res.output).toContain('停用');
+    // list should show 已裝停用
+    res = await runCommand(['list'], { agentDir });
+    expect(res.output).toContain('已裝停用');
+    await runCommand(['enable', 'demo'], { agentDir });
+    res = await runCommand(['list'], { agentDir });
+    expect(res.output).toContain('已裝啟用');
+  });
+
+  it('remove 後可再 install（重新安裝）走 runCommand 縫', async () => {
+    makeCodexMarketplace(mktRoot, 'demo-marketplace', [
+      { name: 'demo', path: './plugins/demo', skills: ['skill-a'] },
+    ]);
+    await runCommand(['add', mktRoot], { agentDir });
+    await runCommand(['install', '1'], { agentDir });
+    await runCommand(['remove', 'demo'], { agentDir });
+    const res = await runCommand(['install', '1'], { agentDir });
+    expect(res.output).toContain('已重新載入生效');
+    const st = readMinimalBridgeState({ agentDir });
+    expect(st.state.installations[0].enabled).toBe(true);
+  });
+
+  it('走 runCommand 縫測試：disable/enable/remove/forget 錯誤處理', async () => {
+    let res = await runCommand(['disable', 'nonexist'], { agentDir });
+    expect(res.output).toContain('找不到');
+    res = await runCommand(['enable', 'nonexist'], { agentDir });
+    expect(res.output).toContain('找不到');
+    res = await runCommand(['remove', 'nonexist'], { agentDir });
+    expect(res.output).toContain('找不到');
+    res = await runCommand(['forget', 'nonexist'], { agentDir });
+    expect(res.output).toContain('找不到');
+
+    // missing args
+    res = await runCommand(['disable'], { agentDir });
+    expect(res.output).toMatch(/用法/);
+    res = await runCommand(['enable'], { agentDir });
+    expect(res.output).toMatch(/用法/);
+    res = await runCommand(['remove'], { agentDir });
+    expect(res.output).toMatch(/用法/);
+    res = await runCommand(['forget'], { agentDir });
+    expect(res.output).toMatch(/用法/);
+  });
+
+  it('enable 後輸出確認＋reload 旗標；再投影，且處理 collision', async () => {
+    const mkt2 = mkdtempSync(join(tmpdir(), 'mkt93c-'));
+    try {
+      makeCodexMarketplace(mktRoot, 'm1', [{ name: 'p1', path: './plugins/p1', skills: ['shared'] }]);
+      makeCodexMarketplace(mkt2, 'm2', [{ name: 'p2', path: './plugins/p2', skills: ['shared', 'other'] }]);
+      await runCommand(['add', mktRoot], { agentDir });
+      await runCommand(['add', mkt2], { agentDir });
+      await runCommand(['install', '1'], { agentDir }); // p1
+      await runCommand(['install', '2'], { agentDir }); // p2 will collide shared
+      // disable p2 then enable again should show collision again
+      await runCommand(['disable', 'p2'], { agentDir });
+      const res = await runCommand(['enable', 'p2'], { agentDir });
+      expect(res.output).toContain('已啟用');
+      expect(res.output).toContain('未投影（名稱衝突）');
+      expect(res.output).toContain('shared');
+      expect(res.reload).toBe(true);
+      const proj = discoverProjectedSkillPaths({ agentDir });
+      // due to collision, shared should be denied for both? But p1 still enabled, p2's shared should be unavailable, but 'other' should be projected
+      expect(proj.skillPaths.some(p=>p.includes('other'))).toBe(true);
+      // shared from p1 should maybe be denied too? In minimal, collision handling denies both? Actually exposure's collision denies all Bridge colliders when Pi layer not involved: group >1 => findings, survivors empty. So shared would be unavailable for both. Let's check behavior: both p1 and p2 have shared, so neither should be projected.
+      // But install collision only warned for second install; first's skill might still be considered? However exposure will deny both after both are enabled.
+      // After disabling p2, shared should be available via p1
+      await runCommand(['disable', 'p2'], { agentDir });
+      const proj2 = discoverProjectedSkillPaths({ agentDir });
+      expect(proj2.skillPaths.some(p=>p.includes('shared'))).toBe(true);
+    } finally {
+      rmSync(mkt2, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/bridge/command-lifecycle93.test.ts
+++ b/tests/unit/bridge/command-lifecycle93.test.ts
@@ -26,69 +26,53 @@ function makeCodexMarketplace(root: string, name: string, plugins: { name: strin
 }
 
 describe('lifecycle 93 disable/enable/remove/forget', () => {
-  let tmpDir: string;
-  let statePath: string;
   let mktRoot: string;
+  let mktRoot2: string;
   let agentDir: string;
 
   beforeEach(() => {
-    tmpDir = mkdtempSync(join(tmpdir(), 'bridge93-'));
-    statePath = join(tmpDir, 'state.json');
     mktRoot = mkdtempSync(join(tmpdir(), 'mkt93-'));
+    mktRoot2 = mkdtempSync(join(tmpdir(), 'mkt93b-'));
     agentDir = mkdtempSync(join(tmpdir(), 'agent93-'));
   });
 
   afterEach(() => {
-    rmSync(tmpDir, { recursive: true, force: true });
     rmSync(mktRoot, { recursive: true, force: true });
+    rmSync(mktRoot2, { recursive: true, force: true });
     rmSync(agentDir, { recursive: true, force: true });
   });
 
   it('disable 後輸出確認；縫層斷言該 installation 不再進入投影（與 enable 的增減成對）', async () => {
-    makeCodexMarketplace(mktRoot, 'demo-marketplace', [
-      { name: 'demo', path: './plugins/demo', skills: ['skill-a', 'skill-b'] },
-    ]);
-    await runCommand(['add', mktRoot], { statePath, agentDir });
-    await runCommand(['install', '1'], { statePath, agentDir });
-    // projection should contain
+    makeCodexMarketplace(mktRoot, 'mkt-b', [{ name: 'p1', path: './plugins/p1', skills: ['s1'] }]);
+    let res = await runCommand(['add', mktRoot], { agentDir });
+    expect(res.output).toContain('已註冊');
+    res = await runCommand(['install', '1'], { agentDir });
+    expect(res.reload).toBe(true);
     let proj = discoverProjectedSkillPaths({ agentDir });
-    // Note: need to use same agentDir as statePath? install used statePath but projection reads agentDir's state? We used agentDir for both add/install, so state is at agentDir. For this test we used statePath separate; but projection reads from agentDir, not statePath. So we need to use agentDir consistently.
-    // Let's redo with agentDir only
-    const mkt2 = mkdtempSync(join(tmpdir(), 'mkt93b-'));
-    try {
-      makeCodexMarketplace(mkt2, 'mkt-b', [{ name: 'p1', path: './plugins/p1', skills: ['s1'] }]);
-      let res = await runCommand(['add', mkt2], { agentDir });
-      expect(res.output).toContain('已註冊');
-      res = await runCommand(['install', '1'], { agentDir });
-      expect(res.reload).toBe(true);
-      proj = discoverProjectedSkillPaths({ agentDir });
-      expect(proj.skillPaths.some(p=>p.includes('s1'))).toBe(true);
+    expect(proj.skillPaths.some(p=>p.includes('s1'))).toBe(true);
 
-      res = await runCommand(['disable', 'p1'], { agentDir });
-      expect(res.output).toContain('已停用');
-      expect(res.reload).toBe(false);
-      const st = readMinimalBridgeState({ agentDir });
-      expect(st.state.installations[0].enabled).toBe(false);
-      proj = discoverProjectedSkillPaths({ agentDir });
-      expect(proj.skillPaths.some(p=>p.includes('s1'))).toBe(false);
+    res = await runCommand(['disable', 'p1'], { agentDir });
+    expect(res.output).toContain('已停用');
+    expect(res.reload).toBe(false);
+    const st = readMinimalBridgeState({ agentDir });
+    expect(st.state.installations[0].enabled).toBe(false);
+    proj = discoverProjectedSkillPaths({ agentDir });
+    expect(proj.skillPaths.some(p=>p.includes('s1'))).toBe(false);
 
-      res = await runCommand(['enable', 'p1'], { agentDir });
-      expect(res.output).toContain('已啟用');
-      expect(res.output).toContain('已重新載入生效');
-      expect(res.reload).toBe(true);
-      proj = discoverProjectedSkillPaths({ agentDir });
-      expect(proj.skillPaths.some(p=>p.includes('s1'))).toBe(true);
+    res = await runCommand(['enable', 'p1'], { agentDir });
+    expect(res.output).toContain('已啟用');
+    expect(res.output).toContain('已重新載入生效');
+    expect(res.reload).toBe(true);
+    proj = discoverProjectedSkillPaths({ agentDir });
+    expect(proj.skillPaths.some(p=>p.includes('s1'))).toBe(true);
 
-      // overview should reflect
-      res = await runCommand([], { agentDir });
-      expect(res.output).toContain('啟用');
-      // after disable again, overview should show 停用
-      await runCommand(['disable', 'p1'], { agentDir });
-      res = await runCommand([], { agentDir });
-      expect(res.output).toContain('停用');
-    } finally {
-      rmSync(mkt2, { recursive: true, force: true });
-    }
+    // overview should reflect
+    res = await runCommand([], { agentDir });
+    expect(res.output).toContain('啟用');
+    // after disable again, overview should show 停用
+    await runCommand(['disable', 'p1'], { agentDir });
+    res = await runCommand([], { agentDir });
+    expect(res.output).toContain('停用');
   });
 
   it('remove 單支：marketplace 與來源資料不動、安裝記錄移除；remove 後可再 install', async () => {
@@ -100,23 +84,36 @@ describe('lifecycle 93 disable/enable/remove/forget', () => {
     await runCommand(['install', '1'], { agentDir });
     let st = readMinimalBridgeState({ agentDir });
     expect(st.state.installations).toHaveLength(1);
-    // source file still exists
     expect(existsSync(join(mktRoot, 'plugins/demo'))).toBe(true);
+    const beforeCatalog = readFileSync(join(mktRoot, '.agents/plugins/marketplace.json'), 'utf8');
+    const beforePluginJson = readFileSync(join(mktRoot, 'plugins/demo/.codex-plugin/plugin.json'), 'utf8');
 
     let res = await runCommand(['remove', 'demo'], { agentDir });
     expect(res.output).toContain('已移除');
+    expect(res.reload).toBe(false);
     st = readMinimalBridgeState({ agentDir });
     expect(st.state.installations).toHaveLength(0);
     expect(st.state.registrations).toHaveLength(1);
+    expect(st.state.registrations[0].marketplaceName).toBe('demo-marketplace');
+    // marketplace 與來源資料不動：內容 hash 比對而非僅存在性
+    expect(readFileSync(join(mktRoot, '.agents/plugins/marketplace.json'), 'utf8')).toBe(beforeCatalog);
+    expect(readFileSync(join(mktRoot, 'plugins/demo/.codex-plugin/plugin.json'), 'utf8')).toBe(beforePluginJson);
     expect(existsSync(join(mktRoot, 'plugins/demo'))).toBe(true);
+    // 投影已移除
+    let proj = discoverProjectedSkillPaths({ agentDir });
+    expect(proj.skillPaths.some(p=>p.includes('skill-a'))).toBe(false);
     // list should show 可安裝 again
     res = await runCommand(['list'], { agentDir });
     expect(res.output).toContain('可安裝');
-    // re-install should succeed
+    expect(res.reload).toBe(false);
+    // re-install should succeed（驗證 remove 後可再 install，透過名稱）
     res = await runCommand(['install', 'demo'], { agentDir });
     expect(res.output).toContain('已重新載入生效');
+    expect(res.reload).toBe(true);
     st = readMinimalBridgeState({ agentDir });
     expect(st.state.installations).toHaveLength(1);
+    proj = discoverProjectedSkillPaths({ agentDir });
+    expect(proj.skillPaths.some(p=>p.includes('skill-a'))).toBe(true);
   });
 
   it('forget：marketplace 及其全部安裝一併移除', async () => {
@@ -130,18 +127,23 @@ describe('lifecycle 93 disable/enable/remove/forget', () => {
     let st = readMinimalBridgeState({ agentDir });
     expect(st.state.installations).toHaveLength(2);
     expect(st.state.registrations).toHaveLength(1);
+    expect(st.state.registrations[0].marketplaceName).toBe('demo-marketplace');
+    const beforeCatalog = readFileSync(join(mktRoot, '.agents/plugins/marketplace.json'), 'utf8');
 
     const res = await runCommand(['forget', 'demo-marketplace'], { agentDir });
     expect(res.output).toContain('已移除 marketplace');
     expect(res.output).toContain('2');
+    expect(res.reload).toBe(false);
     st = readMinimalBridgeState({ agentDir });
     expect(st.state.registrations).toHaveLength(0);
     expect(st.state.installations).toHaveLength(0);
-    // marketplace source still exists on filesystem
+    // marketplace 來源仍在檔案系統且內容不動
     expect(existsSync(join(mktRoot, '.agents/plugins/marketplace.json'))).toBe(true);
-    // projection should be empty
+    expect(readFileSync(join(mktRoot, '.agents/plugins/marketplace.json'), 'utf8')).toBe(beforeCatalog);
+    // 投影應清空
     const proj = discoverProjectedSkillPaths({ agentDir });
     expect(proj.skillPaths.some(p=>p.includes('skill-a'))).toBe(false);
+    expect(proj.skillPaths.some(p=>p.includes('skill-x'))).toBe(false);
   });
 
   it('總覽顯示停用／啟用狀態', async () => {
@@ -164,67 +166,127 @@ describe('lifecycle 93 disable/enable/remove/forget', () => {
     expect(res.output).toContain('已裝啟用');
   });
 
-  it('remove 後可再 install（重新安裝）走 runCommand 縫', async () => {
+  it('remove 後可再 install（編號復用走 runCommand 縫）', async () => {
     makeCodexMarketplace(mktRoot, 'demo-marketplace', [
       { name: 'demo', path: './plugins/demo', skills: ['skill-a'] },
     ]);
     await runCommand(['add', mktRoot], { agentDir });
     await runCommand(['install', '1'], { agentDir });
-    await runCommand(['remove', 'demo'], { agentDir });
-    const res = await runCommand(['install', '1'], { agentDir });
+    let res = await runCommand(['remove', 'demo'], { agentDir });
+    expect(res.reload).toBe(false);
+    // 編號復用：移除後 list 回到可安裝，編號 1 仍對應同一 plugin
+    res = await runCommand(['list'], { agentDir });
+    expect(res.output).toContain('可安裝');
+    res = await runCommand(['install', '1'], { agentDir });
     expect(res.output).toContain('已重新載入生效');
+    expect(res.reload).toBe(true);
     const st = readMinimalBridgeState({ agentDir });
     expect(st.state.installations[0].enabled).toBe(true);
+    const proj = discoverProjectedSkillPaths({ agentDir });
+    expect(proj.skillPaths.some(p=>p.includes('skill-a'))).toBe(true);
   });
 
   it('走 runCommand 縫測試：disable/enable/remove/forget 錯誤處理', async () => {
     let res = await runCommand(['disable', 'nonexist'], { agentDir });
     expect(res.output).toContain('找不到');
+    expect(res.reload).toBe(false);
     res = await runCommand(['enable', 'nonexist'], { agentDir });
     expect(res.output).toContain('找不到');
+    expect(res.reload).toBe(false);
     res = await runCommand(['remove', 'nonexist'], { agentDir });
     expect(res.output).toContain('找不到');
+    expect(res.reload).toBe(false);
     res = await runCommand(['forget', 'nonexist'], { agentDir });
     expect(res.output).toContain('找不到');
+    expect(res.reload).toBe(false);
 
     // missing args
     res = await runCommand(['disable'], { agentDir });
     expect(res.output).toMatch(/用法/);
+    expect(res.reload).toBe(false);
     res = await runCommand(['enable'], { agentDir });
     expect(res.output).toMatch(/用法/);
+    expect(res.reload).toBe(false);
     res = await runCommand(['remove'], { agentDir });
     expect(res.output).toMatch(/用法/);
+    expect(res.reload).toBe(false);
     res = await runCommand(['forget'], { agentDir });
     expect(res.output).toMatch(/用法/);
+    expect(res.reload).toBe(false);
   });
 
   it('enable 後輸出確認＋reload 旗標；再投影，且處理 collision', async () => {
-    const mkt2 = mkdtempSync(join(tmpdir(), 'mkt93c-'));
-    try {
-      makeCodexMarketplace(mktRoot, 'm1', [{ name: 'p1', path: './plugins/p1', skills: ['shared'] }]);
-      makeCodexMarketplace(mkt2, 'm2', [{ name: 'p2', path: './plugins/p2', skills: ['shared', 'other'] }]);
-      await runCommand(['add', mktRoot], { agentDir });
-      await runCommand(['add', mkt2], { agentDir });
-      await runCommand(['install', '1'], { agentDir }); // p1
-      await runCommand(['install', '2'], { agentDir }); // p2 will collide shared
-      // disable p2 then enable again should show collision again
-      await runCommand(['disable', 'p2'], { agentDir });
-      const res = await runCommand(['enable', 'p2'], { agentDir });
-      expect(res.output).toContain('已啟用');
-      expect(res.output).toContain('未投影（名稱衝突）');
-      expect(res.output).toContain('shared');
-      expect(res.reload).toBe(true);
-      const proj = discoverProjectedSkillPaths({ agentDir });
-      // due to collision, shared should be denied for both? But p1 still enabled, p2's shared should be unavailable, but 'other' should be projected
-      expect(proj.skillPaths.some(p=>p.includes('other'))).toBe(true);
-      // shared from p1 should maybe be denied too? In minimal, collision handling denies both? Actually exposure's collision denies all Bridge colliders when Pi layer not involved: group >1 => findings, survivors empty. So shared would be unavailable for both. Let's check behavior: both p1 and p2 have shared, so neither should be projected.
-      // But install collision only warned for second install; first's skill might still be considered? However exposure will deny both after both are enabled.
-      // After disabling p2, shared should be available via p1
-      await runCommand(['disable', 'p2'], { agentDir });
-      const proj2 = discoverProjectedSkillPaths({ agentDir });
-      expect(proj2.skillPaths.some(p=>p.includes('shared'))).toBe(true);
-    } finally {
-      rmSync(mkt2, { recursive: true, force: true });
-    }
+    makeCodexMarketplace(mktRoot, 'm1', [{ name: 'p1', path: './plugins/p1', skills: ['shared'] }]);
+    makeCodexMarketplace(mktRoot2, 'm2', [{ name: 'p2', path: './plugins/p2', skills: ['shared', 'other'] }]);
+    await runCommand(['add', mktRoot], { agentDir });
+    await runCommand(['add', mktRoot2], { agentDir });
+    await runCommand(['install', '1'], { agentDir }); // p1
+    await runCommand(['install', '2'], { agentDir }); // p2 will collide shared
+    // disable p2 then enable again should show collision again
+    await runCommand(['disable', 'p2'], { agentDir });
+    const res = await runCommand(['enable', 'p2'], { agentDir });
+    expect(res.output).toContain('已啟用');
+    expect(res.output).toContain('未投影（名稱衝突）');
+    expect(res.output).toContain('shared');
+    expect(res.reload).toBe(true);
+    const proj = discoverProjectedSkillPaths({ agentDir });
+    // 同層 collider 全否決：p1 與 p2 皆有 shared，兩者皆不投影；p2 的 other 仍投影
+    expect(proj.skillPaths.some(p=>p.includes('other'))).toBe(true);
+    expect(proj.skillPaths.some(p=>p.includes('shared'))).toBe(false);
+    // After disabling p2, shared should be available via p1
+    await runCommand(['disable', 'p2'], { agentDir });
+    const proj2 = discoverProjectedSkillPaths({ agentDir });
+    expect(proj2.skillPaths.some(p=>p.includes('shared'))).toBe(true);
+  });
+
+  it('disable 已停用 / enable 已啟用 分支', async () => {
+    makeCodexMarketplace(mktRoot, 'demo-marketplace', [{ name: 'demo', path: './plugins/demo', skills: ['skill-a'] }]);
+    await runCommand(['add', mktRoot], { agentDir });
+    await runCommand(['install', '1'], { agentDir });
+
+    let res = await runCommand(['disable', 'demo'], { agentDir });
+    expect(res.output).toContain('已停用');
+    expect(res.reload).toBe(false);
+    // 已是停用狀態再 disable
+    res = await runCommand(['disable', 'demo'], { agentDir });
+    expect(res.output).toContain('已是停用狀態');
+    expect(res.reload).toBe(false);
+    let st = readMinimalBridgeState({ agentDir });
+    expect(st.state.installations[0].enabled).toBe(false);
+
+    res = await runCommand(['enable', 'demo'], { agentDir });
+    expect(res.output).toContain('已啟用');
+    expect(res.reload).toBe(true);
+    // 已是啟用狀態再 enable
+    res = await runCommand(['enable', 'demo'], { agentDir });
+    expect(res.output).toContain('已是啟用狀態');
+    expect(res.reload).toBe(false);
+    st = readMinimalBridgeState({ agentDir });
+    expect(st.state.installations[0].enabled).toBe(true);
+  });
+
+  it('remove 歧義：同一 manifestName 橫跨兩 registrations 時回報多個對應', async () => {
+    // 兩個 marketplace 各有同名 plugin "dup"
+    makeCodexMarketplace(mktRoot, 'm1', [{ name: 'dup', path: './plugins/dup', skills: ['skill-a'] }]);
+    makeCodexMarketplace(mktRoot2, 'm2', [{ name: 'dup', path: './plugins/dup', skills: ['skill-b'] }]);
+    await runCommand(['add', mktRoot], { agentDir });
+    await runCommand(['add', mktRoot2], { agentDir });
+    await runCommand(['install', '1'], { agentDir }); // dup from m1
+    await runCommand(['install', '2'], { agentDir }); // dup from m2
+    let st = readMinimalBridgeState({ agentDir });
+    expect(st.state.installations).toHaveLength(2);
+    expect(st.state.registrations).toHaveLength(2);
+
+    const beforeCatalog1 = readFileSync(join(mktRoot, '.agents/plugins/marketplace.json'), 'utf8');
+    const beforeCatalog2 = readFileSync(join(mktRoot2, '.agents/plugins/marketplace.json'), 'utf8');
+
+    const res = await runCommand(['remove', 'dup'], { agentDir });
+    expect(res.output).toContain('對應多個已安裝 plugin');
+    expect(res.reload).toBe(false);
+    // 歧義時不應刪除任何安裝，來源亦不動
+    st = readMinimalBridgeState({ agentDir });
+    expect(st.state.installations).toHaveLength(2);
+    expect(readFileSync(join(mktRoot, '.agents/plugins/marketplace.json'), 'utf8')).toBe(beforeCatalog1);
+    expect(readFileSync(join(mktRoot2, '.agents/plugins/marketplace.json'), 'utf8')).toBe(beforeCatalog2);
   });
 });


### PR DESCRIPTION
Closes #93

Parent #87

已安裝 plugin 的生命週期管理：

- `disable <名稱>`：停用（不再投影；下次 discovery pass 自然消失），輸出確認
- `enable <名稱>`：啟用（重新投影＋reload 旗標）
- `remove <名稱>`：移除單支 plugin（不動 marketplace、不動來源資料）
- `forget <名稱>`：移除整個 marketplace（含其全部安裝）
- 無參數總覽反映 marketplace 與 installed 狀態（啟用／停用）

### 變更項目

- **`src/bridge/command.ts`**：
  - `disable <名稱>`：以 `manifestName|pluginId|id` 定位 Installation；已停用則回「已是停用狀態」，否則設 `enabled=false, installationState='disabled'` → `writeMinimalBridgeState` → 輸出 `已停用 "<name>"`（不觸發 reload，下次 discovery 自然消失）
  - `enable <名稱>`：同一定位；已啟用則回「已是啟用狀態」，否則嘗試由 `sourceRootForReg`→`catalogRootForReg`→`readCatalogForReg` 定位 catalog entry→`resolveContained` 取 pluginDir 並以 `collectSkillNames` 刷新 `skills`（best-effort）；設 `enabled=true, installationState='enabled'`；計算與其他已啟用安裝的同名 skill 碰撞（同 install 全否決語意）→ 寫入 state → `reload=true` → 輸出 `已啟用 "<name>"（N skills：…）· 已重新載入生效` 並逐項 `⚠ skill "x" 與既有同名，未投影（名稱衝突）`
  - `remove <名稱>`：過濾 `manifestName|pluginId|id` 需唯一匹配（0→找不到，>1→多重匹配錯誤）；`state.installations.splice` 移除單支 → 寫入 → 輸出 `已移除 "<name>"`；marketplace 與來源資料不動，`list` 回到 `可安裝`，可再 `install`
  - `forget <名稱>`：以 `marketplaceName|alias|id` 定位 Registration；`relatedCount = installations.filter(registrationId)`；原子移除 registration 與其全部 installations → 寫入 → 輸出 `已移除 marketplace "<name>"（含 N 個安裝）`（N=0 時僅輸出 marketplace 名稱）；來源資料不動
  - 保持 `formatOverview` 對 `enabled/停用` 的顯示（已於 #88 建立），`list` 經 `enumeratePlugins` 反映 `已裝啟用／已裝停用`
- **`tests/unit/bridge/command-lifecycle93.test.ts`**（新增）：
  - 走 `runCommand` 純函式縫（真實 FS＋真實 marketplace fixture＋`agentDir` 隔離）覆蓋 7 項：disable/enable 投影增減與 reload 旗標成對、remove 單支級聯與重裝、forget 整包級聯、總覽／list 狀態顯示、錯誤與用法提示、enable 碰撞再現等

### 驗證

- `npx tsc --noEmit` ✅
- `npx vitest run tests/unit/bridge --coverage=false` ✅（83 tests：含新增 7 項 lifecycle93）
- `npx vitest run --coverage=false` ✅（832 tests 全綠）

### Acceptance criteria 對照

| #93 驗收條件 | 狀態 | 驗證落點 |
|---|---|---|
| disable 後輸出確認；縫層斷言該 installation 不再進入投影（與 enable 的增減成對） | ✅ | `disable 後輸出確認；縫層斷言…`：disable→ projection 不含該 skill，enable→ 重新含該 skill，reload 旗標 disable=false/enable=true |
| enable 後輸出確認＋reload 旗標；再投影 | ✅ | 同上；enable 輸出含 `已啟用`＋`已重新載入生效`，reload=true，discoverProjectedSkillPaths 重新含該 skill |
| remove 單支：marketplace 與來源資料不動、安裝記錄移除 | ✅ | `remove 單支…`：registrations 長度不變、來源目錄仍存在、installations 剩 0、list 回可安裝 |
| forget：marketplace 及其全部安裝一併移除 | ✅ | `forget…`：registrations 0、installations 0、輸出含 N 個安裝、來源 catalog 仍在、projection 不再含 skill |
| remove 後可再 install（重新安裝） | ✅ | `remove 後可再 install` 與 `走 runCommand 縫…` 覆蓋：remove 後再 install 1 成功寫入 enabled |
| 總覽顯示停用／啟用狀態 | ✅ | `總覽顯示停用／啟用狀態`：無參數總覽與 list 分別含 `啟用／停用`／`已裝啟用／已裝停用` |
| 走 runCommand 縫測試 | ✅ | 全程 `runCommand(argv, {agentDir})` 純函式縫，不經 TUI |
