### PR TITLE
T1: Credentialed Acquisition 接線——PI_CODEX_MARKETPLACE_CREDENTIAL_HELPERS 核准 helper（add/update 共用）

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ Nine subcommands, no arguments = 總覽：
 - 安裝成功後由指令層主動要求 reload；reload 失敗不影響已記錄狀態，下次 session start 或 `/reload` 仍生效。
 - `--no-skills` 啟動 Pi 不影響 Bridge 投影。
 
+### 私有 Git repo：Credentialed Acquisition（核准式取得）
+
+預設 `add`／`update` 對 Git 來源完全 credential-free：不執行任何 credential helper，私有 HTTPS repo 會以 401 失敗（並提示核准或改用 SSH）。若要核准 credential helper，以逗號分隔設定環境變數（逐次生效、永不持久化，`add` 與 `update` 共用）：
+
+```
+PI_CODEX_MARKETPLACE_CREDENTIAL_HELPERS='store, !f() { echo "username=${GITHUB_USER}"; echo "password=${GITHUB_TOKEN}"; }; f'
+/codex-marketplace add https://github.com/acme/private-mkt
+```
+
+- 值為 git `credential.helper` 字串，逗號分隔、各項 trim、空項目忽略；未設定或空白＝未核准（行為與 credential-free 完全相同）。
+- 已核准 helper 仍被遠端拒絕（401）時，錯誤訊息提示檢查憑證；未核准時提示核准或改用 SSH。
+- 憑證與核准清單**永不**進入指令輸出、Bridge State、快照指紋或 cache 位址；SSH（known_hosts + agent）是私有 repo 的另一條替代路徑，完全不需要此環境變數。
+
 ## Bridge State storage
 
 Bridge State 是唯一權威，存於**單一 Global Scope 文件** `{getAgentDir()}/codex-marketplace/state.json`（`~/.pi/agent/codex-marketplace/state.json`）：

--- a/src/bridge/command.ts
+++ b/src/bridge/command.ts
@@ -31,6 +31,7 @@ import { findEntryByManifestName, GIT_FAMILY_UNAVAILABLE_REASON, type Catalog, t
 import type { ValidationFinding } from '../registration/findings.js';
 import { normalizeGitLocator } from '../registration/git-locator.js';
 import { acquireGitSource, cleanupAcquisition, type GitExecutor } from '../registration/git-acquisition.js';
+import { CREDENTIAL_HELPERS_ENV, parseCredentialHelpers } from '../registration/credential-helpers.js';
 import { gitSourceKey } from '../registration/source-key.js';
 import { buildGitSnapshot } from '../registration/snapshot.js';
 import { SourceCache } from '../cache/source-cache.js';
@@ -598,6 +599,13 @@ export async function runCommand(
 ): Promise<CommandResult> {
   const rawArgs = typeof argv === 'string' ? argv.trim().split(/\s+/).filter(Boolean) : [...argv];
 
+  // Credentialed Acquisition (#109)：逐次核准的 credential helper allowlist。
+  // 解析結果只經既有 AcquisitionTrustOptions 傳給 Git 取得；底層不讀環境變數，
+  // 未核准（空字串／未設定）時 trust 為 undefined，行為與 credential-free 完全一致。
+  const approvedHelpers = parseCredentialHelpers(process.env[CREDENTIAL_HELPERS_ENV]);
+  const acquireTrust: { allowedCredentialHelpers: string[] } | undefined =
+    approvedHelpers.length > 0 ? { allowedCredentialHelpers: approvedHelpers } : undefined;
+
   // Strip leading command token if passed
   if (rawArgs.length > 0 && (rawArgs[0] === '/codex-marketplace' || rawArgs[0] === 'codex-marketplace')) {
     rawArgs.shift();
@@ -671,6 +679,7 @@ export async function runCommand(
               acquireResult = await acquireGitSource({
                 locator,
                 executor: opts.gitExecutor,
+                trust: acquireTrust,
               });
             } catch (e) {
               const msg = e instanceof Error ? e.message : String(e);
@@ -1089,6 +1098,7 @@ export async function runCommand(
               acquireResult = await acquireGitSource({
                 locator: locRes.locator!,
                 executor: opts.gitExecutor,
+                trust: acquireTrust,
               });
             } catch (e) {
               const msg = e instanceof Error ? e.message : String(e);

--- a/src/registration/credential-helpers.ts
+++ b/src/registration/credential-helpers.ts
@@ -1,0 +1,25 @@
+/**
+ * Credentialed Acquisition approval (#109) — env-var allowlist parsing.
+ * See CONTEXT.md: Credentialed Acquisition; docs/adr/0006-credentialed-acquisition-approval.md.
+ *
+ * Per-invocation approval of git credential helpers via
+ * `PI_CODEX_MARKETPLACE_CREDENTIAL_HELPERS` (comma-separated `credential.helper`
+ * strings). Empty/unset means "not approved" — behavior identical to today.
+ * This module only parses; the resulting allowlist travels through
+ * AcquisitionTrustOptions and never touches Bridge State, snapshots, or cache identity.
+ */
+
+export const CREDENTIAL_HELPERS_ENV = 'PI_CODEX_MARKETPLACE_CREDENTIAL_HELPERS';
+
+/**
+ * Parse the approval env var into a helper allowlist.
+ * Comma-separated, each entry trimmed, empty entries ignored.
+ * Empty/unset → no approval ([]).
+ */
+export function parseCredentialHelpers(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}

--- a/src/registration/git-acquisition.ts
+++ b/src/registration/git-acquisition.ts
@@ -15,6 +15,7 @@ import { join } from 'node:path';
 
 import { CODE, RULE, blocking, type ValidationFinding } from './findings.js';
 import type { CanonicalGitLocator } from './git-locator.js';
+import { CREDENTIAL_HELPERS_ENV } from './credential-helpers.js';
 
 export interface GitExecutor {
   (args: string[], opts?: { cwd?: string; env?: Record<string, string> }): Promise<{
@@ -126,11 +127,28 @@ function isFullHex(s: string): boolean {
   return /^[0-9a-f]{40}$/.test(s) || /^[0-9a-f]{64}$/.test(s);
 }
 
+function authFailureFinding(approvedHelpers: boolean, stderr: string): ValidationFinding {
+  const why = approvedHelpers
+    ? `approved credential helper was rejected by the remote — check your credentials`
+    : `credential helper/agent not approved — set ${CREDENTIAL_HELPERS_ENV} to approve one, or use SSH`;
+  return trustFinding(
+    CODE.GIT_ACQUISITION_FAILED,
+    RULE.GIT_TRUST_CREDENTIAL_HELPER,
+    `Acquisition Trust Base violation: ${why} — ${stderr.trim()}`,
+  );
+}
+
+function isAuthFailure(stderr: string): boolean {
+  const lower = stderr.toLowerCase();
+  return lower.includes('could not read username') || lower.includes('authentication failed') || lower.includes('credential');
+}
+
 async function resolveHead(
   locator: CanonicalGitLocator,
   executor: GitExecutor,
   env: Record<string, string>,
   configArgs: string[],
+  approvedHelpers: boolean,
 ): Promise<{ ok: true; sha: string } | { ok: false; findings: ValidationFinding[]; stderr?: string }> {
   const lsArgs = [...configArgs, 'ls-remote', locator.canonicalUrl, 'HEAD'];
   const res = await executor(lsArgs, { env });
@@ -160,16 +178,10 @@ async function resolveHead(
         stderr: res.stderr,
       };
     }
-    if (stderr.includes('could not read username') || stderr.includes('authentication failed') || stderr.includes('credential')) {
+    if (isAuthFailure(stderr)) {
       return {
         ok: false,
-        findings: [
-          trustFinding(
-            CODE.GIT_ACQUISITION_FAILED,
-            RULE.GIT_TRUST_CREDENTIAL_HELPER,
-            `Acquisition Trust Base: credential helper/agent not approved — ${res.stderr.trim()}`,
-          ),
-        ],
+        findings: [authFailureFinding(approvedHelpers, res.stderr)],
         stderr: res.stderr,
       };
     }
@@ -211,7 +223,8 @@ export async function resolveGitRevision(
 ): Promise<{ ok: true; sha: string } | { ok: false; findings: ValidationFinding[]; stderr?: string }> {
   const env = hardenedEnv(opts.trust, locator);
   const configArgs = hardenedConfigArgs(opts.trust);
-  return resolveHead(locator, opts.executor ?? defaultGitExecutor(), env, configArgs);
+  const approvedHelpers = (opts.trust?.allowedCredentialHelpers?.length ?? 0) > 0;
+  return resolveHead(locator, opts.executor ?? defaultGitExecutor(), env, configArgs, approvedHelpers);
 }
 
 /**
@@ -224,7 +237,7 @@ export async function acquireGitSource(opts: AcquireOptions): Promise<AcquireRes
   const env = hardenedEnv(trust, locator);
   const configArgs = hardenedConfigArgs(trust);
 
-  const resolved = await resolveHead(locator, executor, env, configArgs);
+  const resolved = await resolveHead(locator, executor, env, configArgs, (trust?.allowedCredentialHelpers?.length ?? 0) > 0);
   if (!resolved.ok) {
     return { ok: false, findings: (resolved as { findings: ValidationFinding[] }).findings, stderr: (resolved as { stderr?: string }).stderr };
   }
@@ -267,6 +280,14 @@ export async function acquireGitSource(opts: AcquireOptions): Promise<AcquireRes
         findings: [
           trustFinding(CODE.GIT_TRUST_REDIRECT, RULE.GIT_TRUST_REDIRECT, `Acquisition Trust Base violation: redirect changing canonical locator — ${stderr.trim()}`),
         ],
+        stderr,
+      };
+    }
+    if (isAuthFailure(stderr)) {
+      if (createdTemp) try { rmSync(dest, { recursive: true, force: true }); } catch {}
+      return {
+        ok: false,
+        findings: [authFailureFinding((trust?.allowedCredentialHelpers?.length ?? 0) > 0, stderr)],
         stderr,
       };
     }

--- a/tests/unit/bridge/credentialed-acquisition.test.ts
+++ b/tests/unit/bridge/credentialed-acquisition.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, cpSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { runCommand } from '../../../src/bridge/command.js';
+import { readMinimalBridgeState } from '../../../src/bridge/state.js';
+import type { GitExecutor } from '../../../src/registration/git-acquisition.js';
+import { CREDENTIAL_HELPERS_ENV } from '../../../src/registration/credential-helpers.js';
+
+function makeCodexMarketplace(root: string, name: string, plugins: { name: string; path: string; skills?: string[] }[]) {
+  mkdirSync(join(root, '.agents', 'plugins'), { recursive: true });
+  writeFileSync(join(root, '.agents', 'plugins', 'marketplace.json'), JSON.stringify({ name, plugins }));
+  for (const p of plugins) {
+    const abs = join(root, p.path.replace(/^\.\//, ''));
+    mkdirSync(abs, { recursive: true });
+    writeFileSync(join(abs, 'plugin.json'), JSON.stringify({ name: p.name }));
+    if (p.skills) {
+      for (const skill of p.skills) {
+        const sdir = join(abs, 'skills', skill);
+        mkdirSync(sdir, { recursive: true });
+        writeFileSync(join(sdir, 'SKILL.md'), `---\nname: ${skill}\ndescription: Desc for ${skill}\n---\n\nBody for ${skill}\n`);
+      }
+    }
+  }
+}
+
+/**
+ * 私有 repo 模擬：只有當 git 命令列攜帶已核准 credential.helper 時才放行，
+ * 否則回 401（Authentication failed）——與真實私有 HTTPS repo 未核准時的行為一致。
+ */
+function makeAuthGatedGitExecutor(fixtureRoot: string, sha: string, approvedHelpers: string[]): GitExecutor {
+  const approved = (args: string[]): boolean => {
+    const seen = args.filter((a) => a.startsWith('credential.helper='));
+    return approvedHelpers.every((h) => seen.includes(`credential.helper=${h}`));
+  };
+  return async (args) => {
+    if (!approved(args)) {
+      return {
+        exitCode: 128,
+        stdout: '',
+        stderr: "fatal: Authentication failed for 'https://github.com/acme/private-mkt/'",
+      };
+    }
+    if (args.includes('ls-remote')) {
+      const ref = args[args.length - 1];
+      return { exitCode: 0, stdout: `${sha}\t${ref}\n`, stderr: '' };
+    }
+    if (args.includes('clone')) {
+      const dest = args[args.length - 1];
+      cpSync(fixtureRoot, dest, { recursive: true });
+      mkdirSync(join(dest, '.git'), { recursive: true });
+      return { exitCode: 0, stdout: '', stderr: '' };
+    }
+    return { exitCode: 0, stdout: '', stderr: '' };
+  };
+}
+
+/** 永遠 401 的 executor：即使 helper 已核准也失敗 */
+function makeAlwaysAuthFailGitExecutor(): GitExecutor {
+  return async () => ({ exitCode: 128, stdout: '', stderr: "fatal: Authentication failed for 'https://github.com/acme/private-mkt/'" });
+}
+
+describe('Credentialed Acquisition add 接線（#109）', () => {
+  let tmpDir: string;
+  let agentDir: string;
+  let gitRepo: string;
+
+  beforeEach(() => {
+    delete process.env[CREDENTIAL_HELPERS_ENV];
+    tmpDir = mkdtempSync(join(tmpdir(), 't109-'));
+    agentDir = join(tmpDir, 'agent');
+    mkdirSync(agentDir, { recursive: true });
+    gitRepo = mkdtempSync(join(tmpDir, 'gitrepo'));
+  });
+
+  afterEach(() => {
+    delete process.env[CREDENTIAL_HELPERS_ENV];
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('未核准（env 未設定）→ 401 失敗、不註冊；輸出不含任何 helper 字串', async () => {
+    makeCodexMarketplace(gitRepo, 'private-mkt', [{ name: 'p1', path: './plugins/p1' }]);
+    const helper = 'approved-helper-a';
+    const executor = makeAuthGatedGitExecutor(gitRepo, 'a'.repeat(40), [helper]);
+
+    const res = await runCommand(['add', 'https://github.com/acme/private-mkt'], { agentDir, gitExecutor: executor });
+
+    expect(res.output).toContain('錯誤：git 取得失敗');
+    expect(res.output).not.toContain(helper);
+    const st = readMinimalBridgeState({ agentDir });
+    expect(st.state.registrations).toHaveLength(0);
+  });
+
+  it('未核准（env 為空字串）→ 與未設定相同：401 失敗、不註冊', async () => {
+    process.env[CREDENTIAL_HELPERS_ENV] = '  ,  ';
+    makeCodexMarketplace(gitRepo, 'private-mkt', [{ name: 'p1', path: './plugins/p1' }]);
+    const executor = makeAuthGatedGitExecutor(gitRepo, 'a'.repeat(40), ['approved-helper-a']);
+
+    const res = await runCommand(['add', 'https://github.com/acme/private-mkt'], { agentDir, gitExecutor: executor });
+
+    expect(res.output).toContain('錯誤：git 取得失敗');
+    expect(readMinimalBridgeState({ agentDir }).state.registrations).toHaveLength(0);
+  });
+
+  it('已核准 helper → add 成功註冊；偵測（格式、plugin 數）與公開 repo 一致；輸出與 Bridge State 不含 helper 字串', async () => {
+    makeCodexMarketplace(gitRepo, 'private-mkt', [
+      { name: 'p1', path: './plugins/p1' },
+      { name: 'p2', path: './plugins/p2' },
+    ]);
+    const helper = 'approved-helper-a';
+    process.env[CREDENTIAL_HELPERS_ENV] = `  ${helper} , cache `;
+    const executor = makeAuthGatedGitExecutor(gitRepo, 'a'.repeat(40), [helper]);
+
+    const res = await runCommand(['add', 'https://github.com/acme/private-mkt'], { agentDir, gitExecutor: executor });
+
+    expect(res.reload).toBe(false);
+    expect(res.output).toContain('偵測：codex marketplace');
+    expect(res.output).toMatch(/2 plugins/);
+    expect(res.output).toContain('已註冊');
+    expect(res.output).toContain('private-mkt');
+    expect(res.output).not.toContain(helper);
+
+    const st = readMinimalBridgeState({ agentDir });
+    expect(st.state.registrations).toHaveLength(1);
+    expect(st.state.registrations[0].sourceKind).toBe('git');
+    expect(st.state.registrations[0].snapshot).toMatch(/^[0-9a-f]{64}$/);
+    // 憑證不進入 Bridge State（含 helper 字串與 env 值）
+    expect(JSON.stringify(st.state)).not.toContain(helper);
+    expect(JSON.stringify(st.state)).not.toContain('cache');
+  });
+
+  it('已核准但仍 401 → 錯誤訊息為「核准後仍失敗」變體（提示檢查憑證），非「未核准」變體', async () => {
+    process.env[CREDENTIAL_HELPERS_ENV] = 'approved-helper-a';
+    const executor = makeAlwaysAuthFailGitExecutor();
+
+    const res = await runCommand(['add', 'https://github.com/acme/private-mkt'], { agentDir, gitExecutor: executor });
+
+    expect(res.output).toContain('錯誤：git 取得失敗');
+    expect(res.output).toMatch(/check your credentials|憑證/i);
+    expect(res.output).not.toMatch(/not approved/i);
+    expect(readMinimalBridgeState({ agentDir }).state.registrations).toHaveLength(0);
+  });
+
+  it('未核准 → 錯誤訊息為「未核准」變體（提示核准或 SSH）', async () => {
+    delete process.env[CREDENTIAL_HELPERS_ENV];
+    const executor = makeAlwaysAuthFailGitExecutor();
+
+    const res = await runCommand(['add', 'https://github.com/acme/private-mkt'], { agentDir, gitExecutor: executor });
+
+    expect(res.output).toContain('錯誤：git 取得失敗');
+    expect(res.output).toMatch(/not approved/i);
+    expect(res.output).not.toMatch(/check your credentials|憑證/i);
+  });
+});
+
+describe('Credentialed Acquisition update 接線（#109）', () => {
+  let tmpDir: string;
+  let agentDir: string;
+  let gitRepo: string;
+  let gitRepo2: string;
+
+  beforeEach(() => {
+    delete process.env[CREDENTIAL_HELPERS_ENV];
+    tmpDir = mkdtempSync(join(tmpdir(), 't109u-'));
+    agentDir = join(tmpDir, 'agent');
+    mkdirSync(agentDir, { recursive: true });
+    gitRepo = mkdtempSync(join(tmpDir, 'gitrepo'));
+    gitRepo2 = mkdtempSync(join(tmpDir, 'gitrepo2'));
+  });
+
+  afterEach(() => {
+    delete process.env[CREDENTIAL_HELPERS_ENV];
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('未核准 → 重抓失敗（未核准變體）、snapshot 不變、不 reload；輸出不含 helper 字串', async () => {
+    makeCodexMarketplace(gitRepo, 'private-mkt', [{ name: 'p1', path: './plugins/p1' }]);
+    const helper = 'approved-helper-a';
+    const sha = 'a'.repeat(40);
+    process.env[CREDENTIAL_HELPERS_ENV] = helper;
+    await runCommand(['add', 'https://github.com/acme/private-mkt'], { agentDir, gitExecutor: makeAuthGatedGitExecutor(gitRepo, sha, [helper]) });
+    const before = readMinimalBridgeState({ agentDir });
+    delete process.env[CREDENTIAL_HELPERS_ENV];
+
+    // 未核准：即使 executor 認識 helper 也不放行
+    const res = await runCommand(['update'], { agentDir, gitExecutor: makeAuthGatedGitExecutor(gitRepo, sha, [helper]) });
+
+    expect(res.output).toContain('錯誤：git 重抓失敗');
+    expect(res.output).toMatch(/not approved/i);
+    expect(res.output).not.toContain(helper);
+    expect(res.reload).toBe(false);
+    const after = readMinimalBridgeState({ agentDir });
+    expect(after.state.registrations[0].snapshot).toBe(before.state.registrations[0].snapshot);
+  });
+
+  it('已核准 → 對私有 repo 成功重抓當下最新（新 sha 新 tree → 有新版本＋reload＋snapshot 推進）', async () => {
+    makeCodexMarketplace(gitRepo, 'private-mkt', [{ name: 'p1', path: './plugins/p1', skills: ['s1'] }]);
+    const helper = 'approved-helper-a';
+    const shaA = 'a'.repeat(40);
+    process.env[CREDENTIAL_HELPERS_ENV] = helper;
+    await runCommand(['add', 'https://github.com/acme/private-mkt'], { agentDir, gitExecutor: makeAuthGatedGitExecutor(gitRepo, shaA, [helper]) });
+    await runCommand(['install', '1'], { agentDir, gitExecutor: makeAuthGatedGitExecutor(gitRepo, shaA, [helper]) });
+    const oldFp = readMinimalBridgeState({ agentDir }).state.registrations[0].snapshot!;
+
+    // upstream 升級：新 sha＋新 tree（新增 plugin p2）
+    const shaB = 'b'.repeat(40);
+    makeCodexMarketplace(gitRepo2, 'private-mkt', [
+      { name: 'p1', path: './plugins/p1', skills: ['s1'] },
+      { name: 'p2', path: './plugins/p2' },
+    ]);
+
+    const res = await runCommand(['update'], { agentDir, gitExecutor: makeAuthGatedGitExecutor(gitRepo2, shaB, [helper]) });
+
+    expect(res.output).toContain('private-mkt  重新抓取… p1 有新版本');
+    expect(res.output).toContain('已重新載入生效');
+    expect(res.reload).toBe(true);
+
+    const st = readMinimalBridgeState({ agentDir });
+    const newFp = st.state.registrations[0].snapshot!;
+    expect(newFp).not.toBe(oldFp);
+    expect(newFp).toMatch(/^[0-9a-f]{64}$/);
+    expect(st.state.installations[0].skills).toEqual(['s1']);
+
+    // 憑證不進入任何可持久化位置：輸出、Bridge State、快照指紋
+    expect(res.output).not.toContain(helper);
+    expect(JSON.stringify(st.state)).not.toContain(helper);
+    expect(oldFp).not.toContain(helper);
+    expect(newFp).not.toContain(helper);
+  });
+
+  it('已核准但 upstream 無變化 → 「無變化」、不 reload、snapshot 不動', async () => {
+    makeCodexMarketplace(gitRepo, 'private-mkt', [{ name: 'p1', path: './plugins/p1' }]);
+    const helper = 'approved-helper-b';
+    const sha = 'c'.repeat(40);
+    process.env[CREDENTIAL_HELPERS_ENV] = helper;
+    await runCommand(['add', 'https://github.com/acme/private-mkt'], { agentDir, gitExecutor: makeAuthGatedGitExecutor(gitRepo, sha, [helper]) });
+    const before = readMinimalBridgeState({ agentDir });
+
+    const res = await runCommand(['update'], { agentDir, gitExecutor: makeAuthGatedGitExecutor(gitRepo, sha, [helper]) });
+
+    expect(res.output).toContain('private-mkt  重新抓取… 無變化');
+    expect(res.reload).toBe(false);
+    expect(readMinimalBridgeState({ agentDir }).state.registrations[0].snapshot).toBe(before.state.registrations[0].snapshot);
+  });
+});

--- a/tests/unit/registration/credential-helpers.test.ts
+++ b/tests/unit/registration/credential-helpers.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseCredentialHelpers, CREDENTIAL_HELPERS_ENV } from '../../../src/registration/credential-helpers.js';
+
+describe('credential-helpers 核准解析（#109）', () => {
+  it('環境變數名為 PI_CODEX_MARKETPLACE_CREDENTIAL_HELPERS', () => {
+    expect(CREDENTIAL_HELPERS_ENV).toBe('PI_CODEX_MARKETPLACE_CREDENTIAL_HELPERS');
+  });
+
+  it('未設定（undefined）→ 未核准（空清單）', () => {
+    expect(parseCredentialHelpers(undefined)).toEqual([]);
+  });
+
+  it('空字串 → 未核准（空清單）', () => {
+    expect(parseCredentialHelpers('')).toEqual([]);
+  });
+
+  it('全空白 → 未核准（空清單）', () => {
+    expect(parseCredentialHelpers('   , ,  ')).toEqual([]);
+  });
+
+  it('單一 helper → 原樣單項', () => {
+    expect(parseCredentialHelpers('store')).toEqual(['store']);
+  });
+
+  it('逗號分隔多 helper → 依序保留', () => {
+    expect(parseCredentialHelpers('store, cache')).toEqual(['store', 'cache']);
+  });
+
+  it('各項 trim 前後空白', () => {
+    expect(parseCredentialHelpers('  store ,  cache  ')).toEqual(['store', 'cache']);
+  });
+
+  it('空項目忽略（前導／中段／尾隨逗號）', () => {
+    expect(parseCredentialHelpers(',store,,cache,')).toEqual(['store', 'cache']);
+  });
+
+  it('helper 內容原樣傳遞（不重寫、不截斷）', () => {
+    const helper = '!f() { echo "username=x"; echo "password=${PRIVATE_TOKEN}"; }; f';
+    expect(parseCredentialHelpers(helper)).toEqual([helper]);
+  });
+});


### PR DESCRIPTION
## What

Closed #109。接線 Credentialed Acquisition（ADR 0006 的實作面）：

- 新增 `src/registration/credential-helpers.ts`：解析 `PI_CODEX_MARKETPLACE_CREDENTIAL_HELPERS`（逗號分隔、各項 trim、空項目忽略、空字串／未設定＝未核准）。
- `runCommand` 解析一次，以既有 `AcquisitionTrustOptions.allowedCredentialHelpers` 傳給 `add` 與 `update` 兩處 `acquireGitSource`；底層取得邏輯不讀環境變數。
- 401 診斷依核准狀態分兩變體：未核准 → 提示設定環境變數或改用 SSH；已核准仍被拒 → 提示檢查憑證（`ls-remote` 與 `clone` 兩路徑）。
- 未核准時 `trust` 為 `undefined`，行為與 credential-free 完全一致。
- README 新增使用說明。

## 憑證安全

核准清單只存在於 `-c credential.helper=` git 命令列參數；不進入指令輸出、Bridge State、快照指紋或 cache 位址（測試逐項斷言）。

## Verification

- 新增 17 個測試（解析 9＋add 接線 5＋update 接線 3）
- 全套 233 tests 全綠、`tsc --noEmit` 乾淨
- 回歸：既有 add/update 測試（未核准路徑）全部不變

Closes #109