### PR TITLE
feat: 提供九個 /codex-marketplace 根層 autocomplete 選項 (#121)

### DIFF
--- a/extensions/pi/autocomplete.ts
+++ b/extensions/pi/autocomplete.ts
@@ -1,0 +1,58 @@
+/**
+ * Narrow Bridge autocomplete provider — thin Pi adapter (TUI session only) (#119, #121).
+ *
+ * Pi 0.84.2's built-in combined provider completes the slash-command name and inserts a
+ * trailing space without exposing empty-prefix argument completion (root subcommands) when
+ * the editor holds exactly `/codex-marketplace`. This wrapper intercepts only that exact
+ * editor content and presents the nine root candidates; everything else — other slash
+ * commands, text, file/path completion, suggestion generation and completion application —
+ * delegates unchanged to the host's current provider.
+ *
+ * The wrapper is installed from a `session_start` handler via `ctx.ui.addAutocompleteProvider`,
+ * which interactive (TUI) mode wires into the editor and RPC/JSON/print modes no-op, so a
+ * terminal-only provider is never registered outside a TUI session.
+ */
+
+import type { AutocompleteProvider } from '@earendil-works/pi-tui';
+
+import { completeArguments, type CompletionReadOptions } from '../../src/bridge/completion.js';
+
+/** The exact editor content this provider owns. */
+export const EXACT_COMMAND = '/codex-marketplace';
+
+/**
+ * Wrap the host's current autocomplete provider. Suggestion generation intercepts only the
+ * exact `/codex-marketplace` line; completion application and file-trigger decisions delegate
+ * to the current provider's semantics, so selection behavior stays Pi-native.
+ */
+export function createBridgeAutocompleteProvider(
+  current: AutocompleteProvider,
+  readOptions: CompletionReadOptions = {},
+): AutocompleteProvider {
+  return {
+    async getSuggestions(lines, cursorLine, cursorCol, options) {
+      const line = lines[cursorLine] ?? '';
+      // Intercept only when the editor content is exactly the complete command text — a
+      // mid-command cursor or trailing text after the command is not "editor 內容恰為
+      // /codex-marketplace" and must fall through to the host provider unchanged.
+      if (line === EXACT_COMMAND && cursorCol === EXACT_COMMAND.length) {
+        const items = completeArguments('', readOptions);
+        if (items && items.length > 0) {
+          // The intercepted prefix is the whole line before the cursor (prefix ''), so the
+          // insertion value must carry the separator space the editor content lacks.
+          return {
+            items: items.map((item) => ({ ...item, value: ` ${item.value}` })),
+            prefix: '',
+          };
+        }
+      }
+      return current.getSuggestions(lines, cursorLine, cursorCol, options);
+    },
+    applyCompletion(lines, cursorLine, cursorCol, item, prefix) {
+      return current.applyCompletion(lines, cursorLine, cursorCol, item, prefix);
+    },
+    shouldTriggerFileCompletion(lines, cursorLine, cursorCol) {
+      return current.shouldTriggerFileCompletion?.(lines, cursorLine, cursorCol) ?? true;
+    },
+  };
+}

--- a/extensions/pi/index.ts
+++ b/extensions/pi/index.ts
@@ -14,8 +14,18 @@ import type { ExtensionAPI, ExtensionCommandContext } from '@earendil-works/pi-c
 
 import { runCommand } from '../../src/bridge/command.js';
 import { discoverProjectedSkillPaths } from '../../src/projection/exposure.js';
+import { completeArguments } from '../../src/bridge/completion.js';
+import { createBridgeAutocompleteProvider } from './autocomplete.js';
 
 export default function (pi: ExtensionAPI) {
+  // Root-level autocomplete (#121): stack a narrow provider for the exact `/codex-marketplace`
+  // editor text (Pi otherwise completes just the command name plus a space). session_start
+  // supplies the full TUI ui context; RPC/JSON/print modes no-op ctx.ui.addAutocompleteProvider,
+  // so a terminal-only provider is never registered outside a TUI session and command
+  // execution is unchanged.
+  pi.on('session_start', (_event, ctx) => {
+    ctx.ui.addAutocompleteProvider((current) => createBridgeAutocompleteProvider(current));
+  });
   // Runtime Skill Exposure (ADR 0001): contribute Projected Skills through Pi's
   // resource-discovery seam at every startup and reload. Passive existence inspection over the
   // current Effective State only — no fingerprint validation and no Bridge State mutation.
@@ -33,6 +43,9 @@ export default function (pi: ExtensionAPI) {
 
   pi.registerCommand('codex-marketplace', {
     description: 'codex / claude marketplace 管理（add/list/install/update/disable/enable/remove/forget/help）',
+    // Standard argument completion (#121): typed subcommand prefixes go through Pi's normal
+    // autocomplete; unowned syntax returns null so Pi falls through to its own behavior.
+    getArgumentCompletions: (argumentPrefix: string) => completeArguments(argumentPrefix),
     handler: async (args: string, ctx: ExtensionCommandContext) => {
       const rawArgs = (args ?? '').trim();
       const argv = rawArgs.length > 0 ? rawArgs.split(/\s+/) : [];

--- a/src/bridge/command.ts
+++ b/src/bridge/command.ts
@@ -63,7 +63,9 @@ export interface CommandResult {
 
 const USAGE_LINE = '用法：/codex-marketplace <add|list|install|update|disable|enable|remove|forget|help>';
 
-const HELP_TEXT = [
+// Exported so the Bridge completion seam can be verified against the same description
+// vocabulary it mirrors (#121) — alignment is pinned by tests, not by manual syncing.
+export const HELP_TEXT = [
   '用法：/codex-marketplace <子命令> [參數]',
   '',
   '子命令：',

--- a/src/bridge/completion.ts
+++ b/src/bridge/completion.ts
@@ -1,0 +1,120 @@
+/**
+ * Bridge completion seam (#121).
+ *
+ * Pure root-level autocomplete for `/codex-marketplace` subcommands. This module owns no
+ * terminal, TUI, rendering, or Pi host types: its input is the complete argument prefix plus
+ * replaceable read-only options, and its output is only the insertion value, display label,
+ * and optional description that Pi autocomplete needs — or `null` when the argument prefix is
+ * not Bridge-owned syntax.
+ *
+ * Not owned (#121 scope): state-dependent second-level candidates, arbitrary text, file and
+ * path completion. When the module does not own the syntax, callers fall through to Pi's
+ * normal behavior unchanged.
+ */
+
+export interface CompletionItem {
+  /** Insertion value. Argument-taking subcommands carry a trailing space (#121). */
+  value: string;
+  /** Display label shown in Pi's candidate list. */
+  label: string;
+  /** Optional short description, matching the command surface's HELP_TEXT vocabulary. */
+  description?: string;
+}
+
+/**
+ * Replaceable read-only options for composing candidates (Bridge State read seam).
+ *
+ * Root-level (#121) candidates never read Bridge State, so these options have no effect on
+ * the current output — the seam exists so state-dependent second-level candidates can be
+ * composed passively without ever writing or resetting a damaged document (#119 stories
+ * 22–23). The adapter passes them through from registrable sources only.
+ */
+export interface CompletionReadOptions {
+  statePath?: string;
+  agentDir?: string;
+}
+
+interface RootCommandCandidate {
+  label: string;
+  description: string;
+  /** Whether applying the subcommand expects an argument (inserts a trailing space). */
+  takesArgument: boolean;
+}
+
+/** The nine root subcommands, descriptions aligned with the command surface's HELP_TEXT vocabulary. */
+const ROOT_CANDIDATES: RootCommandCandidate[] = [
+  { label: 'add', description: '註冊 marketplace', takesArgument: true },
+  { label: 'list', description: '列出 plugins', takesArgument: true },
+  { label: 'install', description: '安裝最新版本並立即啟用', takesArgument: true },
+  { label: 'update', description: '全部更新', takesArgument: false },
+  { label: 'disable', description: '停用 plugin（不再投影）', takesArgument: true },
+  { label: 'enable', description: '啟用 plugin（恢復投影）', takesArgument: true },
+  { label: 'remove', description: '移除 plugin', takesArgument: true },
+  { label: 'forget', description: '移除 marketplace（含其全部安裝）', takesArgument: true },
+  { label: 'help', description: '這份說明清單', takesArgument: false },
+];
+
+function toItem(candidate: RootCommandCandidate): CompletionItem {
+  return {
+    value: candidate.takesArgument ? `${candidate.label} ` : candidate.label,
+    label: candidate.label,
+    description: candidate.description,
+  };
+}
+
+/** Scoring: earlier first-match wins, then a tighter char span within the label. */
+const FIRST_MATCH_WEIGHT = 1000;
+
+/**
+ * Case-insensitive non-contiguous fuzzy match: every query character must appear in order
+ * within the label. The score prefers earlier first-match position then a tighter span.
+ */
+function fuzzyScore(query: string, label: string): number | null {
+  const q = query.toLowerCase();
+  const target = label.toLowerCase();
+  let queryIndex = 0;
+  let firstMatch = -1;
+  let lastMatch = -1;
+  for (let i = 0; i < target.length && queryIndex < q.length; i += 1) {
+    if (target[i] === q[queryIndex]) {
+      if (firstMatch === -1) firstMatch = i;
+      lastMatch = i;
+      queryIndex += 1;
+    }
+  }
+  if (queryIndex < q.length) return null;
+  return firstMatch * FIRST_MATCH_WEIGHT + (lastMatch - firstMatch);
+}
+
+/**
+ * Compose root-level completion candidates for `/codex-marketplace <argumentPrefix>`.
+ *
+ * - Empty prefix → all nine root candidates (Pi's exact-command interception surface).
+ * - A single token → case-insensitive fuzzy-filtered subcommands; `[]` when nothing matches
+ *   (the syntax is still Bridge-owned, there are simply no candidates).
+ * - Whitespace-containing prefixes (second-level argument text) are not Bridge-owned in #121 → `null`,
+ *   so callers fall through to Pi's own completion unchanged.
+ *
+ * The module never writes Bridge State; root candidates are derived without reading it at all.
+ */
+export function completeArguments(
+  argumentPrefix: string,
+  _options: CompletionReadOptions = {},
+): CompletionItem[] | null {
+  if (/\s/.test(argumentPrefix)) return null;
+
+  const query = argumentPrefix.trim();
+  if (query.length === 0) {
+    return ROOT_CANDIDATES.map(toItem);
+  }
+
+  const scored: { item: CompletionItem; score: number }[] = [];
+  for (const candidate of ROOT_CANDIDATES) {
+    const score = fuzzyScore(query, candidate.label);
+    if (score !== null) {
+      scored.push({ item: toItem(candidate), score });
+    }
+  }
+  scored.sort((a, b) => a.score - b.score || a.item.label.localeCompare(b.item.label));
+  return scored.map((entry) => entry.item);
+}

--- a/tests/e2e/extension-autocomplete.test.ts
+++ b/tests/e2e/extension-autocomplete.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AutocompleteItem, AutocompleteProvider, AutocompleteSuggestions } from '@earendil-works/pi-tui';
+import { CombinedAutocompleteProvider } from '@earendil-works/pi-tui';
+
+import registerBridgeExtension from '../../extensions/pi/index.js';
+
+const ROOT_LABELS = ['add', 'list', 'install', 'update', 'disable', 'enable', 'remove', 'forget', 'help'];
+
+interface CapturedCommand {
+  handler(args: string, ctx: unknown): Promise<void>;
+  getArgumentCompletions?: (argumentPrefix: string) => AutocompleteItem[] | null;
+}
+
+type SessionStartHandler = (
+  event: unknown,
+  ctx: { ui: { addAutocompleteProvider: (factory: (current: AutocompleteProvider) => AutocompleteProvider) => void } },
+) => void | Promise<void>;
+
+interface CapturedExtension {
+  commands: Map<string, CapturedCommand>;
+  sessionStartHandlers: SessionStartHandler[];
+  /** The factory captured from ctx.ui.addAutocompleteProvider during a session_start. */
+  autocompleteFactory?: (current: AutocompleteProvider) => AutocompleteProvider;
+}
+
+function captureExtension(): CapturedExtension {
+  const captured: CapturedExtension = { commands: new Map(), sessionStartHandlers: [] };
+  registerBridgeExtension({
+    on(event: string, handler: SessionStartHandler) {
+      if (event === 'session_start') {
+        captured.sessionStartHandlers.push(handler);
+      }
+      // other events (resources_discover / …) are only registered, never emitted here
+    },
+    registerCommand(name: string, command: CapturedCommand) {
+      captured.commands.set(name, command);
+    },
+  } as never);
+  return captured;
+}
+
+/** Emit the captured session_start with a host ui context, returning the installed factory. */
+function installFactory(captured: CapturedExtension): (current: AutocompleteProvider) => AutocompleteProvider {
+  const ctx = {
+    mode: 'tui',
+    hasUI: true,
+    cwd: '/tmp',
+    ui: {
+      addAutocompleteProvider(factory: (current: AutocompleteProvider) => AutocompleteProvider) {
+        captured.autocompleteFactory = factory;
+      },
+    },
+  };
+  for (const handler of captured.sessionStartHandlers) {
+    void handler({ type: 'session_start', reason: 'startup' }, ctx as never);
+  }
+  const factory = captured.autocompleteFactory;
+  if (!factory) throw new Error('session_start did not install an autocomplete provider factory');
+  return factory;
+}
+
+function fakeCurrentProvider(options: {
+  suggestions?: AutocompleteSuggestions | null;
+} = {}): AutocompleteProvider & { calls: string[] } {
+  const calls: string[] = [];
+  const provider: AutocompleteProvider = {
+    async getSuggestions(lines, cursorLine, cursorCol, _options) {
+      calls.push('getSuggestions');
+      return options.suggestions ?? null;
+    },
+    applyCompletion(lines, cursorLine, cursorCol, item, prefix) {
+      calls.push(`applyCompletion:${item.value}` as string);
+      return { lines, cursorLine, cursorCol };
+    },
+  };
+  return Object.assign(provider, { calls });
+}
+
+describe('/codex-marketplace autocomplete thin Pi adapter (#121)', () => {
+  it('registers the command with Bridge-owned argument completion', () => {
+    const captured = captureExtension();
+    const command = captured.commands.get('codex-marketplace');
+    expect(command).toBeDefined();
+    expect(typeof command!.getArgumentCompletions).toBe('function');
+
+    const items = command!.getArgumentCompletions!('');
+    expect(items!.map((item) => item.label)).toEqual(ROOT_LABELS);
+  });
+
+  it('argument completion narrows by typed prefix and stays null for unowned syntax', () => {
+    const captured = captureExtension();
+    const command = captured.commands.get('codex-marketplace')!;
+
+    const narrowed = command.getArgumentCompletions!('INSTL');
+    expect(narrowed!.map((item) => item.label)).toEqual(['install']);
+
+    expect(command.getArgumentCompletions!('install my-plugin')).toBeNull();
+  });
+
+  it('installs an autocomplete provider factory through session_start', () => {
+    const captured = captureExtension();
+    const factory = installFactory(captured);
+    expect(typeof factory).toBe('function');
+  });
+
+  it('intercepts the exact /codex-marketplace editor text with all nine subcommands and does not consult the current provider', async () => {
+    const captured = captureExtension();
+    const current = fakeCurrentProvider();
+    const wrapper = installFactory(captured)(current) as AutocompleteProvider;
+
+    const result = await wrapper.getSuggestions(['/codex-marketplace'], 0, '/codex-marketplace'.length, {
+      signal: new AbortController().signal,
+      force: false,
+    });
+
+    expect(current.calls).toEqual([]);
+    expect(result).not.toBeNull();
+    expect(result!.prefix).toBe('');
+    expect(result!.items.map((item) => item.label)).toEqual(ROOT_LABELS);
+  });
+
+  it('delegates suggestion generation for unrelated editor text to the current provider', async () => {
+    const captured = captureExtension();
+    const current = fakeCurrentProvider({
+      suggestions: { items: [{ value: 'x', label: 'x' }], prefix: 'x' },
+    });
+    const wrapper = installFactory(captured)(current) as AutocompleteProvider;
+
+    const result = await wrapper.getSuggestions(['/other'], 0, 6, {
+      signal: new AbortController().signal,
+      force: false,
+    });
+
+    expect(current.calls).toEqual(['getSuggestions']);
+    expect(result).toEqual({ items: [{ value: 'x', label: 'x' }], prefix: 'x' });
+  });
+
+  it('delegates completion application to the current provider', () => {
+    const captured = captureExtension();
+    const current = fakeCurrentProvider();
+    const wrapper = installFactory(captured)(current) as AutocompleteProvider;
+
+    const lines = ['/codex-marketplace'];
+    const result = wrapper.applyCompletion(lines, 0, 16, { value: 'install ', label: 'install' }, '');
+
+    expect(current.calls).toEqual(['applyCompletion:install ']);
+    expect(result).toEqual({ lines, cursorLine: 0, cursorCol: 16 });
+  });
+
+  it('delegates file-completion triggering to the current provider when present', async () => {
+    const captured = captureExtension();
+    const current = fakeCurrentProvider();
+    const wrapper = installFactory(captured)(current) as AutocompleteProvider;
+
+    expect(wrapper.shouldTriggerFileCompletion?.(['import x from "./a'], 0, 18)).toBe(true);
+  });
+
+  it('applies an intercepted subcommand through Pi 0.84.2 real combined provider, cursor after the trailing space', async () => {
+    // Real host provider: CombinedAutocompleteProvider is what interactive mode wraps.
+    const captured = captureExtension();
+    const command = captured.commands.get('codex-marketplace')!;
+    const base = new CombinedAutocompleteProvider(
+      [{ name: 'codex-marketplace', getArgumentCompletions: command.getArgumentCompletions }],
+      '/tmp',
+      null,
+    );
+    const wrapper = installFactory(captured)(base) as AutocompleteProvider;
+
+    const line = '/codex-marketplace';
+    const suggestions = await wrapper.getSuggestions([line], 0, line.length, {
+      signal: new AbortController().signal,
+      force: false,
+    });
+    const install = suggestions!.items.find((item) => item.label === 'install')!;
+    const applied = wrapper.applyCompletion([line], 0, line.length, install, suggestions!.prefix);
+
+    expect(applied.lines[0]).toBe('/codex-marketplace install ');
+    expect(applied.cursorCol).toBe('/codex-marketplace install '.length);
+
+    const update = suggestions!.items.find((item) => item.label === 'update')!;
+    const appliedUpdate = wrapper.applyCompletion([line], 0, line.length, update, suggestions!.prefix);
+    expect(appliedUpdate.lines[0]).toBe('/codex-marketplace update');
+    expect(appliedUpdate.cursorCol).toBe('/codex-marketplace update'.length);
+  });
+
+  it('does not intercept when the line holds trailing text after the command', async () => {
+    const captured = captureExtension();
+    const current = fakeCurrentProvider();
+    const wrapper = installFactory(captured)(current) as AutocompleteProvider;
+
+    await wrapper.getSuggestions(['/codex-marketplace pasted-junk'], 0, 18, {
+      signal: new AbortController().signal,
+      force: false,
+    });
+
+    // "editor 內容恰為 /codex-marketplace" — trailing text means not Bridge-owned here.
+    expect(current.calls).toEqual(['getSuggestions']);
+  });
+
+  it('does not chain-reopen the subcommand list after an applied argument (next Tab is delegated, force path)', async () => {
+    const captured = captureExtension();
+    const current = fakeCurrentProvider();
+    const wrapper = installFactory(captured)(current) as AutocompleteProvider;
+
+    // After applying "install " the editor holds "/codex-marketplace install "; a subsequent
+    // Tab is a forced request and must not re-intercept the line as the exact command.
+    await wrapper.getSuggestions(['/codex-marketplace install '], 0, 25, {
+      signal: new AbortController().signal,
+      force: true,
+    });
+
+    expect(current.calls).toEqual(['getSuggestions']);
+  });
+
+  it('registers nothing terminal-only and keeps command execution when the host ui no-ops (RPC/JSON/print modes)', () => {
+    // runner.js / rpc-mode give session_start contexts a no-op ui.addAutocompleteProvider —
+    // the extension must still register the command and never install a terminal-only provider.
+    const captured = captureExtension();
+    let uiCalls = 0;
+    for (const handler of captured.sessionStartHandlers) {
+      void handler(
+        { type: 'session_start' },
+        {
+          ui: {
+            addAutocompleteProvider() {
+              uiCalls += 1;
+              // no-op, exactly like ExtensionRunner's default UI context and RPC mode
+            },
+          },
+        } as never,
+      );
+    }
+
+    expect(uiCalls).toBe(1);
+    expect(captured.autocompleteFactory).toBeUndefined();
+    const command = captured.commands.get('codex-marketplace');
+    expect(command).toBeDefined();
+    expect(typeof command!.getArgumentCompletions).toBe('function');
+    // Command execution behavior is unaffected by the no-op ui.
+    expect(typeof command!.handler).toBe('function');
+  });
+});

--- a/tests/unit/bridge/completion.test.ts
+++ b/tests/unit/bridge/completion.test.ts
@@ -1,0 +1,98 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { completeArguments } from '../../../src/bridge/completion.js';
+import { HELP_TEXT } from '../../../src/bridge/command.js';
+
+const ROOT_LABELS = ['add', 'list', 'install', 'update', 'disable', 'enable', 'remove', 'forget', 'help'];
+
+/** Parse the command surface's canonical description per subcommand out of HELP_TEXT. */
+function helpDescriptions(): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const line of HELP_TEXT.split('\n')) {
+    const match = line.match(/^ {2}([a-z-]+)(?: .*?)?\s{2,}(.+)$/);
+    if (match) map.set(match[1], match[2].trim());
+  }
+  return map;
+}
+
+describe('Bridge completion seam (#121)', () => {
+  it('returns all nine root candidates with descriptions for an empty argument prefix', () => {
+    const result = completeArguments('');
+
+    expect(result).not.toBeNull();
+    expect(result!.map((item) => item.label)).toEqual(ROOT_LABELS);
+    expect(result!.every((item) => typeof item.description === 'string' && item.description.length > 0)).toBe(true);
+  });
+
+  it('narrows the list with case-insensitive fuzzy matching', () => {
+    const mixedCase = completeArguments('INSTL');
+    expect(mixedCase!.map((item) => item.label)).toEqual(['install']);
+
+    const lower = completeArguments('dis');
+    expect(lower!.map((item) => item.label)).toEqual(['disable']);
+  });
+
+  it('narrows the list with non-contiguous fuzzy matching', () => {
+    const result = completeArguments('istl');
+    expect(result!.map((item) => item.label)).toEqual(['install']);
+  });
+
+  it('keeps a trailing space in the insertion value of argument-taking subcommands', () => {
+    const result = completeArguments('add');
+    expect(result![0].value).toBe('add ');
+
+    const all = completeArguments('');
+    const argTaking = all!.filter((item) => ['add', 'list', 'install', 'disable', 'enable', 'remove', 'forget'].includes(item.label));
+    for (const item of argTaking) {
+      expect(item.value.endsWith(' ')).toBe(true);
+      expect(item.value).toBe(item.label + ' ');
+    }
+  });
+
+  it('inserts no trailing space for update and help', () => {
+    const update = completeArguments('upd');
+    expect(update![0].value).toBe('update');
+
+    const help = completeArguments('he');
+    expect(help![0].value).toBe('help');
+  });
+
+  it('returns an empty list when no subcommand fuzzy-matches', () => {
+    expect(completeArguments('zzz')).toEqual([]);
+  });
+
+  it('returns null when the argument prefix is not Bridge-owned syntax', () => {
+    // Second-level argument text is out of scope for #121 — Bridge must not own it.
+    expect(completeArguments('install my-plugin')).toBeNull();
+    expect(completeArguments('list ')).toBeNull();
+  });
+
+  it('mirrors the command surface description vocabulary without drift', () => {
+    const canonical = helpDescriptions();
+    expect([...canonical.keys()].sort()).toEqual([...ROOT_LABELS].sort());
+
+    for (const item of completeArguments('')!) {
+      expect(canonical.get(item.label)).toBe(item.description);
+    }
+  });
+
+  it('is passive: composing candidates never writes or resets a damaged Bridge State document', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'bridge-completion-passive-'));
+    try {
+      const statePath = join(tmpDir, 'state.json');
+      const damaged = 'INVALID JSON CONTENT';
+      writeFileSync(statePath, damaged, 'utf-8');
+
+      const result = completeArguments('', { statePath });
+
+      expect(result).not.toBeNull();
+      // The damaged document must survive untouched — autocomplete is read-only (#119 22–23).
+      expect(readFileSync(statePath, 'utf-8')).toBe(damaged);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Resolves #121（父 spec：#119）。

## 變更內容

- **Bridge completion seam**（`src/bridge/completion.ts`，純 Node、零 terminal/TUI rendering types）：
  - 輸入＝完整 argument prefix＋可替換唯讀選項；輸出只含 insertion value、display label、可選 description；不擁有該語法時回傳 `null`。
  - 九個根層候選 `add/list/install/update/disable/enable/remove/forget/help` 及短說明，與 `HELP_TEXT` 詞彙一致（測試釘住對齊）。
  - 不分大小寫、非連續 partial input 模糊比對。
  - `add/list/install/disable/enable/remove/forget` 的 insertion value 帶尾端空格；`update`/`help` 不帶。
  - 永不寫入或重設 Bridge State（damaged state 檔測試證明 passive）。
- **薄 Pi adapter**（`extensions/pi/`）：
  - `registerCommand` 掛 `getArgumentCompletions`，已輸入的子命令／參數 prefix 走 Pi 0.84.2 標準 autocomplete。
  - `session_start` 疊加窄範圍 provider，僅在 editor 內容恰為 `/codex-marketplace` 時呈現九個候選；suggestion generation、completion application、file-trigger 判斷全部委派 Pi 目前 provider。
  - RPC/JSON/print 模式的 `ctx.ui.addAutocompleteProvider` 為 no-op → terminal-only provider 不會在非 TUI session 註冊，既有指令執行行為不變。
  - 未建立任何 custom editor／overlay／selector／widget／footer。

## 測試與驗證

- `npm run typecheck`（Pi 0.84.2 `@earendil-works/pi-coding-agent`／`pi-tui` interfaces）✅
- `npm test`：28 files／279 tests 全綠（新增 20 個：Bridge completion 行為 9 + 薄 adapter capture 模式 11，含以真實 `CombinedAutocompleteProvider` 驗證套用後游標位於尾端空格之後、`update`/`help` 無誤導空格）。

## Acceptance Criteria 對照

- ✅ 九個根層候選＋說明（interception + descriptions 測試）
- ✅ 大小寫混合與非連續 partial input 模糊縮小（`INSTL`→install、`istl`→install）
- ✅ argument-taking 套用後游標在尾端空格後；`update`/`help` 無尾端空格（真實 provider 測試）
- ✅ 選取後不自動連鎖重開；再按一次 Tab 走 Pi 原生 force path（委派測試）
- ✅ command completion registration、exact-command interception、completion application、previous-provider delegation 皆由薄 Pi adapter 測試證明
- ✅ RPC/JSON/print 不註冊 terminal-only provider；既有指令執行行為不變（既有 e2e 全綠）
- ✅ 以 Pi 0.84.2 interfaces typecheck 並通過測試