### PR TITLE
fix: allow marketplace root as contained plugin path

### DIFF
--- a/src/registration/contained.ts
+++ b/src/registration/contained.ts
@@ -25,10 +25,10 @@ export function containedPathSyntax(p: string): PathSyntax {
   if (p.includes('\\')) return { ok: false, reason: 'backslash' };
   if (isAbsolute(p)) return { ok: false, reason: 'absolute path' };
   if (!p.startsWith('./')) return { ok: false, reason: 'not ./ relative' };
-  const segments = p.split('/');
-  // "./x" -> segments ['', '.', 'x']; a bare "." or ".." component anywhere is rejected
-  const rest = segments.slice(1);
-  for (const seg of rest) {
+  if (p === './') return { ok: true };
+  // The mandatory "./" prefix is not a path component; validate only the declared remainder.
+  const segments = p.slice(2).split('/');
+  for (const seg of segments) {
     if (seg === '' || seg === '.' || seg === '..') {
       return { ok: false, reason: `dot or parent segment '${seg}'` };
     }

--- a/tests/unit/bridge/command-install.test.ts
+++ b/tests/unit/bridge/command-install.test.ts
@@ -85,6 +85,18 @@ describe('install #90', () => {
     expect(res.output).toContain('已重新載入生效');
   });
 
+  it('installs a plugin whose path is the marketplace root', async () => {
+    makeCodexMarketplace(mktRoot, 'root-plugin-marketplace', [
+      { name: 'root-plugin', path: './', skills: [] },
+    ]);
+    const added = await runCommand(['add', mktRoot], { statePath });
+    expect(added.output).toContain('已註冊');
+
+    const installed = await runCommand(['install', '1'], { statePath });
+    expect(installed.output).toContain('安裝 \"root-plugin\"');
+    expect(installed.output).not.toContain('path containment syntax violation');
+  });
+
   it('repeat install overwrites', async () => {
     makeCodexMarketplace(mktRoot, 'demo-marketplace', [
       { name: 'demo', path: './plugins/demo', skills: ['skill-a'] },

--- a/tests/unit/registration/contained.test.ts
+++ b/tests/unit/registration/contained.test.ts
@@ -6,7 +6,8 @@ import { join } from 'node:path';
 import { containedPathSyntax, resolveContained } from '../../../src/registration/contained.js';
 
 describe('Contained Path syntax', () => {
-  it('accepts clean ./ relative paths', () => {
+  it('accepts clean ./ relative paths, including the owning root', () => {
+    expect(containedPathSyntax('./').ok).toBe(true);
     expect(containedPathSyntax('./plugin-a/plugin.json').ok).toBe(true);
     expect(containedPathSyntax('./a/b/c').ok).toBe(true);
   });
@@ -44,6 +45,14 @@ describe('Contained Path resolution', () => {
     expect(res.outcome.kind).toBe('ok');
     if (res.outcome.kind === 'ok') {
       expect(res.outcome.canonicalPath).toBe(join(root, 'plugins', 'p1'));
+    }
+  });
+
+  it('resolves the owning root itself', () => {
+    const res = resolveContained(root, './', 'directory');
+    expect(res.outcome.kind).toBe('ok');
+    if (res.outcome.kind === 'ok') {
+      expect(res.outcome.canonicalPath).toBe(root);
     }
   });
 


### PR DESCRIPTION
## 問題

當 marketplace catalog 的本機 plugin 宣告 `path: \"./\"`，也就是 marketplace root 同時為 plugin root 時，`install` 會錯誤回報：

```text
plugin 路徑檢查失敗（Contained Path 違規）— path containment syntax violation: dot or parent segment ''
```

`./` 是受 Contained Path 契約允許、且仍位於 owning root 內的合法 root path。原本的語法檢查以 `/` 切割完整字串，將 `./` 的尾端拆成空 segment，因而誤判為重複斜線。

## 變更

- 明確允許 `./` 指向 owning root。
- 移除必要的 `./` 前綴後，再驗證剩餘 path segments。
- 保留既有安全限制：絕對路徑、反斜線、NUL、`.`、`..`、空 segment 與 root escape 仍會被拒絕。
- 新增語法、canonical resolution 與完整 install command seam 的回歸測試。

## 驗證

- `npm run typecheck`
- `npm test`
  - 25 個 test files 通過
  - 257 個 tests 通過
- 修正前，root plugin 安裝測試穩定重現原始錯誤；修正後通過。