### PR TITLE
feat: update 全部 marketplace 重抓最新（本機重讀／git 重抓、有變升／無變顯示、投影指向最新材料） (#94)

### DIFF
--- a/src/bridge/command.ts
+++ b/src/bridge/command.ts
@@ -1074,7 +1074,8 @@ export async function runCommand(
         // 整包 deep backup：任一 marketplace 失敗不影響其他；最後一次寫入，寫失敗即回滾全部。
         const stateBackup = JSON.parse(JSON.stringify(state)) as MinimalBridgeState;
         const updateLines: string[] = [];
-        let anyChanged = false;
+        let anyChanged = false;   // 有 plugin 實際升到最新 → reload＋結尾「已重新載入生效」
+        let gitAdvanced = false; // git registration 已推進到新 fingerprint → 需持久化（即使無已安裝 plugin）
 
         for (const reg of state.registrations) {
           const display = reg.marketplaceName || reg.alias || reg.id;
@@ -1086,12 +1087,12 @@ export async function runCommand(
           if (reg.sourceKind === 'git') {
             // ---- git 重抓（當下最新）：ls-remote → clone → checkout → snapshot fingerprint ----
             if (!reg.snapshot || !/^[0-9a-f]{64}$/.test(reg.snapshot)) {
-              messages.push(`⚠ marketplace [${display}] git cache 指紋缺失，無法重抓（請先重新 add）`);
+              updateLines.push(`⚠ marketplace [${display}] git cache 指紋缺失，無法重抓（請先重新 add）`);
               continue;
             }
             const locRes = normalizeGitLocator(reg.source);
             if (!locRes.ok) {
-              messages.push(`⚠ marketplace [${display}] Git 網址不合法：${locRes.findings[0]?.outcome ?? '未知錯誤'}`);
+              updateLines.push(`⚠ marketplace [${display}] Git 網址不合法：${locRes.findings[0]?.outcome ?? '未知錯誤'}`);
               continue;
             }
             const selectorDefault: NormalizedGitSelector = { kind: 'default', canonical: 'default', raw: 'default' };
@@ -1104,15 +1105,15 @@ export async function runCommand(
               });
             } catch (e) {
               const msg = e instanceof Error ? e.message : String(e);
-              messages.push(`錯誤：git 重抓失敗 — ${msg}`);
+              updateLines.push(`錯誤：git 重抓失敗 — ${msg}`);
               continue;
             }
             if (!acquireResult.ok) {
               const outcome = acquireResult.findings[0]?.outcome ?? acquireResult.stderr ?? 'git 重抓失敗';
-              messages.push(`錯誤：git 重抓失敗 — ${outcome}`);
+              updateLines.push(`錯誤：git 重抓失敗 — ${outcome}`);
               if (acquireResult.findings.length > 1) {
                 const extra = acquireResult.findings.slice(1, 3).map((f) => f.outcome).join('；');
-                if (extra) messages.push(`詳細：${extra}`);
+                if (extra) updateLines.push(`詳細：${extra}`);
               }
               if (acquireResult.acquiredPath && acquireResult.createdTemp) {
                 try { cleanupAcquisition(acquireResult.acquiredPath); } catch {}
@@ -1138,7 +1139,7 @@ export async function runCommand(
             });
             if (!snapRes.ok || !snapRes.snapshot) {
               cleanupAcquired();
-              messages.push(`⚠ marketplace [${display}] snapshot 建立失敗 — ${snapRes.findings[0]?.outcome ?? '未知錯誤'}`);
+              updateLines.push(`⚠ marketplace [${display}] snapshot 建立失敗 — ${snapRes.findings[0]?.outcome ?? '未知錯誤'}`);
               continue;
             }
             const fingerprint = snapRes.snapshot.fingerprint;
@@ -1163,11 +1164,12 @@ export async function runCommand(
             } catch (e) {
               cleanupAcquired();
               const msg = e instanceof Error ? e.message : String(e);
-              messages.push(`錯誤：cache 寫入失敗（fingerprint ${fingerprint.slice(0, 12)}…）：${msg}`);
+              updateLines.push(`錯誤：cache 寫入失敗（fingerprint ${fingerprint.slice(0, 12)}…）：${msg}`);
               continue;
             }
             cleanupAcquired();
             reg.snapshot = fingerprint;
+            gitAdvanced = true;
 
             // 重裝＝更新：從最新 cache 材料重裝全部已安裝 plugin（投影直讀新位址）
             const cacheRoot = catalogRootForReg(reg, opts);
@@ -1202,7 +1204,7 @@ export async function runCommand(
           } else {
             // ---- 本機重讀（live 路徑）----
             if (!reg.source || !existsSync(reg.source)) {
-              messages.push(`⚠ marketplace [${display}] 本機路徑不存在（${reg.source ?? '未記錄'}）`);
+              updateLines.push(`⚠ marketplace [${display}] 本機路徑不存在（${reg.source ?? '未記錄'}）`);
               continue;
             }
             // 先 probe catalog：不可讀時不能聲稱「無變化」，必須明示（不靜默略過）
@@ -1242,7 +1244,7 @@ export async function runCommand(
           }
         }
 
-        if (anyChanged) {
+        if (gitAdvanced || anyChanged) {
           try {
             writeMinimalBridgeState(state, opts);
           } catch (e) {
@@ -1253,7 +1255,7 @@ export async function runCommand(
             messages.push(`錯誤：寫入 Bridge State 失敗：${msg}`);
             break;
           }
-          reload = true;
+          if (anyChanged) reload = true;
         }
         messages.push(...updateLines);
         if (anyChanged) messages.push('已重新載入生效');

--- a/src/bridge/command.ts
+++ b/src/bridge/command.ts
@@ -380,10 +380,7 @@ function tryRefreshSkills(
     return undefined;
   }
   if (read.error || !read.catalog) return undefined;
-  const entry =
-    read.catalog.entries.find((e) => e.name === inst.manifestName && e.type === 'local' && e.path) ??
-    read.catalog.entries.find((e) => e.name === inst.manifestName && e.path) ??
-    read.catalog.entries.find((e) => e.path && basename(e.path) === inst.manifestName && e.type === 'local');
+  const entry = findEntryByManifestName(read.catalog, inst.manifestName);
   if (!entry?.path) return undefined;
   const contained = resolveContained(sourceRoot, entry.path, 'directory');
   if (contained.outcome.kind !== 'ok') return undefined;
@@ -407,6 +404,90 @@ function detectCollidingSkills(
     for (const s of (other as any).skills ?? []) existing.set(s, (existing.get(s) ?? 0) + 1);
   }
   return [...new Set(skillList.filter((s) => existing.has(s)))].sort((a, b) => a.localeCompare(b));
+}
+
+function findEntryByManifestName(catalog: Catalog, manifestName: string): MarketplaceEntry | undefined {
+  return (
+    catalog.entries.find((e) => e.name === manifestName && e.type === 'local' && e.path) ??
+    catalog.entries.find((e) => e.name === manifestName && e.path) ??
+    catalog.entries.find((e) => e.path && basename(e.path) === manifestName && e.type === 'local')
+  );
+}
+
+interface PluginRefreshOutcome {
+  ok: boolean;
+  manifestName: string;
+  skillNames: string[];
+  /** true when the latest material differs from the installation record（有變化） */
+  changed: boolean;
+  colliding: string[];
+  error?: string;
+}
+
+/**
+ * 重裝＝更新（#94）：對已安裝 plugin 在最新材料root（本機 live 路徑或 git 新 cache entry）重讀
+ * catalog → 重解析 manifest＋skills，回傳刷新結果由呼叫端套用。純邏輯分支不拋；
+ * 僅 I/O（readCatalogForReg／readManifestName／collectSkillNames）由各函式內部 try/catch 守護。
+ */
+function refreshInstalledPlugin(
+  root: string,
+  format: 'codex' | 'claude',
+  inst: MinimalBridgeState['installations'][number],
+  installations: MinimalBridgeState['installations'],
+): PluginRefreshOutcome {
+  const read = readCatalogForReg(root, format);
+  if (read.error || !read.catalog) {
+    return {
+      ok: false,
+      manifestName: inst.manifestName,
+      skillNames: [],
+      changed: false,
+      colliding: [],
+      error: read.error ?? 'catalog 讀取失敗',
+    };
+  }
+  const entry = findEntryByManifestName(read.catalog, inst.manifestName);
+  if (!entry?.path) {
+    return {
+      ok: false,
+      manifestName: inst.manifestName,
+      skillNames: [],
+      changed: false,
+      colliding: [],
+      error: '找不到對應 catalog entry（已從 marketplace 移除？）',
+    };
+  }
+  const contained = resolveContained(root, entry.path, 'directory');
+  if (contained.outcome.kind !== 'ok') {
+    const reason =
+      contained.outcome.kind === 'blocking' ? contained.outcome.reason : `plugin 目錄不存在（${entry.path}）`;
+    return {
+      ok: false,
+      manifestName: inst.manifestName,
+      skillNames: [],
+      changed: false,
+      colliding: [],
+      error: reason,
+    };
+  }
+  const pluginDir = contained.outcome.canonicalPath;
+  const manifestRes = readManifestName(pluginDir);
+  if (manifestRes.error || !manifestRes.name) {
+    return {
+      ok: false,
+      manifestName: inst.manifestName,
+      skillNames: [],
+      changed: false,
+      colliding: [],
+      error: manifestRes.error ?? 'manifest 讀取失敗',
+    };
+  }
+  const skillNames = collectSkillNames(pluginDir, format);
+  const oldSkills = [...(inst.skills ?? [])].sort((a, b) => a.localeCompare(b));
+  const newSkills = [...skillNames].sort((a, b) => a.localeCompare(b));
+  const changed = manifestRes.name !== inst.manifestName || JSON.stringify(oldSkills) !== JSON.stringify(newSkills);
+  const colliding = detectCollidingSkills(skillNames, installations, (other) => other.id === inst.id);
+  return { ok: true, manifestName: manifestRes.name, skillNames, changed, colliding };
 }
 
 function tryWriteState(state: MinimalBridgeState, opts: CommandOptions): string | undefined {
@@ -984,11 +1065,198 @@ export async function runCommand(
         break;
       }
       case 'update': {
+        // #94：對全部已註冊 marketplace 重抓「當下最新」（本機重讀、git 重抓），
+        // 有變化的 plugin 升到最新（重裝＝更新，不引入更新計畫機械），無變化各自顯示「無變化」。
         if (state.registrations.length === 0) {
           messages.push('尚無已註冊的 marketplace。');
-        } else {
-          messages.push('更新 marketplace（骨架建立中，功能即將推出）');
+          break;
         }
+        // 整包 deep backup：任一 marketplace 失敗不影響其他；最後一次寫入，寫失敗即回滾全部。
+        const stateBackup = JSON.parse(JSON.stringify(state)) as MinimalBridgeState;
+        const updateLines: string[] = [];
+        let anyChanged = false;
+
+        for (const reg of state.registrations) {
+          const display = reg.marketplaceName || reg.alias || reg.id;
+          const format = (reg.format ?? 'codex') as 'codex' | 'claude';
+          const insts = state.installations.filter((i) => i.registrationId === reg.id);
+          const upgraded: string[] = [];
+          const failures: string[] = [];
+
+          if (reg.sourceKind === 'git') {
+            // ---- git 重抓（當下最新）：ls-remote → clone → checkout → snapshot fingerprint ----
+            if (!reg.snapshot || !/^[0-9a-f]{64}$/.test(reg.snapshot)) {
+              messages.push(`⚠ marketplace [${display}] git cache 指紋缺失，無法重抓（請先重新 add）`);
+              continue;
+            }
+            const locRes = normalizeGitLocator(reg.source);
+            if (!locRes.ok) {
+              messages.push(`⚠ marketplace [${display}] Git 網址不合法：${locRes.findings[0]?.outcome ?? '未知錯誤'}`);
+              continue;
+            }
+            const selectorDefault: NormalizedGitSelector = { kind: 'default', canonical: 'default', raw: 'default' };
+            let acquireResult;
+            try {
+              acquireResult = await acquireGitSource({
+                locator: locRes.locator!,
+                selector: selectorDefault,
+                executor: opts.gitExecutor,
+              });
+            } catch (e) {
+              const msg = e instanceof Error ? e.message : String(e);
+              messages.push(`錯誤：git 重抓失敗 — ${msg}`);
+              continue;
+            }
+            if (!acquireResult.ok) {
+              const outcome = acquireResult.findings[0]?.outcome ?? acquireResult.stderr ?? 'git 重抓失敗';
+              messages.push(`錯誤：git 重抓失敗 — ${outcome}`);
+              if (acquireResult.findings.length > 1) {
+                const extra = acquireResult.findings.slice(1, 3).map((f) => f.outcome).join('；');
+                if (extra) messages.push(`詳細：${extra}`);
+              }
+              if (acquireResult.acquiredPath && acquireResult.createdTemp) {
+                try { cleanupAcquisition(acquireResult.acquiredPath); } catch {}
+              }
+              continue;
+            }
+
+            const acquiredPath = acquireResult.acquiredPath!;
+            const resolvedRevision = acquireResult.resolvedRevision!;
+            const createdTemp = acquireResult.createdTemp ?? false;
+            const cleanupAcquired = (): void => {
+              if (createdTemp) {
+                try { cleanupAcquisition(acquiredPath); } catch {}
+              }
+            };
+
+            const sourceKey = gitSourceKey(locRes.locator!, selectorDefault);
+            (sourceKey as unknown as { resolvedRevision?: string }).resolvedRevision = resolvedRevision;
+            const snapRes = buildGitSnapshot(acquiredPath, sourceKey, {
+              canonicalLocator: reg.source,
+              resolvedRevision,
+              selectorCanonical: selectorDefault.canonical,
+            });
+            if (!snapRes.ok || !snapRes.snapshot) {
+              cleanupAcquired();
+              messages.push(`⚠ marketplace [${display}] snapshot 建立失敗 — ${snapRes.findings[0]?.outcome ?? '未知錯誤'}`);
+              continue;
+            }
+            const fingerprint = snapRes.snapshot.fingerprint;
+
+            if (fingerprint === reg.snapshot) {
+              // 當下最新與上次相同 → 無變化
+              cleanupAcquired();
+              updateLines.push(`${display}  重新抓取… 無變化`);
+              continue;
+            }
+
+            // 有新版本：寫入 fingerprint 位址化的新 cache entry，registration 指向新材料
+            const cache = new SourceCache({ agentDir: opts.agentDir });
+            try {
+              await cache.storeTree(acquiredPath, fingerprint);
+              cache.recordIndex({
+                fingerprint,
+                resolvedRevision,
+                canonicalLocator: reg.source,
+                selectorCanonical: selectorDefault.canonical,
+              });
+            } catch (e) {
+              cleanupAcquired();
+              const msg = e instanceof Error ? e.message : String(e);
+              messages.push(`錯誤：cache 寫入失敗（fingerprint ${fingerprint.slice(0, 12)}…）：${msg}`);
+              continue;
+            }
+            cleanupAcquired();
+            reg.snapshot = fingerprint;
+
+            // 重裝＝更新：從最新 cache 材料重裝全部已安裝 plugin（投影直讀新位址）
+            const cacheRoot = catalogRootForReg(reg, opts);
+            if (cacheRoot) {
+              for (const inst of insts) {
+                const outcome = refreshInstalledPlugin(cacheRoot, format, inst, state.installations);
+                if (!outcome.ok) {
+                  failures.push(`${inst.manifestName} 更新失敗：${outcome.error}`);
+                  continue;
+                }
+                inst.manifestName = outcome.manifestName;
+                inst.pluginId = outcome.manifestName;
+                inst.skills = outcome.skillNames;
+                inst.snapshot = fingerprint;
+                upgraded.push(outcome.manifestName);
+                for (const c of outcome.colliding) {
+                  updateLines.push(`⚠ skill "${c}" 與既有同名，未投影（名稱衝突）`);
+                }
+              }
+            } else {
+              for (const inst of insts) failures.push(`${inst.manifestName} 更新失敗：cache 材料無法解析`);
+            }
+
+            for (const f of failures) updateLines.push(`⚠ marketplace [${display}] ${f}`);
+            if (upgraded.length > 0) {
+              updateLines.push(`${display}  重新抓取… ${upgraded.join(', ')} 有新版本`);
+              anyChanged = true;
+            } else if (insts.length === 0) {
+              // upstream 移動但沒有已安裝 plugin：registration 已指向最新，下次 install 即用最新
+              updateLines.push(`${display}  重新抓取… 有新版本`);
+            }
+          } else {
+            // ---- 本機重讀（live 路徑）----
+            if (!reg.source || !existsSync(reg.source)) {
+              messages.push(`⚠ marketplace [${display}] 本機路徑不存在（${reg.source ?? '未記錄'}）`);
+              continue;
+            }
+            // 先 probe catalog：不可讀時不能聲稱「無變化」，必須明示（不靜默略過）
+            const probe = readCatalogForReg(reg.source, format);
+            if (probe.error) {
+              updateLines.push(`⚠ marketplace [${display}] ${probe.error}`);
+              continue;
+            }
+            if (insts.length === 0) {
+              updateLines.push(`${display}  重新抓取… 無變化`);
+              continue;
+            }
+            let changed = false;
+            for (const inst of insts) {
+              const outcome = refreshInstalledPlugin(reg.source, format, inst, state.installations);
+              if (!outcome.ok) {
+                failures.push(`${inst.manifestName} 更新失敗：${outcome.error}`);
+                continue;
+              }
+              inst.manifestName = outcome.manifestName;
+              inst.pluginId = outcome.manifestName;
+              inst.skills = outcome.skillNames;
+              changed = changed || outcome.changed;
+              upgraded.push(outcome.manifestName);
+              for (const c of outcome.colliding) {
+                updateLines.push(`⚠ skill "${c}" 與既有同名，未投影（名稱衝突）`);
+              }
+            }
+            for (const f of failures) updateLines.push(`⚠ marketplace [${display}] ${f}`);
+            if (upgraded.length === 0) continue; // 全部失敗，⚠ 已明示
+            if (changed) {
+              updateLines.push(`${display}  重新抓取… ${upgraded.join(', ')} 有新版本`);
+              anyChanged = true;
+            } else {
+              updateLines.push(`${display}  重新抓取… 無變化`);
+            }
+          }
+        }
+
+        if (anyChanged) {
+          try {
+            writeMinimalBridgeState(state, opts);
+          } catch (e) {
+            // 寫入失敗 → 回滾全部已套用的更新（registration snapshot 與安裝記錄）
+            state.registrations = stateBackup.registrations;
+            state.installations = stateBackup.installations;
+            const msg = e instanceof Error ? e.message : String(e);
+            messages.push(`錯誤：寫入 Bridge State 失敗：${msg}`);
+            break;
+          }
+          reload = true;
+        }
+        messages.push(...updateLines);
+        if (anyChanged) messages.push('已重新載入生效');
         break;
       }
       case 'disable': {

--- a/tests/unit/bridge/command-update.test.ts
+++ b/tests/unit/bridge/command-update.test.ts
@@ -225,6 +225,34 @@ describe('update #94 全部重抓最新（本機重讀／git 重抓）', () => {
     expect(readMinimalBridgeState({ agentDir }).state.registrations[0].snapshot).toBe(newFp);
   });
 
+  it('git 重抓：upstream 升級但無已安裝 plugin → reg.snapshot 仍推進並持久化（投影指向最新材料），不 reload', async () => {
+    makeCodexMarketplace(gitRepo, 'git-mkt', [{ name: 'gp1', path: './plugins/gp1', skills: ['g1'] }]);
+    const shaA = 'a'.repeat(40);
+    await runCommand(['add', 'https://github.com/acme/git-mkt'], { agentDir, gitExecutor: makeGitExecutor(gitRepo, shaA) });
+    const oldFp = readMinimalBridgeState({ agentDir }).state.registrations[0].snapshot!;
+
+    // upstream bump：新 sha 且新 tree，但沒有任何安裝 → 沒有可升級的 plugin
+    const shaB = 'b'.repeat(40);
+    makeCodexMarketplace(gitRepo2, 'git-mkt', [{ name: 'gp1', path: './plugins/gp1', skills: ['g1', 'g2'] }]);
+    const newExecutor = makeGitExecutor(gitRepo2, shaB);
+
+    const res = await runCommand(['update'], { agentDir, gitExecutor: newExecutor });
+    expect(res.output).toContain('git-mkt  重新抓取… 有新版本');
+    expect(res.output).not.toContain('已重新載入生效');
+    expect(res.reload).toBe(false);
+
+    // reg.snapshot 推進已持久化（重抓最新不因無 plugin 而丟失）；cache 新 entry 存在
+    const st = readMinimalBridgeState({ agentDir });
+    const newFp = st.state.registrations[0].snapshot!;
+    expect(newFp).not.toBe(oldFp);
+    expect(existsSync(join(getCacheEntriesDir(getCacheDir(agentDir)), newFp))).toBe(true);
+
+    // 再 update 一次（同新版本）→ 無變化
+    const again = await runCommand(['update'], { agentDir, gitExecutor: newExecutor });
+    expect(again.output).toContain('git-mkt  重新抓取… 無變化');
+    expect(again.reload).toBe(false);
+  });
+
   it('git 重抓失敗（ls-remote 失敗）→ 明示錯誤、不 reload、state 不變', async () => {
     makeCodexMarketplace(gitRepo, 'git-mkt', [{ name: 'gp1', path: './plugins/gp1', skills: ['g1'] }]);
     const sha = 'a'.repeat(40);

--- a/tests/unit/bridge/command-update.test.ts
+++ b/tests/unit/bridge/command-update.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, readFileSync, cpSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { runCommand } from '../../../src/bridge/command.js';
+import { readMinimalBridgeState } from '../../../src/bridge/state.js';
+import { discoverProjectedSkillPaths } from '../../../src/projection/exposure.js';
+import type { GitExecutor } from '../../../src/registration/git-acquisition.js';
+import { getCacheDir, getCacheEntriesDir } from '../../../src/cache/paths.js';
+
+function makeCodexMarketplace(root: string, name: string, plugins: { name: string; path: string; skills?: string[] }[]) {
+  mkdirSync(join(root, '.agents', 'plugins'), { recursive: true });
+  writeFileSync(join(root, '.agents', 'plugins', 'marketplace.json'), JSON.stringify({ name, plugins: plugins.map(p=>({name:p.name, source:{source:'local', path:p.path}})) }));
+  for (const p of plugins) {
+    const abs = join(root, p.path.replace(/^\.\//, ''));
+    mkdirSync(abs, { recursive: true });
+    mkdirSync(join(abs, '.codex-plugin'), { recursive: true });
+    writeFileSync(join(abs, '.codex-plugin', 'plugin.json'), JSON.stringify({ name: p.name }));
+    writeFileSync(join(abs, 'plugin.json'), JSON.stringify({ name: p.name }));
+    if (p.skills) {
+      for (const skill of p.skills) {
+        const sdir = join(abs, 'skills', skill);
+        mkdirSync(sdir, { recursive: true });
+        writeFileSync(join(sdir, 'SKILL.md'), `---\nname: ${skill}\ndescription: Desc for ${skill}\n---\n\nBody for ${skill}\n`);
+      }
+    }
+  }
+}
+
+function addSkillToPlugin(pluginDir: string, skill: string): void {
+  const sdir = join(pluginDir, 'skills', skill);
+  mkdirSync(sdir, { recursive: true });
+  writeFileSync(join(sdir, 'SKILL.md'), `---\nname: ${skill}\ndescription: Desc for ${skill}\n---\n\nBody for ${skill}\n`);
+}
+
+function makeGitExecutor(fixtureRoot: string, sha: string): GitExecutor {
+  return async (args) => {
+    if (args.includes('ls-remote')) {
+      const ref = args[args.length - 1];
+      return { exitCode: 0, stdout: `${sha}\t${ref}\n`, stderr: '' };
+    }
+    if (args.includes('clone')) {
+      const dest = args[args.length - 1];
+      cpSync(fixtureRoot, dest, { recursive: true });
+      mkdirSync(join(dest, '.git'), { recursive: true });
+      return { exitCode: 0, stdout: '', stderr: '' };
+    }
+    return { exitCode: 0, stdout: '', stderr: '' };
+  };
+}
+
+describe('update #94 全部重抓最新（本機重讀／git 重抓）', () => {
+  let agentDir: string;
+  let mktRoot: string;
+  let mktRoot2: string;
+  let gitRepo: string;
+  let gitRepo2: string;
+
+  beforeEach(() => {
+    agentDir = mkdtempSync(join(tmpdir(), 'agent94-'));
+    mktRoot = mkdtempSync(join(tmpdir(), 'mkt94-'));
+    mktRoot2 = mkdtempSync(join(tmpdir(), 'mkt94b-'));
+    gitRepo = mkdtempSync(join(tmpdir(), 'git94-'));
+    gitRepo2 = mkdtempSync(join(tmpdir(), 'git94b-'));
+  });
+
+  afterEach(() => {
+    rmSync(agentDir, { recursive: true, force: true });
+    rmSync(mktRoot, { recursive: true, force: true });
+    rmSync(mktRoot2, { recursive: true, force: true });
+    rmSync(gitRepo, { recursive: true, force: true });
+    rmSync(gitRepo2, { recursive: true, force: true });
+  });
+
+  it('無已註冊 marketplace → 提示且不 reload', async () => {
+    const res = await runCommand(['update'], { agentDir });
+    expect(res.output).toContain('尚無已註冊的 marketplace');
+    expect(res.reload).toBe(false);
+  });
+
+  it('本機重讀：全部 plugin 無變化 → 顯示「無變化」、不 reload、記錄不變', async () => {
+    makeCodexMarketplace(mktRoot, 'mkt-a', [{ name: 'p1', path: './plugins/p1', skills: ['s1'] }]);
+    await runCommand(['add', mktRoot], { agentDir });
+    await runCommand(['install', '1'], { agentDir });
+    const before = readMinimalBridgeState({ agentDir });
+
+    const res = await runCommand(['update'], { agentDir });
+    expect(res.output).toContain('mkt-a  重新抓取… 無變化');
+    expect(res.output).not.toContain('有新版本');
+    expect(res.output).not.toContain('已重新載入生效');
+    expect(res.reload).toBe(false);
+
+    const after = readMinimalBridgeState({ agentDir });
+    expect(after.state.registrations.length).toBe(before.state.registrations.length);
+    expect(after.state.installations).toEqual(before.state.installations);
+  });
+
+  it('本機重讀：plugin 有新技能 → 「有新版本」＋「已重新載入生效」＋reload＋記錄刷新＋投影縫層斷言', async () => {
+    makeCodexMarketplace(mktRoot, 'mkt-a', [{ name: 'p1', path: './plugins/p1', skills: ['s1'] }]);
+    await runCommand(['add', mktRoot], { agentDir });
+    await runCommand(['install', '1'], { agentDir });
+
+    // live tree gains a new skill（有變化）
+    addSkillToPlugin(join(mktRoot, 'plugins', 'p1'), 's2');
+
+    const res = await runCommand(['update'], { agentDir });
+    expect(res.output).toContain('mkt-a  重新抓取… p1 有新版本');
+    expect(res.output).toContain('已重新載入生效');
+    expect(res.reload).toBe(true);
+
+    const st = readMinimalBridgeState({ agentDir });
+    expect(st.state.installations).toHaveLength(1);
+    expect(st.state.installations[0].skills).toEqual(['s1', 's2']);
+
+    const proj = discoverProjectedSkillPaths({ agentDir });
+    expect(proj.skillPaths.some((p) => p.includes('s1'))).toBe(true);
+    expect(proj.skillPaths.some((p) => p.includes('s2'))).toBe(true);
+  });
+
+  it('兩個 marketplace 混合：一無變化一有新版本；各有「無變化／有新版本」行，結尾單一「已重新載入生效」', async () => {
+    makeCodexMarketplace(mktRoot, 'mkt-a', [{ name: 'p1', path: './plugins/p1', skills: ['s1'] }]);
+    makeCodexMarketplace(mktRoot2, 'mkt-b', [{ name: 'p2', path: './plugins/p2', skills: ['s2'] }]);
+    await runCommand(['add', mktRoot], { agentDir });
+    await runCommand(['add', mktRoot2], { agentDir });
+    await runCommand(['install', '1'], { agentDir }); // p1（mkt-a）
+    await runCommand(['install', '2'], { agentDir }); // p2（mkt-b）
+
+    addSkillToPlugin(join(mktRoot2, 'plugins', 'p2'), 's3');
+
+    const res = await runCommand(['update'], { agentDir });
+    expect(res.output).toContain('mkt-a  重新抓取… 無變化');
+    expect(res.output).toContain('mkt-b  重新抓取… p2 有新版本');
+    const reloadLines = res.output.split('\n').filter((l) => l.includes('已重新載入生效'));
+    expect(reloadLines).toHaveLength(1);
+    expect(res.reload).toBe(true);
+
+    const st = readMinimalBridgeState({ agentDir });
+    const instB = st.state.installations.find((i) => i.manifestName === 'p2')!;
+    expect(instB.skills).toEqual(['s2', 's3']);
+  });
+
+  it('本機重讀：catalog 讀取失敗 → 明示錯誤不靜默；其他 marketplace 照常處理；不 reload', async () => {
+    makeCodexMarketplace(mktRoot, 'mkt-a', [{ name: 'p1', path: './plugins/p1', skills: ['s1'] }]);
+    await runCommand(['add', mktRoot], { agentDir });
+    // 破壞 catalog 後 update
+    writeFileSync(join(mktRoot, '.agents', 'plugins', 'marketplace.json'), '{ broken,,');
+    const res = await runCommand(['update'], { agentDir });
+    expect(res.output).toMatch(/⚠ marketplace \[mkt-a\].*catalog/i);
+    expect(res.reload).toBe(false);
+    expect(res.output).not.toContain('無變化');
+    const st = readMinimalBridgeState({ agentDir });
+    expect(st.state.installations).toHaveLength(0);
+  });
+
+  it('本機重讀：已安裝 plugin 的 entry 從 catalog 消失 → ⚠ 明示失敗、不 crash、安裝保留、不 reload', async () => {
+    makeCodexMarketplace(mktRoot, 'mkt-a', [{ name: 'p1', path: './plugins/p1', skills: ['s1'] }]);
+    await runCommand(['add', mktRoot], { agentDir });
+    await runCommand(['install', '1'], { agentDir });
+    // catalog 移除 p1 entry
+    makeCodexMarketplace(mktRoot, 'mkt-a', []);
+    const res = await runCommand(['update'], { agentDir });
+    expect(res.output).toMatch(/⚠ marketplace \[mkt-a\].*p1.*找不到對應/);
+    expect(res.reload).toBe(false);
+    const st = readMinimalBridgeState({ agentDir });
+    expect(st.state.installations).toHaveLength(1);
+    expect(st.state.installations[0].skills).toEqual(['s1']);
+  });
+
+  it('git 重抓：upstream 無變化（同 sha 同 tree）→ 「無變化」、不 reload、snapshot 不動', async () => {
+    makeCodexMarketplace(gitRepo, 'git-mkt', [{ name: 'gp1', path: './plugins/gp1', skills: ['g1'] }]);
+    const sha = 'a'.repeat(40);
+    const gitExecutor = makeGitExecutor(gitRepo, sha);
+    await runCommand(['add', 'https://github.com/acme/git-mkt'], { agentDir, gitExecutor });
+    await runCommand(['install', '1'], { agentDir, gitExecutor });
+    const before = readMinimalBridgeState({ agentDir });
+
+    const res = await runCommand(['update'], { agentDir, gitExecutor });
+    expect(res.output).toContain('git-mkt  重新抓取… 無變化');
+    expect(res.output).not.toContain('有新版本');
+    expect(res.output).not.toContain('已重新載入生效');
+    expect(res.reload).toBe(false);
+
+    const after = readMinimalBridgeState({ agentDir });
+    expect(after.state.registrations[0].snapshot).toBe(before.state.registrations[0].snapshot);
+    expect(after.state.installations).toEqual(before.state.installations);
+  });
+
+  it('git 重抓：upstream 升級（新 sha 新 tree）→ 「有新版本」＋reload＋reg.snapshot 指向新 fingerprint＋cache 新 entry＋投影自新 cache 位址（縫層斷言）', async () => {
+    makeCodexMarketplace(gitRepo, 'git-mkt', [{ name: 'gp1', path: './plugins/gp1', skills: ['g1'] }]);
+    const shaA = 'a'.repeat(40);
+    const gitExecutor = makeGitExecutor(gitRepo, shaA);
+    await runCommand(['add', 'https://github.com/acme/git-mkt'], { agentDir, gitExecutor });
+    await runCommand(['install', '1'], { agentDir, gitExecutor });
+    const oldFp = readMinimalBridgeState({ agentDir }).state.registrations[0].snapshot!;
+
+    // upstream bump：新 sha 且新 tree（新增 skill）
+    const shaB = 'b'.repeat(40);
+    makeCodexMarketplace(gitRepo2, 'git-mkt', [{ name: 'gp1', path: './plugins/gp1', skills: ['g1', 'g2'] }]);
+    const newExecutor = makeGitExecutor(gitRepo2, shaB);
+
+    const res = await runCommand(['update'], { agentDir, gitExecutor: newExecutor });
+    expect(res.output).toContain('git-mkt  重新抓取… gp1 有新版本');
+    expect(res.output).toContain('已重新載入生效');
+    expect(res.reload).toBe(true);
+
+    const st = readMinimalBridgeState({ agentDir });
+    const reg = st.state.registrations[0];
+    expect(reg.snapshot).not.toBe(oldFp);
+    const newFp = reg.snapshot!;
+    expect(st.state.installations[0].skills).toEqual(['g1', 'g2']);
+    expect(st.state.installations[0].snapshot).toBe(newFp);
+
+    // cache 新 entry 存在、投影指向新 cache 位址（最新材料）
+    const entriesDir = getCacheEntriesDir(getCacheDir(agentDir));
+    expect(existsSync(join(entriesDir, newFp))).toBe(true);
+    const proj = discoverProjectedSkillPaths({ agentDir });
+    expect(proj.skillPaths.some((p) => p.includes(newFp))).toBe(true);
+    expect(proj.skillPaths.some((p) => p.includes('g2'))).toBe(true);
+
+    // 再 update 一次（同新版本）→ 無變化
+    const again = await runCommand(['update'], { agentDir, gitExecutor: newExecutor });
+    expect(again.output).toContain('git-mkt  重新抓取… 無變化');
+    expect(again.reload).toBe(false);
+    expect(readMinimalBridgeState({ agentDir }).state.registrations[0].snapshot).toBe(newFp);
+  });
+
+  it('git 重抓失敗（ls-remote 失敗）→ 明示錯誤、不 reload、state 不變', async () => {
+    makeCodexMarketplace(gitRepo, 'git-mkt', [{ name: 'gp1', path: './plugins/gp1', skills: ['g1'] }]);
+    const sha = 'a'.repeat(40);
+    await runCommand(['add', 'https://github.com/acme/git-mkt'], { agentDir, gitExecutor: makeGitExecutor(gitRepo, sha) });
+    await runCommand(['install', '1'], { agentDir, gitExecutor: makeGitExecutor(gitRepo, sha) });
+    const before = readMinimalBridgeState({ agentDir });
+
+    const failing: GitExecutor = async (args) => {
+      if (args.includes('ls-remote')) return { exitCode: 1, stdout: '', stderr: 'boom' };
+      return { exitCode: 0, stdout: '', stderr: '' };
+    };
+    const res = await runCommand(['update'], { agentDir, gitExecutor: failing });
+    expect(res.output).toMatch(/錯誤.*git 重抓失敗|git 重抓失敗/);
+    expect(res.reload).toBe(false);
+
+    const after = readMinimalBridgeState({ agentDir });
+    expect(after.state).toEqual(before.state);
+  });
+});


### PR DESCRIPTION
Closes #94

Parent #87

`update`：對全部已註冊 marketplace 重新抓取「當下最新」（本機重讀、git 重抓），有變化的 plugin 升到最新並重新載入生效，無變化的各自顯示「無變化」。語意上「重裝＝更新」，不引入任何更新計畫機械。

### 變更項目

- **`src/bridge/command.ts`**：
  - `update` 實作：
    - **本機 marketplace**：live 路徑重讀 catalog（先 probe：catalog 缺失／malformed → `⚠ marketplace [name] <原因>`，不靜默略過）→ 對全部已安裝 plugin 重解析（entry → manifest → skills，含衝突重算）；有 diff（manifest 名稱或 skill 名單）→ 刷新 Installation 記錄＋「有新版本」；無 → 「無變化」
    - **git marketplace**：完整重抓（ls-remote → clone → checkout → snapshot fingerprint，同 add 取得路徑與安全線）；fingerprint 同舊 → 「無變化」（丟棄暫存）；不同 → `storeTree` 新 fingerprint 位址化 cache entry → registration/installation snapshot 重指向最新材料（投影直讀新位址）→ 全部已安裝 plugin 重裝（重裝＝更新）
    - 有變 → 結尾「已重新載入生效」＋`reload=true`；無變 → 不 reload
    - 無已安裝 plugin 的 git marketplace 升級：registration 仍推進並持久化（下次 install 即用最新），不 reload
    - git 重抓失敗／cache 寫入失敗／entry 消失／plugin 目錄缺失 → 明示錯誤，不靜默略過；任一 marketplace 失敗不影響其他
    - 整包 deep backup、最後一次原子寫入、寫失敗全回滾（沿用既有 fail-closed 慣例）
  - 抽出 `findEntryByManifestName`（收斂 `tryRefreshSkills` 重複）與 `refreshInstalledPlugin` 共用 helper
- **`tests/unit/bridge/command-update.test.ts`**（新增，走 runCommand 縫）：
  - 本機：無註冊提示／無變化（記錄不變、不 reload）／有新技能（記錄刷新＋reload＋投影縫層斷言）／兩 marketplace 混合（各有「無變化／有新版本」行、結尾單一「已重新載入生效」）／catalog 損壞明示／entry 消失保留安裝
  - git（注入 `gitExecutor` mock）：同 sha 同 tree 無變化／新 sha 新 tree 升級（reg.snapshot 指向新 fingerprint＋cache 新 entry＋投影自新 cache 位址縫層斷言＋再 update 無變化）／升級但無安裝（snapshot 仍持久化）／ls-remote 失敗明示

### 驗證

- `npx tsc --noEmit` ✅
- `npx vitest run tests/unit/bridge/command-update.test.ts --coverage=false` ✅（10 tests）
- `npx vitest run --coverage=false` ✅（844 tests 全綠）

### Acceptance criteria 對照

| #94 驗收條件 | 狀態 | 驗證落點 |
|---|---|---|
| update 對全部已註冊 marketplace 重抓最新（本機重讀、git 重抓） | ✅ | 本機 live 路徑重讀；git ls-remote→clone→checkout→fingerprint 完整重抓（`本機重讀：…`／`git 重抓：…`） |
| 有變化 → 升到最新＋「已重新載入生效」＋reload 旗標 | ✅ | 輸出含「有新版本」＋「已重新載入生效」，`reload=true`，Installation 記錄刷新（skills／snapshot） |
| 無變化 → 顯示「無變化」 | ✅ | 各自顯示「無變化」，`reload=false`，記錄不變 |
| 更新後投影仍指向最新材料（縫層或 e2e 斷言） | ✅ | `discoverProjectedSkillPaths` 縫層斷言：git 升級後 skillPaths 含新 fingerprint cache 位址與新 skill；本機含新 skill |
| 走 runCommand 縫測試 | ✅ | 全程 `runCommand(argv, {agentDir})` 純函式縫（git 情境注入 `gitExecutor` mock） |