### PR TITLE
docs: 文件收斂＋全綠收尾（CONTEXT/ADR/README、CI gate） (#97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ All notable changes to `pi-codex-marketplace` are documented here. Format follow
   - 全專案 typecheck＋測試全綠（CI gate 維持）。
 
 ### Removed
+- **拆防損毀／生命週期機械＋舊 TUI 殘餘** (#95)：
+  - 移除 receipt／fence／journal／State Revision／CAS／repair／startup reconciliation／migration／refresh／update／update-plan／rebind 機械及其對應測試（`src/journal/`、`src/lifecycle/`、`src/reconciliation/`、`src/bridge-state/{migrate,repair,schema,store,types}.ts`、`src/installation/`、`src/compatibility/`、`src/projection/{runtime,effective-state}.ts`、`src/registration/{fence,receipt,flow,git-flow,registration}.ts`）。
+  - 移除舊 TUI 殘餘與重疊舊 extensions（bridge ledger、transaction sheet、journal view、effective-state view、ui-strings、terminal-presentation 等）；extension 收斂為薄 adapter（`runCommand`＋`resources_discover`）。
+  - 存活消費者收斂：投影僅讀 Minimal Bridge State、Source Cache pinning 讀極簡 state、Entry Acquisition 收斂為 `entry-spec` 純解析（git 家族 entry 一律 unavailable 不取得）。
+  - CONTEXT.md 詞彙與 README 收斂至極簡表面；ADR 0004／0005 標記 superseded。
+  - 全專案 typecheck＋存活測試全綠。
+- **拆讀取／分類退場** (#96)：移除 entry-acquisition（外部 git entry 收編＋pin 矩陣）、git-selector（pins）、compatibility v2 儀式（atomic 三分法分類、Agent Profile 解析、resources 掃描、captureFingerprint、ruleset/budget/profile 字串常數）及其測試；catalog 內 git 型／不支援 entry 的 unavailable 行為維持（#91）。
 
 ## [0.3.0] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,18 @@ All notable changes to `pi-codex-marketplace` are documented here. Format follow
 
 ## [Unreleased]
 
+### Added
+- **disable／enable／remove／forget＋總覽狀態** (#93)：`disable <名稱>` 停用（不再投影、下次 discovery pass 自然消失）、`enable <名稱>` 重新投影＋reload、`remove <名稱>` 移除單支 plugin（不動 marketplace、不動來源資料）、`forget <名稱>` 移除整個 marketplace（含其全部安裝）；無參數總覽反映 marketplace 與 installed 狀態。
+- **update：全部 marketplace 重抓最新** (#94)：對全部已註冊 marketplace 重新抓取當下最新（本機重讀／git 重抓），有變化的 plugin 升到最新並以「已重新載入生效」收尾，無變化的各自顯示「無變化」；投影指向最新材料。語意上「重裝＝更新」，不引入任何更新計畫機械。
+
+### Changed
+- **文件收斂＋全綠收尾** (#97)：
+  - CONTEXT.md 移除僅描述已退場機械的詞彙（Git Selector、Validation Ruleset），修正 Validation Snapshot／Validation Budget 描述至極簡現狀（指紋不再綁 ruleset/budget 字串；budget 為固定常數限制），存活詞彙全部保留並同步至最新語意（Resolved Revision 僅 HEAD、Source Key 固定 `default` selector）。
+  - ADR 收斂至與極簡一致：0001（投影縫）與 0003（雙格式偵測 codex 優先）標記仍生效並改寫退場機械引用（receipt／Retry Application／Project Scope layering／Refresh／Update Plan）；0002（Global-only）標記部分仍生效並註明生命週期機械後續退場；0004／0005 維持 superseded 並更正拆除範圍（#95/#96、`parseGitEntrySpec` 已移除）。
+  - README 持續反映新指令表面與極簡承諾（九子命令、重建＝重置、無 repair／migration／State Revision）。
+  - 全專案 typecheck＋測試全綠（CI gate 維持）。
+
 ### Removed
-- **拆防損毀／生命週期機械＋舊 TUI 殘餘** (#95)：
-  - 移除 receipt／fence／journal／State Revision／CAS／repair／startup reconciliation／migration／refresh／update／update-plan／rebind 機械及其對應測試（`src/journal/`、`src/lifecycle/`、`src/reconciliation/`、`src/bridge-state/{migrate,repair,schema,store,types}.ts`、`src/installation/`、`src/compatibility/`、`src/projection/{runtime,effective-state}.ts`、`src/registration/{fence,receipt,flow,git-flow,registration}.ts`）。
-  - 移除舊 TUI 殘餘與重疊舊 extensions（bridge ledger、transaction sheet、journal view、effective-state view、ui-strings、terminal-presentation 等）；extension 收斂為薄 adapter（`runCommand`＋`resources_discover`）。
-  - 存活消費者收斂：投影僅讀 Minimal Bridge State、Source Cache pinning 讀極簡 state、Entry Acquisition 收斂為 `entry-spec` 純解析（git 家族 entry 一律 unavailable 不取得）。
-  - CONTEXT.md 詞彙與 README 收斂至極簡表面；ADR 0004／0005 標記 superseded。
-  - 全專案 typecheck＋存活測試全綠。
 
 ## [0.3.0] - 2026-08-27
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -64,13 +64,9 @@ _Avoid_: Package installation, build, Plugin activation
 The constrained host components trusted during Source Acquisition: the selected Git and SSH executables, operating-system certificate authorities, pre-established SSH known-host keys, and approved credential helper or SSH agent. The Bridge Package permits only necessary trust and credential configuration, rejects unknown or changed SSH host keys and canonical-locator-changing redirects, and never extends this trust to repository content or repository-controlled Git configuration.
 _Avoid_: Project Trust, Plugin trust, sandbox
 
-**Git Selector**:
-The structured `default`, `branch`, `tag`, or `commit` choice attached to a Git Marketplace Source. Branch and tag values obey Git ref-name rules and canonicalize to exact case-sensitive `refs/heads/...` or `refs/tags/...` values; commit values are complete 40- or 64-hex object names canonicalized to lowercase. Ambiguous shorthand, abbreviated object names, generic refs, `HEAD`, revision or reflog expressions, option-like values, whitespace, and control characters are not accepted.
-_Avoid_: Resolved Revision, arbitrary Git revision expression
-
 **Resolved Revision**:
-The full Git commit at which a Git Marketplace Source was acquired. It is a source attribute rather than identity; a changed resolution means the latest material differs, which an explicit `update` re-fetches.
-_Avoid_: Git Selector, Plugin version
+The full Git commit at which a Git Marketplace Source was acquired. Git acquisition always resolves HEAD; there is no branch, tag, or commit selector. It is a source attribute rather than identity; a changed resolution means the latest material differs, which an explicit `update` re-fetches.
+_Avoid_: Plugin version
 
 **Canonical Git Locator**:
 A credential-free HTTPS or SSH repository locator that preserves identity-relevant transport, host, port, path, and SSH user. Plaintext or local transports, embedded credentials, query, fragment, and ambiguous encoding are not accepted.
@@ -85,15 +81,11 @@ A symlink whose canonical target is a regular file or directory within the same 
 _Avoid_: Unrestricted symlink, path escape
 
 **Validation Snapshot**:
-The deterministic fingerprint of one acquired or inspected source tree (ordered paths, object types, modes, symlink targets, content hashes), binding the Source Key, verified Canonical Git Locator and Resolved Revision where applicable, and the Validation Ruleset and Validation Budget strings. It is the Source Cache addressing key: Git Registrations and Installations pin their fingerprint, and projection reads the pinned cache entry directly, so the fingerprint must never be replaced by another identity value.
+The deterministic fingerprint of one acquired or inspected source tree (ordered paths, object types, modes, symlink targets, content hashes), binding the Source Key and, for Git, the verified Canonical Git Locator and Resolved Revision. It is the Source Cache addressing key: Git Registrations and Installations pin their fingerprint, and projection reads the pinned cache entry directly, so the fingerprint must never be replaced by another identity value.
 _Avoid_: Live source tree, cache freshness marker
 
-**Validation Ruleset**:
-The versioned Bridge contract for source, parser, content, path, symlink, finding, and failure-granularity rules, bound into the Validation Snapshot fingerprint. A changed ruleset changes fingerprints and therefore cache addresses.
-_Avoid_: Compatibility Profile alone, implementation version
-
 **Validation Budget**:
-A versioned set of fixed, non-waivable limits on acquisition time and size, parser complexity, path depth, file counts, and validation-relevant content. Exceeding a limit produces a Blocking Finding at the owning source, catalog, entry, or Plugin boundary rather than partial or best-effort validation.
+A fixed, non-waivable set of limits on tree depth, inspected file counts and content bytes, Marketplace Catalog size, entry count, and declared name length. Exceeding a limit produces a Blocking Finding at the owning source or catalog boundary rather than partial or best-effort validation; the limits are constants, not a versioned contract.
 _Avoid_: Cache retention policy, warning threshold
 
 **Source Cache**:
@@ -109,7 +101,7 @@ An opaque, immutable lowercase UUIDv4 generated locally by the Bridge Package fo
 _Avoid_: Marketplace name, alias, source path, Git URL
 
 **Source Key**:
-A deterministic, typed value used to compare Marketplace Sources for duplicate detection and repeated registration; it is not the identity of a Marketplace Registration. A local Source Key uses the Marketplace Root's canonical real path, while a Git Source Key combines a canonical remote URL with its exact selector; local and Git keys remain distinct, and equal keys do not merge registrations.
+A deterministic, typed value used to compare Marketplace Sources for duplicate detection and repeated registration; it is not the identity of a Marketplace Registration. A local Source Key uses the Marketplace Root's canonical real path, while a Git Source Key combines a canonical remote URL with its fixed `default` selector (Git sources always resolve HEAD); local and Git keys remain distinct, and equal keys do not merge registrations.
 _Avoid_: Registration ID, user-facing alias
 
 **Registration Alias**:
@@ -125,7 +117,7 @@ A bundle whose `.codex-plugin/plugin.json` or `.claude-plugin/plugin.json` manif
 _Avoid_: Pi package, Pi extension
 
 **Plugin ID**:
-The canonical identity of a Plugin, composed of its Marketplace ID and authoritative manifest name. Version, source revision, Marketplace Entry ordinal, and directory path are attributes; changing the manifest name creates a new Plugin ID without automatically migrating an Installation.
+The canonical identity of a Plugin, composed of its Marketplace ID and authoritative manifest name. Version, Resolved Revision, Marketplace Entry ordinal, and directory path are attributes; changing the manifest name creates a new Plugin ID without automatically migrating an Installation.
 _Avoid_: Marketplace entry name, Plugin path
 
 **Unavailable Entry**:
@@ -163,7 +155,7 @@ _Avoid_: Compatible Plugin, renamed skill
 
 **Runtime Skill Exposure**:
 The read-time participation of Projected Skills in Pi through host resource discovery contributed by the Bridge Extension at session start or runtime reload. It derives entirely from the current Effective State and its collision survivors, performs passive existence inspection only, never mutates Bridge State, and is neither confirmation nor activation admission. Exposure never establishes Skill Availability. `install` / `enable` / `update` request a host reload as the only activation action; a failed reload does not affect the recorded state.
-_Avoid_: Installation, Marketplace Refresh, activation confirmation
+_Avoid_: Installation, activation confirmation
 
 **Skill Availability**:
 The evidence status of an Installed Plugin skill, for which the Bridge may report eligibility, known unavailability, or unverified availability while only independent host evidence may establish that it is Available. It does not alter Plugin classification or whole-state application.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Every row is a **release blocker**: `v*` may not publish unless the full matrix 
 | Layer | What is covered |
 |-------|-----------------|
 | unit — 縫層 | `runCommand` 指令分派（add/list/install/update/disable/enable/remove/forget/help、重複註冊拒絕、重裝覆寫、衝突未投影清單、corrupt→重置、unavailable 顯示、git 重抓）、Minimal Bridge State 原子持久化 |
-| unit — 低層 | 雙格式 catalog 解析（codex＋claude、open 政策、unavailable entry）、git locator／selector／source-key、contained path／symlink、collision、投影（exposure）、source-cache（store/hit/LRU/pin/flock）、git acquisition（mock executor） |
+| unit — 低層 | 雙格式 catalog 解析（codex＋claude、open 政策、unavailable entry）、git locator／source-key（fixed `default` selector）、contained path／symlink、collision、投影（exposure）、source-cache（store/hit/LRU/pin/flock）、git acquisition（mock executor） |
 | integration | 真 Pi 縫：extension 註冊 `resources_discover` → 投影 skillPaths（startup/reload 一致、trust flag 無關、被動不變異） |
 | E2E | `/codex-marketplace` 薄 Pi adapter：overview/help 輸出路由、corrupt 重置通知、reload 門控 |
 

--- a/docs/adr/0001-runtime-skill-exposure-via-host-discovery.md
+++ b/docs/adr/0001-runtime-skill-exposure-via-host-discovery.md
@@ -9,7 +9,7 @@ Bridge 記錄了 Installation、也能唯讀投影 Effective State，但沒有�
 - **發現時只做存在性檢查**：指紋在 snapshot 建立與 cache 寫入時驗證；discovery 是被動檢查，不是 activation admission（見 CONTEXT.md「Runtime Skill Exposure」）。
 - **安裝／啟用後由指令層要求 reload**：reload 是唯一生效動作，由 `install`／`enable`／`update` 指令層觸發；輸出只宣稱「已重新載入生效」，不斷言 skills 在 runtime 可見（與既有 `Skill Availability` 定義一致）。
 - **只貢獻 collision 存活者**：沿用 Runtime Skill Collision 的 `Pi → Global Scope` 兩層 layering。
-- **explicit-only Invocation Policy 照常貢獻**：政策僅由 SKILL.md frontmatter 的 `disable-model-invocation` 定義（Agent Profile 解析已隨 v2 儀式退場，見 ADR 0004）；Pi 目前沒有 policy 攔截點，投影照常貢獻。
+- **不解析 invocation policy**：投影只讀 SKILL.md frontmatter 的 `name`／`description`（見 CONTEXT.md「Skill Descriptor」），不讀取任何政策金鑰；Agent Profile 解析已隨 v2 儀式退場（見 ADR 0004），Pi 目前沒有 policy 攔截點，投影照常貢獻。
 
 ## Considered Options（拒絕）
 

--- a/docs/adr/0001-runtime-skill-exposure-via-host-discovery.md
+++ b/docs/adr/0001-runtime-skill-exposure-via-host-discovery.md
@@ -1,18 +1,20 @@
 # Runtime Skill Exposure via host resource discovery
 
+> **Status: 仍生效（極簡收斂保留）** — 本投影縫決策維持不變；下文涉及已退場機械（receipt／Retry Application／Project Scope layering）之引用已收斂至極簡表面（#87、#95、#96）。
+
 Bridge 記錄了 Installation、也能唯讀投影 Effective State，但沒有任何機制把 enabled 外掛的 skills 帶進 Pi——reload 再多次也不會出現 slash command。決定：Bridge Extension 透過 host 的資源發現縫（`resources_discover` 回傳 `skillPaths`），在每次 session start 與 reload 時，依當下 Effective State 的 collision 存活者（Projected Skills）動態貢獻 skill 目錄；路徑直接指向 Source Cache 中該 Installation Validation Snapshot 對應的 entry——Installation 本身已永久 pin 該 entry（免於 LRU 驅逐），因此不保留任何 materialized 副本。
 
 ## Decisions
 
-- **發現時只做存在性檢查**：完整指紋驗證仍綁在 Lifecycle Operations 與 Retry Application；discovery 是被動檢查，不是 activation admission（見 CONTEXT.md「Runtime Skill Exposure」）。
-- **Applied 維持 state-level 語意**：收據代表 state committed + reload re-entered 通過，不斷言 skills 在 runtime 可見（與既有 `Skill Availability` 定義一致）。
-- **只貢獻 collision 存活者**：沿用 Runtime Skill Collision 的 `Pi → Project Scope → Global Scope` layering。
-- **explicit-only Invocation Policy 照常貢獻**：Pi 目前沒有 policy 攔截點；待 host 端可表達政策再接（追蹤 issue）。
+- **發現時只做存在性檢查**：指紋在 snapshot 建立與 cache 寫入時驗證；discovery 是被動檢查，不是 activation admission（見 CONTEXT.md「Runtime Skill Exposure」）。
+- **安裝／啟用後由指令層要求 reload**：reload 是唯一生效動作，由 `install`／`enable`／`update` 指令層觸發；輸出只宣稱「已重新載入生效」，不斷言 skills 在 runtime 可見（與既有 `Skill Availability` 定義一致）。
+- **只貢獻 collision 存活者**：沿用 Runtime Skill Collision 的 `Pi → Global Scope` 兩層 layering。
+- **explicit-only Invocation Policy 照常貢獻**：政策僅由 SKILL.md frontmatter 的 `disable-model-invocation` 定義（Agent Profile 解析已隨 v2 儀式退場，見 ADR 0004）；Pi 目前沒有 policy 攔截點，投影照常貢獻。
 
 ## Considered Options（拒絕）
 
 - **Materialize 副本到 Bridge 專屬目錄**：製造第二份位元組真相，衍生漂移、清理與 snapshot 綁定問題。
-- **每次 discovery 重算 fingerprint**：高頻 IO 成本；快取已 pin 且寫入時驗過，事後竄改屬 Source Drift／修復流程管轄。
+- **每次 discovery 重算 fingerprint**：高頻 IO 成本；快取已 pin 且寫入時驗過。
 - **名稱衝突交給 Pi 原生目錄 layering**：等於放棄已實作的 Runtime Skill Collision 投影。
 - **本期做 host 層可用性掃描（AVAIL-01）**：需在 extension 內重刻半個 Pi 載入器；AVAIL-01 維持詞彙。
-- **升級 receipt 斷言 runtime 可見性**：host 沒有可靠的載入結果內省 API，硬做只是猜測。
+- **升級輸出斷言 runtime 可見性**：host 沒有可靠的載入結果內省 API，硬做只是猜測。

--- a/docs/adr/0002-global-only-retire-project-scope.md
+++ b/docs/adr/0002-global-only-retire-project-scope.md
@@ -1,14 +1,16 @@
 # Global-only: retire Project Scope
 
-Bridge 原本以雙範圍架構交付（Global Scope 基準線 + Project Scope overlay + Scope Overrides），並為此撐起一整組專屬機制：Scope Override、Project Trust、Global Pending Barrier、project precedence、`Pi → Project → Global` 三層碰撞解析，以及雙文件 store / journal / fence。決定：**移除「多範圍」這個維度，Bridge 只管理單一 Global Scope**；其餘生命週期機制（Registration、Installation、Refresh／Update Plan、Rebind、Removal、Receipt Journal、Repair State、Runtime Skill Exposure、Attempt Fence）全部保留，並以 Global 為單一目標。此決策移除約 1,800 行純 project 相關程式碼（`overrides.ts`、`project.ts`、`global-barrier.ts`、`scope-overrides.ts` 等）並大幅收斂 TUI 與測試矩陣。
+> **Status: 部分仍是現行決策（極簡收斂）** — 「Global-only」本身仍成立並維持。決策時點列為「保留」的生命週期機制清單已過時：Refresh／Update Plan、Rebind、Receipt Journal、Repair State、Attempt Fence 及其餘防損毀機械於 #87 極簡定案後經 #95 整層退場，TUI 亦已移除。
+
+Bridge 原本以雙範圍架構交付（Global Scope 基準線 + Project Scope overlay + Scope Overrides），並為此撐起一整組專屬機制：Scope Override、Project Trust、Global Pending Barrier、project precedence、`Pi → Project → Global` 三層碰撞解析，以及雙文件 store / journal / fence。決定：**移除「多範圍」這個維度，Bridge 只管理單一 Global Scope**；其餘生命週期機制（Registration、Installation、Refresh／Update Plan、Rebind、Removal、Receipt Journal、Repair State、Runtime Skill Exposure、Attempt Fence）全部保留，並以 Global 為單一目標（後續 #87 極簡收斂已將其中 Refresh／Update Plan、Rebind、Receipt Journal、Repair State、Attempt Fence 整層退場）。此決策移除約 1,800 行純 project 相關程式碼（`overrides.ts`、`project.ts`、`global-barrier.ts`、`scope-overrides.ts` 等）並大幅收斂 TUI 與測試矩陣。
 
 ## Decisions
 
 - **只砍「多範圍」維度**：生命週期機制不重新設計。Scope Override、Project Trust、Global Pending Barrier、project precedence 全數移除；Runtime Skill Collision 改為 `Pi → Global` 兩層；Installation ID 不再含 scope 分量（即 Plugin ID）。
 - **既有 project state 檔完全無視**：不讀、不提示、不刪。fail-closed 只作用於 Bridge 實際讀取的檔案；使用者磁碟上殘留的 project 資料由使用者自行處置。`.pi/` 已在 `.gitignore`，無 repo 清理問題。
-- **schemaVersion 升為 2**：v1→v2 WAL migration 剝除 `scopeOverrides`。該欄位在 global 語意中定義即為死欄位，故非空 overrides 一律剝除並記 diagnostic finding，**不** fail-closed——避免把正常 Registration 卡死在語意已死的欄位上。
-- **內部 API 移除 scope 參數**：刪除 `Scope` type 與所有 `'global' | 'project'` 分支；路徑／收據／fence helpers 只剩 global 系列。不為「未來可能回頭」保留死參數——需要時 git 歷史與本 ADR 就是接點。
-- **TUI 單軌收斂**：Bridge Ledger 只有 Global 分區；移除 `g`／`p` 瀏覽焦點鍵與「Scope & inheritance」導航群組；Trust／Barrier 指示區移除；導航收斂為 Observe / Sources / Plugins / Recovery & receipts。
+- **schemaVersion 升為 2**：v1→v2 WAL migration 剝除 `scopeOverrides`。該欄位在 global 語意中定義即為死欄位，故非空 overrides 一律剝除並記 diagnostic finding，**不** fail-closed——避免把正常 Registration 卡死在語意已死的欄位上。（後收斂：極簡 Bridge State 已於 #95 起固定 `schemaVersion = 1`、永不遷移、無 WAL migration——本條僅為 v2 時點之歷史決策，見 README「Bridge State storage」。）
+- **內部 API 移除 scope 參數**：刪除 `Scope` type 與所有 `'global' | 'project'` 分支；路徑／收據／fence helpers 只剩 global 系列（後於 #95 全數拆除）。不為「未來可能回頭」保留死參數——需要時 git 歷史與本 ADR 就是接點。
+- **TUI 單軌收斂**：Bridge Ledger 只有 Global 分區；移除 `g`／`p` 瀏覽焦點鍵與「Scope & inheritance」導航群組；Trust／Barrier 指示區移除；導航收斂為 Observe / Sources / Plugins / Recovery & receipts。（TUI 已於 #95 整層移除，本條僅為歷史。）
 - **版本 0.2.0**：0.y 視窗內以 minor bump 表達 breaking；schemaVersion 綁版號 bump 依 README 既有流程。
 - **順序**：本次簡化先行，Claude 雙格式路線圖（#43–#52）在其後——簡化先縮小 Profile v2 每張 ticket 的表面積。
 

--- a/docs/adr/0003-dual-format-detection-and-codex-precedence.md
+++ b/docs/adr/0003-dual-format-detection-and-codex-precedence.md
@@ -10,7 +10,7 @@ Bridge 擴展至支援 Claude Code 外掛生態系（`.claude-plugin/marketplace
 - **codex 格式優先（Fixed Precedence）**：當兩種 catalog 檔案並存於同一 repo 時，固定自動採用 `codex`，不向使用者提問、不猜測、亦不提供動態覆寫參數，維持自動判定之可預測性。
 - **格式固化於 Registration（Fixed at Registration）**：格式（`format: 'codex' | 'claude'`）於註冊確認（Registration Confirmation）時寫入 Bridge State Registration 紀錄，成為不可變屬性。
 - **格式翻轉僅經由明確 `update`（No Silent Format Flip）**：上游來源格式變更（如 codex catalog 被刪除改為 claude）在平日讀取或 reload 時絕不自動翻轉；必須經由明確的 `update` 重抓最新並重讀重裝後才生效。
-- **Entry ID 結構一致**：雙格式皆採 `/plugins/<zero-based ordinal>` 作為 Marketplace Entry ID，維持快照範圍內一致的識別與 TUI 綁定能力。
+- **Entry ID 結構一致**：雙格式皆採 `/plugins/<zero-based ordinal>` 作為 Marketplace Entry ID，維持快照範圍內一致的識別。
 
 ## Considered Options（拒絕）
 

--- a/docs/adr/0003-dual-format-detection-and-codex-precedence.md
+++ b/docs/adr/0003-dual-format-detection-and-codex-precedence.md
@@ -1,18 +1,20 @@
 # 雙格式偵測與 codex 優先 (Dual format detection and codex precedence)
 
-Bridge 擴展至支援 Claude Code 外掛生態系（`.claude-plugin/marketplace.json`），需要決定如何在登記與取得 Marketplace Source 時判定其格式，以及當兩種 catalog 同時存在時的行為。決定：**Marketplace Format 由 Marketplace Root 內容靜態且決定性推導，偵測順序固定為 codex 優先（`.agents/plugins/marketplace.json` > `.claude-plugin/marketplace.json`），判定結果固化於 Registration 記錄；格式翻轉僅能透過明確的 Marketplace Refresh 與 Update Plan 生效。**
+> **Status: 仍生效（極簡收斂保留）** — 格式靜態決定性推導、codex 優先、固化於 Registration 均不變；「格式翻轉經由 Refresh／Update Plan」的途徑已隨生命週期機械退場（#87、#95），改由明確 `update`（重抓最新、重讀重裝）生效。
+
+Bridge 擴展至支援 Claude Code 外掛生態系（`.claude-plugin/marketplace.json`），需要決定如何在登記與取得 Marketplace Source 時判定其格式，以及當兩種 catalog 同時存在時的行為。決定：**Marketplace Format 由 Marketplace Root 內容靜態且決定性推導，偵測順序固定為 codex 優先（`.agents/plugins/marketplace.json` > `.claude-plugin/marketplace.json`），判定結果固化於 Registration 記錄；格式翻轉僅能透過明確的 `update`（重抓最新、重讀重裝）生效。**
 
 ## Decisions
 
 - **靜態決定性推導格式**：Marketplace Root 依檔案存在性偵測 `.agents/plugins/marketplace.json` 與 `.claude-plugin/marketplace.json`；若兩者皆無則 fail-closed 報 `CATALOG_MISSING`，不支援啟發式猜測。
 - **codex 格式優先（Fixed Precedence）**：當兩種 catalog 檔案並存於同一 repo 時，固定自動採用 `codex`，不向使用者提問、不猜測、亦不提供動態覆寫參數，維持自動判定之可預測性。
 - **格式固化於 Registration（Fixed at Registration）**：格式（`format: 'codex' | 'claude'`）於註冊確認（Registration Confirmation）時寫入 Bridge State Registration 紀錄，成為不可變屬性。
-- **格式翻轉僅經由 Update Plan（No Silent Format Flip）**：上游來源格式變更（如 codex catalog 被刪除改為 claude）在平日讀取或 reload 時絕不自動翻轉；必須經由明確的 Marketplace Refresh 產生帶有新格式的 Update Candidate，並在使用者審核 Update Plan 及通過 Confirmation 後才原子生效。
+- **格式翻轉僅經由明確 `update`（No Silent Format Flip）**：上游來源格式變更（如 codex catalog 被刪除改為 claude）在平日讀取或 reload 時絕不自動翻轉；必須經由明確的 `update` 重抓最新並重讀重裝後才生效。
 - **Entry ID 結構一致**：雙格式皆採 `/plugins/<zero-based ordinal>` 作為 Marketplace Entry ID，維持快照範圍內一致的識別與 TUI 綁定能力。
 
 ## Considered Options（拒絕）
 
 - **互動式詢問使用者格式**：破壞自動化流程與指令腳本一致性，增加不必要的 UI 摩擦。
-- **支援執行階段動態自適應格式**：動態嗅探會導致快照指紋與持久化狀態不一致，破壞 CAS 與 Validation Snapshot 邊界。
+- **支援執行階段動態自適應格式**：動態嗅探會導致快照指紋與持久化狀態不一致，破壞 Validation Snapshot 的指紋定址邊界。
 - **同時解析並合併雙格式 catalog**：會產生同一 repo 內 entry 來源重疊、ID 混亂與複雜的跨格式衝突。
 - **允許上游格式變更時自動靜默遷移**：靜默變更會繞過 Validation Disclosure 與 Consent 邊界，違反 Default-No 原則。

--- a/docs/adr/0004-unified-compatibility-profile-v2.md
+++ b/docs/adr/0004-unified-compatibility-profile-v2.md
@@ -1,6 +1,6 @@
 # 統一 Compatibility Profile v2 取代凍結 v1 (Unified Compatibility Profile v2 replacing frozen v1)
 
-> **Status: superseded（#95 拆除）** — Compatibility Profile v2 儀式已整層退場（極簡 #87 §7）：不再有原子三分法分類、Agent Profile（`openai.yaml`）解析、resources 掃描或 captureFingerprint；雙格式支援收斂為 catalog 解析＋manifest 名稱讀取。本記錄保留為歷史決策參考。
+> **Status: superseded（#95/#96 拆除）** — Compatibility Profile v2 儀式已整層退場（極簡 #87 §7）：不再有原子三分法分類、Agent Profile（`openai.yaml`）解析、resources 掃描或 captureFingerprint；雙格式支援收斂為 catalog 解析＋manifest 名稱讀取。本記錄保留為歷史決策參考。
 
 導入 Claude 外掛支援後，Bridge 需處理兩種不同 manifest 結構（`.codex-plugin/plugin.json` 與 `.claude-plugin/plugin.json`）及各自的技能與中繼資料規範。決定：**以單一統一的 Compatibility Profile v2 取代並凍結 Profile v1，將 Validation Ruleset 跳升至 v2，強制雙格式外掛在同一套嚴格規則集下進行原子分類；Claude 與 Codex 外掛享有完全一致的生命週期、碰撞解析與全有全無語意。**
 

--- a/docs/adr/0005-entry-acquisition-trust-boundary.md
+++ b/docs/adr/0005-entry-acquisition-trust-boundary.md
@@ -1,6 +1,6 @@
 # Entry 級取得的信任邊界與定位器正規化 (Entry-level acquisition trust boundary and locator normalization)
 
-> **Status: superseded（#95 拆除）** — Entry Acquisition 已整層退場（極簡 #87 Out of Scope）：catalog 內 git 家族 entry 一律標記 `unavailable`（保留 `parseGitEntrySpec` 純解析用於分類），不再取得、不再 pin。本記錄保留為歷史決策參考。
+> **Status: superseded（#95/#96 拆除）** — Entry Acquisition 已整層退場（極簡 #87 Out of Scope）：catalog 內 git 家族 entry 一律標記 `unavailable`，不再取得、不再 pin、無保留解析器（`parseGitEntrySpec` 一併移除）。本記錄保留為歷史決策參考。
 
 Marketplace Catalog（包含 Claude 與 Codex 格式）允許 Marketplace 聚合分散於外部 Git 倉庫的外掛條目（如 `github`、`url`、`git-subdir` 形態）。Bridge 需要在不擴大既有信任基礎與維持「零執行」（Zero-Execution）安全承諾的前提下，取得並驗證這些外部 entry。決定：**Entry 級外部 Git 取得完全遵循頂層 Marketplace 既有的 Acquisition Trust Base 與 Validation Budget 約束；`owner/repo` 簡寫一律決定性正規化為 canonical HTTPS 定位器；`command` 來源永久不合格；外掛宣告以 `sha` 為不可變 pin，而可動 `ref` 於 Refresh 時產生 Update Candidate，確保第三方聚合不擴大信任面與執行邊界。**
 


### PR DESCRIPTION
Closes #97

## What

文件收斂＋全綠收尾（#87 Q8）：CONTEXT.md 移除僅描述已退場機械的詞彙、ADR 收斂至極簡一致（保留投影縫／Global-only／雙格式偵測 codex 優先）、CHANGELOG 補登極簡化期間各票（#93/#94/#96/#97）、README 維持新指令表面；typecheck＋216 tests 全綠（+38 / −35，8 files）。

**CONTEXT.md**：
- 移除 **Git Selector** 詞條（git-selector pins 已於 #96 退場，git 取得僅 HEAD）與 **Validation Ruleset** 詞條（ruleset 字串常數已於 #96 退場，不再參與指紋）。
- 修正 **Validation Snapshot** 描述：指紋僅 bind Source Key（git 另含 Canonical Locator＋Resolved Revision），不再 bind ruleset/budget 字串。
- 修正 **Validation Budget** 描述：固定常數限制（tree depth／file count／content bytes／catalog size／entry count／name length），非 versioned contract。
- 收斂存活詞條語意：Resolved Revision（僅 HEAD、無 selector 選擇）、Source Key（固定 `default` selector）、Plugin ID 屬性用語、Runtime Skill Exposure _Avoid_ 移除「Marketplace Refresh」。

**ADR**：
- 0001（投影縫）標記仍生效；重寫 receipt／Retry Application／Project Scope layering／Source Drift 引用至極簡語意（指令層 reload、`Pi → Global` 兩層、`disable-model-invocation` frontmatter）。
- 0002（Global-only）標記部分仍生效；註明決策時「保留」的生命週期機械於 #87/#95 整層退場、TUI 已移除。
- 0003（雙格式偵測 codex 優先）標記仍生效；格式翻轉途徑由 Refresh／Update Plan 改為明確 `update`（重抓重讀重裝）。
- 0004／0005 維持 superseded；拆除範圍更正為 #95/#96（`parseGitEntrySpec` 一併移除、無保留解析器）。

**CHANGELOG**：補登 [Unreleased] 極簡化期間各票——#93（disable/enable/remove/forget＋總覽）、#94（update 全部重抓最新）、#96（拆讀取／分類退場）、#97（本票文件收斂）。

**README**：驗證矩陣 unit 低層列改述「git locator／source-key（fixed `default` selector）」。

## Acceptance criteria

- [x] CONTEXT.md 無已退場機械語彙（rg 抽檢：receipt/journal/fence/refresh/update-plan/rebind/State Revision/Git Selector/Ruleset 於存活語境零命中，僅留明確歷史標記）
- [x] ADR 與極簡一致（0001/0003 仍生效＋改寫退場引用；0002 部分生效＋註記；0004/0005 superseded 並更正範圍）
- [x] README／CHANGELOG 反映新指令表面與極簡承諾
- [x] typecheck && test 全綠（CI gate 維持）

## Verification

- `npx tsc --noEmit` 全綠
- `npx vitest run` 21 files / 216 tests 全綠
- 雙軸 review（Standards／Spec）完成一輪修正（ADR 0001 Status 中文化、0003 決策句收斂、CHANGELOG 分節順序）