### PR TITLE
fix: git snapshot 誤判 contained symlink——ownership root 先 canonicalize 再建 prefix (#116)

### DIFF
--- a/src/registration/snapshot.ts
+++ b/src/registration/snapshot.ts
@@ -214,7 +214,14 @@ function walkTree(
   return { fileCount, totalBytes, budgetBlocked };
 }
 
-function checkSymlinkContainment(canonicalRoot: string, entries: SnapshotEntry[], findings: ValidationFinding[]): void {
+function checkSymlinkContainment(root: string, entries: SnapshotEntry[], findings: ValidationFinding[]): void {
+  // Canonicalize the owning root once before building the prefix — the raw root may itself
+  // contain symlink components (macOS TMPDIR: /var → /private/var), which would make every
+  // realpath'd target look like it escapes (same pattern as resolveContained in contained.ts).
+  let canonicalRoot = root;
+  try {
+    canonicalRoot = realpathSync.native(root);
+  } catch {}
   for (const e of entries) {
     if (e.type !== 'symlink') continue;
     const abs = join(canonicalRoot, ...e.relPath.split('/'));
@@ -244,6 +251,28 @@ function checkSymlinkContainment(canonicalRoot: string, entries: SnapshotEntry[]
           pointer: e.relPath,
           rule: RULE.CONTAINED_SYMLINK_VIOLATION,
           outcome: `symlink target '${canonical}' escapes owning root`,
+        }),
+      );
+      continue;
+    }
+    // CONTEXT: Contained Symlink — canonical target must be a regular file or directory;
+    // special-file targets (FIFO/socket/device) are Blocking Findings (same rule as
+    // resolveContained in contained.ts). statSync follows the symlink.
+    let st: ReturnType<typeof statSync> | undefined;
+    try {
+      st = statSync(abs);
+    } catch {
+      continue; // vanished between walk and check; broken/looping already handled above
+    }
+    if (!st.isFile() && !st.isDirectory()) {
+      findings.push(
+        blocking({
+          code: CODE.CONTAINED_SYMLINK_VIOLATION,
+          phase: 'validation',
+          target: 'source',
+          pointer: e.relPath,
+          rule: RULE.CONTAINED_SYMLINK_VIOLATION,
+          outcome: `contained symlink target is a special file: '${canonical}' (${st.isFIFO() ? 'fifo' : 'other'})`,
         }),
       );
     }

--- a/tests/unit/registration/repro-symlink.test.ts
+++ b/tests/unit/registration/repro-symlink.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, symlinkSync, cpSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { buildGitSnapshot } from '../../../src/registration/snapshot.js';
+import { gitSourceKey } from '../../../src/registration/source-key.js';
+import { normalizeGitLocator } from '../../../src/registration/git-locator.js';
+import { CODE } from '../../../src/registration/findings.js';
+import { runCommand } from '../../../src/bridge/command.js';
+import type { GitExecutor } from '../../../src/registration/git-acquisition.js';
+
+// Regression for: add https://github.com/mattpocock/skills → snapshot 建立失敗 —
+// "symlink target '.../git-acq-XXX/CLAUDE.md' escapes owning root"
+// Root cause: git acquisition root is mkdtempSync(tmpdir()) — raw, NOT realpath'd — while
+// checkSymlinkContainment resolved targets via realpathSync.native; on macOS /var → /private/var
+// makes every contained symlink look like it escapes. (localSourceKey realpaths the root first,
+// which is why local add was unaffected.)
+describe('repro: git snapshot symlink containment on macOS tmpdir', () => {
+  it('contained symlink (AGENTS.md -> CLAUDE.md) under a raw mkdtemp root must pass', () => {
+    const root = mkdtempSync(join(tmpdir(), 'git-acq-repro-'));
+    try {
+      writeFileSync(join(root, 'CLAUDE.md'), '# hi\n');
+      symlinkSync('CLAUDE.md', join(root, 'AGENTS.md'));
+
+      const locRes = normalizeGitLocator('https://github.com/mattpocock/skills');
+      if (!locRes.ok || !locRes.locator) throw new Error('locator should normalize');
+      const sourceKey = gitSourceKey(locRes.locator);
+      const res = buildGitSnapshot(root, sourceKey, {
+        canonicalLocator: 'https://github.com/mattpocock/skills',
+        resolvedRevision: 'x'.repeat(40),
+        selectorCanonical: 'default',
+      });
+      expect(res.ok).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('special-file symlink target → blocking（CONTEXT: Contained Symlink）', () => {
+    const root = mkdtempSync(join(tmpdir(), 'git-acq-repro-'));
+    try {
+      execFileSync('mkfifo', [join(root, 'pipe')]); // POSIX-only; CI matrix 為 ubuntu/macos
+      symlinkSync('pipe', join(root, 'AGENTS.md'));
+
+      const locRes = normalizeGitLocator('https://github.com/mattpocock/skills');
+      if (!locRes.ok || !locRes.locator) throw new Error('locator should normalize');
+      const res = buildGitSnapshot(root, gitSourceKey(locRes.locator), {
+        canonicalLocator: 'https://github.com/mattpocock/skills',
+        resolvedRevision: 'x'.repeat(40),
+        selectorCanonical: 'default',
+      });
+      expect(res.ok).toBe(false);
+      expect(res.findings[0].code).toBe(CODE.CONTAINED_SYMLINK_VIOLATION);
+      expect(res.findings[0].outcome).toMatch(/special file/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('e2e: add 流程對 contained symlink 不誤判（離線 fixture clone mock）', async () => {
+    // fixture: 與 mattpocock/skills 同形的 root 布局 — 含抓得住 add 流程的 marketplace
+    // 清單與一個 contained symlink（AGENTS.md -> CLAUDE.md）。git clone 以 mock executor
+    // 把 fixture 複製到真實的 mkdtemp 暫存 root，完整走 acquire → snapshot → 註冊，不需網路。
+    const fixture = mkdtempSync(join(tmpdir(), 'repro-fixture-'));
+    try {
+      mkdirSync(join(fixture, '.agents', 'plugins'), { recursive: true });
+      writeFileSync(
+        join(fixture, '.agents', 'plugins', 'marketplace.json'),
+        JSON.stringify({
+          name: 'mattpocock',
+          plugins: [{ name: 'p1', source: { source: 'local', path: './plugins/p1' } }],
+        }),
+      );
+      mkdirSync(join(fixture, 'plugins', 'p1'), { recursive: true });
+      writeFileSync(join(fixture, 'plugins', 'p1', 'plugin.json'), JSON.stringify({ name: 'p1' }));
+      writeFileSync(join(fixture, 'CLAUDE.md'), '# hi\n');
+      symlinkSync('CLAUDE.md', join(fixture, 'AGENTS.md'));
+
+      const SHA = 'a'.repeat(40);
+      const executor: GitExecutor = async (args) => {
+        if (args.includes('ls-remote')) {
+          const ref = args[args.length - 1];
+          return { exitCode: 0, stdout: `${SHA}\t${ref}\n`, stderr: '' };
+        }
+        if (args.includes('clone')) {
+          const dest = args[args.length - 1];
+          // verbatimSymlinks: cpSync 預設把相對 link target 重寫成絕對路徑 —
+          // 真實 git clone 保留相對 target，fixture 複製必須一致
+          cpSync(fixture, dest, { recursive: true, verbatimSymlinks: true });
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (args.includes('get-url')) {
+          return { exitCode: 0, stdout: 'https://github.com/mattpocock/skills\n', stderr: '' };
+        }
+        return { exitCode: 0, stdout: '', stderr: '' };
+      };
+
+      const dir = mkdtempSync(join(tmpdir(), 'repro-e2e-'));
+      try {
+        const res = await runCommand(['add', 'https://github.com/mattpocock/skills'], {
+          agentDir: dir,
+          statePath: join(dir, 'state.json'),
+          gitExecutor: executor,
+        });
+        expect(res.output).not.toMatch(/snapshot 建立失敗/);
+        expect(res.output).toMatch(/已註冊/);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Fixes #116

## 根因

`acquireGitSource` 的 root 是 `mkdtempSync(join(tmpdir(), 'git-acq-'))` 回傳值——macOS `TMPDIR` 未 realpath（`/var` → `/private/var`）。`checkSymlinkContainment` 用 `realpathSync.native` 解析 symlink target（會把 `/var` 元件也 canonicalize），但 containment prefix 由未 canonicalize 的 raw root 組成 → root 內的 contained symlink 被誤判「escapes owning root」。

影響：任何含 symlink 的 git marketplace 在 macOS 無法 `add` / `update`。本地 `add` 不受影響（`localSourceKey` 先 realpath）。

## 修法

`checkSymlinkContainment` 進入時先把 owning root canonicalize 一次再建 prefix——與 `src/registration/contained.ts` `resolveContained` 既有做法一致。`buildGitSnapshot` / `buildLocalSnapshot` 共用此函數，兩路徑同時修正。

同函數補齊 CONTEXT.md「Contained Symlink」定義：canonical target 須為 regular file 或 directory，special-file target（FIFO/socket）為 Blocking Finding（與 `resolveContained` 既有規則一致）。

## 回歸測試（`tests/unit/registration/repro-symlink.test.ts`）

- 單元：raw mkdtemp root（`tmpdir()` 底下）+ `AGENTS.md -> CLAUDE.md` → `buildGitSnapshot` `ok === true`（CI macOS runner 的 `/var` → `/private/var` 差異真實存在）
- 單元：symlink → FIFO → `CONTAINED_SYMLINK_VIOLATION` blocking
- e2e：離線 fixture clone mock 走完整 `add` 流程斷言「已註冊」——原真實網路版改為離線，避免 CI 網路 flake（`cpSync` 需 `verbatimSymlinks: true` 保留相對 link target，與真 `git clone` 一致）

驗證：`npm run typecheck` ✓、`npm test` 255 passed ✓