### PR TITLE
feat: 提供狀態感知的 install Plugin autocomplete (#122)

### DIFF
--- a/extensions/pi/autocomplete.ts
+++ b/extensions/pi/autocomplete.ts
@@ -1,12 +1,15 @@
 /**
- * Narrow Bridge autocomplete provider — thin Pi adapter (TUI session only) (#119, #121).
+ * Narrow Bridge autocomplete provider — thin Pi adapter (TUI session only) (#119, #121, #122).
  *
  * Pi 0.84.2's built-in combined provider completes the slash-command name and inserts a
  * trailing space without exposing empty-prefix argument completion (root subcommands) when
- * the editor holds exactly `/codex-marketplace`. This wrapper intercepts only that exact
- * editor content and presents the nine root candidates; everything else — other slash
- * commands, text, file/path completion, suggestion generation and completion application —
- * delegates unchanged to the host's current provider.
+ * the editor holds exactly `/codex-marketplace`. This wrapper intercepts that exact editor
+ * content and presents the nine root candidates. It also owns the second-level `install`
+ * argument context on forced (Tab) requests, which Pi 0.84.2 routes to file completion
+ * instead of slash-command argument completion (its argument path only runs when `force` is
+ * false) — the wrapper returns the state-aware install candidates there. Everything else —
+ * other slash commands, text, file/path completion, suggestion generation and completion
+ * application — delegates unchanged to the host's current provider.
  *
  * The wrapper is installed from a `session_start` handler via `ctx.ui.addAutocompleteProvider`,
  * which interactive (TUI) mode wires into the editor and RPC/JSON/print modes no-op, so a
@@ -20,10 +23,14 @@ import { completeArguments, type CompletionReadOptions } from '../../src/bridge/
 /** The exact editor content this provider owns. */
 export const EXACT_COMMAND = '/codex-marketplace';
 
+/** The second-level install argument context owned on forced requests: `/codex-marketplace install `. */
+export const INSTALL_ARGUMENT_PREFIX = `${EXACT_COMMAND} install `;
+
 /**
  * Wrap the host's current autocomplete provider. Suggestion generation intercepts only the
- * exact `/codex-marketplace` line; completion application and file-trigger decisions delegate
- * to the current provider's semantics, so selection behavior stays Pi-native.
+ * Bridge-owned editor contexts (the exact `/codex-marketplace` line and the forced `install `
+ * argument context); completion application and file-trigger decisions delegate to the
+ * current provider's semantics, so selection behavior stays Pi-native.
  */
 export function createBridgeAutocompleteProvider(
   current: AutocompleteProvider,
@@ -32,9 +39,9 @@ export function createBridgeAutocompleteProvider(
   return {
     async getSuggestions(lines, cursorLine, cursorCol, options) {
       const line = lines[cursorLine] ?? '';
-      // Intercept only when the editor content is exactly the complete command text — a
-      // mid-command cursor or trailing text after the command is not "editor 內容恰為
-      // /codex-marketplace" and must fall through to the host provider unchanged.
+      // Root-level interception (#121): only when the editor content is exactly the complete
+      // command text — a mid-command cursor or trailing text after the command is not
+      // "editor 內容恰為 /codex-marketplace" and must fall through to the host provider.
       if (line === EXACT_COMMAND && cursorCol === EXACT_COMMAND.length) {
         const items = completeArguments('', readOptions);
         if (items && items.length > 0) {
@@ -44,6 +51,18 @@ export function createBridgeAutocompleteProvider(
             items: items.map((item) => ({ ...item, value: ` ${item.value}` })),
             prefix: '',
           };
+        }
+      }
+      // Second-level install interception (#122): forced (Tab) requests inside `install `
+      // are Bridge-owned — the host's combined provider would route them to file completion.
+      // Natural typing (force=false) is delegated and reaches the same candidates through the
+      // command's getArgumentCompletions. The prefix returned is the text after the command
+      // name (`install ` or `install <query>`), matching the host's argument-text semantics.
+      if (options.force && line.startsWith(INSTALL_ARGUMENT_PREFIX) && cursorCol >= INSTALL_ARGUMENT_PREFIX.length) {
+        const argumentText = line.slice(EXACT_COMMAND.length + 1, cursorCol);
+        const items = completeArguments(argumentText, readOptions);
+        if (items) {
+          return { items, prefix: argumentText };
         }
       }
       return current.getSuggestions(lines, cursorLine, cursorCol, options);

--- a/extensions/pi/autocomplete.ts
+++ b/extensions/pi/autocomplete.ts
@@ -56,9 +56,16 @@ export function createBridgeAutocompleteProvider(
       // Second-level install interception (#122): forced (Tab) requests inside `install `
       // are Bridge-owned — the host's combined provider would route them to file completion.
       // Natural typing (force=false) is delegated and reaches the same candidates through the
-      // command's getArgumentCompletions. The prefix returned is the text after the command
+      // command's getArgumentCompletions. Like the root branch, the cursor must be at the end
+      // of the line: a mid-line cursor with trailing text would otherwise produce a malformed
+      // line after applying a candidate. The prefix returned is the text after the command
       // name (`install ` or `install <query>`), matching the host's argument-text semantics.
-      if (options.force && line.startsWith(INSTALL_ARGUMENT_PREFIX) && cursorCol >= INSTALL_ARGUMENT_PREFIX.length) {
+      if (
+        options.force
+        && cursorCol === line.length
+        && line.startsWith(INSTALL_ARGUMENT_PREFIX)
+        && cursorCol >= INSTALL_ARGUMENT_PREFIX.length
+      ) {
         const argumentText = line.slice(EXACT_COMMAND.length + 1, cursorCol);
         const items = completeArguments(argumentText, readOptions);
         if (items) {

--- a/extensions/pi/index.ts
+++ b/extensions/pi/index.ts
@@ -18,11 +18,12 @@ import { completeArguments } from '../../src/bridge/completion.js';
 import { createBridgeAutocompleteProvider } from './autocomplete.js';
 
 export default function (pi: ExtensionAPI) {
-  // Root-level autocomplete (#121): stack a narrow provider for the exact `/codex-marketplace`
-  // editor text (Pi otherwise completes just the command name plus a space). session_start
-  // supplies the full TUI ui context; RPC/JSON/print modes no-op ctx.ui.addAutocompleteProvider,
-  // so a terminal-only provider is never registered outside a TUI session and command
-  // execution is unchanged.
+  // Root-level autocomplete (#121) + second-level install autocomplete (#122): stack a narrow
+  // provider for the exact `/codex-marketplace` editor text and the forced `install ` argument
+  // context (Pi otherwise completes just the command name plus a space, and routes forced
+  // argument Tabs to file completion). session_start supplies the full TUI ui context;
+  // RPC/JSON/print modes no-op ctx.ui.addAutocompleteProvider, so a terminal-only provider is
+  // never registered outside a TUI session and command execution is unchanged.
   pi.on('session_start', (_event, ctx) => {
     ctx.ui.addAutocompleteProvider((current) => createBridgeAutocompleteProvider(current));
   });
@@ -43,8 +44,9 @@ export default function (pi: ExtensionAPI) {
 
   pi.registerCommand('codex-marketplace', {
     description: 'codex / claude marketplace 管理（add/list/install/update/disable/enable/remove/forget/help）',
-    // Standard argument completion (#121): typed subcommand prefixes go through Pi's normal
-    // autocomplete; unowned syntax returns null so Pi falls through to its own behavior.
+    // Standard argument completion (#121, #122): typed subcommand and `install <query>`
+    // prefixes go through Pi's normal autocomplete; unowned syntax returns null so Pi falls
+    // through to its own behavior.
     getArgumentCompletions: (argumentPrefix: string) => completeArguments(argumentPrefix),
     handler: async (args: string, ctx: ExtensionCommandContext) => {
       const rawArgs = (args ?? '').trim();

--- a/src/bridge/completion.ts
+++ b/src/bridge/completion.ts
@@ -123,13 +123,15 @@ function nameInsertionUsable(unique: boolean, name: string): boolean {
 }
 
 interface InstallCandidate {
+  /** Plugin candidate name (entry name → path basename → ordinal fallback). */
+  name: string;
   /** Marketplace provenance shown in the candidate description. */
   marketplaceName: string;
   /** 可安裝 / 已裝啟用 / 已裝停用 — install and reinstall are both selectable. */
   status: string;
   /** Case-insensitive fuzzy search target: plugin name + marketplace provenance. */
   searchText: string;
-  /** Insertion token: the name when unique in the full enumeration, else the enumeration number. */
+  /** Insertion token: the name when usable, else the enumeration number. */
   insertion: string;
 }
 
@@ -156,6 +158,7 @@ function composeInstallCandidates(state: MinimalBridgeState, options: Completion
   for (const plugin of plugins) {
     if (!plugin.structurallyInstallable) continue;
     candidates.push({
+      name: plugin.candidateName,
       marketplaceName: plugin.marketplaceName,
       status: installStatusLabel(plugin.installationState),
       searchText: `${plugin.candidateName} ${plugin.marketplaceName}`,
@@ -167,10 +170,21 @@ function composeInstallCandidates(state: MinimalBridgeState, options: Completion
   return candidates;
 }
 
+/**
+ * Compose the candidate label. A name insertion shows the name itself; a number insertion
+ * keeps the enumeration number visible but labels the plugin so the user can tell which
+ * same-named entry each candidate selects (the description carries provenance + status).
+ */
+function installLabel(candidate: InstallCandidate): string {
+  return candidate.insertion === candidate.name
+    ? candidate.name
+    : `${candidate.name} (#${candidate.insertion})`;
+}
+
 function toInstallItem(candidate: InstallCandidate): CompletionItem {
   return {
     value: `install ${candidate.insertion}`,
-    label: candidate.insertion,
+    label: installLabel(candidate),
     description: `[${candidate.marketplaceName}] ${candidate.status}`,
   };
 }

--- a/src/bridge/completion.ts
+++ b/src/bridge/completion.ts
@@ -105,6 +105,23 @@ function installStatusLabel(state: MarketplacePluginInstallationState): string {
   return '可安裝';
 }
 
+/**
+ * Positive canonical integer without leading zeros — the exact argument shape `install`
+ * parses as an enumeration number (`String(Number(arg)) === arg && Number.isInteger && >= 1`),
+ * so a unique plugin name with this shape can never be resolved by name.
+ */
+const CANONICAL_INTEGER_RE = /^[1-9]\d*$/;
+
+/**
+ * Whether a name-typed `install <name>` invocation would actually resolve this candidate
+ * name: it must be unique in the full enumeration, contain no whitespace (the command splits
+ * arguments on whitespace), and not look like a canonical integer (the command parses those
+ * as enumeration numbers). Otherwise the insertion must be the enumeration number instead.
+ */
+function nameInsertionUsable(unique: boolean, name: string): boolean {
+  return unique && !/\s/.test(name) && !CANONICAL_INTEGER_RE.test(name);
+}
+
 interface InstallCandidate {
   /** Marketplace provenance shown in the candidate description. */
   marketplaceName: string;
@@ -121,10 +138,12 @@ interface InstallCandidate {
  * structurally installable entries. Unavailable Entries (unsupported source, unresolvable
  * source, invalid plugin, identity collision) never become candidates.
  *
- * Name uniqueness is judged against the *full* enumeration — the same domain `install <名稱>`
- * resolves against, so a same-named sibling that is unavailable still forces the number
- * insertion (the name would otherwise be rejected as ambiguous). The number is the plugin's
- * number in that full enumeration, matching `list` and `install <編號>` exactly.
+ * Name insertion is allowed only when a name-typed `install <名稱>` would actually resolve
+ * the plugin: the candidate name must be unique against the *full* enumeration (the same
+ * domain `install <名稱>` resolves against — a same-named sibling, even an unavailable one,
+ * forces the number insertion because the name would be rejected as ambiguous), contain no
+ * whitespace, and not parse as a canonical enumeration number. The inserted number is the
+ * plugin's number in that full enumeration, matching `list` and `install <編號>` exactly.
  */
 function composeInstallCandidates(state: MinimalBridgeState, options: CompletionReadOptions): InstallCandidate[] {
   const { plugins } = queryMarketplacePlugins(state, { agentDir: options.agentDir });
@@ -136,12 +155,13 @@ function composeInstallCandidates(state: MinimalBridgeState, options: Completion
   const candidates: InstallCandidate[] = [];
   for (const plugin of plugins) {
     if (!plugin.structurallyInstallable) continue;
-    const unique = (nameCounts.get(plugin.candidateName) ?? 0) === 1;
     candidates.push({
       marketplaceName: plugin.marketplaceName,
       status: installStatusLabel(plugin.installationState),
       searchText: `${plugin.candidateName} ${plugin.marketplaceName}`,
-      insertion: unique ? plugin.candidateName : String(plugin.number),
+      insertion: nameInsertionUsable((nameCounts.get(plugin.candidateName) ?? 0) === 1, plugin.candidateName)
+        ? plugin.candidateName
+        : String(plugin.number),
     });
   }
   return candidates;

--- a/src/bridge/completion.ts
+++ b/src/bridge/completion.ts
@@ -1,16 +1,20 @@
 /**
- * Bridge completion seam (#121).
+ * Bridge completion seam (#121, #122).
  *
- * Pure root-level autocomplete for `/codex-marketplace` subcommands. This module owns no
- * terminal, TUI, rendering, or Pi host types: its input is the complete argument prefix plus
- * replaceable read-only options, and its output is only the insertion value, display label,
- * and optional description that Pi autocomplete needs — or `null` when the argument prefix is
- * not Bridge-owned syntax.
+ * Pure autocomplete for `/codex-marketplace`: root-level subcommands (#121) plus
+ * state-aware second-level `install` candidates (#122). This module owns no terminal, TUI,
+ * rendering, or Pi host types: its input is the complete argument prefix plus replaceable
+ * read-only options, and its output is only the insertion value, display label, and optional
+ * description that Pi autocomplete needs — or `null` when the argument prefix is not
+ * Bridge-owned syntax.
  *
- * Not owned (#121 scope): state-dependent second-level candidates, arbitrary text, file and
- * path completion. When the module does not own the syntax, callers fall through to Pi's
- * normal behavior unchanged.
+ * Not owned: second-level candidates for subcommands other than `install`, arbitrary text,
+ * file and path completion. When the module does not own the syntax, callers fall through to
+ * Pi's normal behavior unchanged.
  */
+
+import { queryMarketplacePlugins, type MarketplacePluginInstallationState } from './plugin-query.js';
+import { readMinimalBridgeStatePassive, type MinimalBridgeState } from './state.js';
 
 export interface CompletionItem {
   /** Insertion value. Argument-taking subcommands carry a trailing space (#121). */
@@ -24,10 +28,10 @@ export interface CompletionItem {
 /**
  * Replaceable read-only options for composing candidates (Bridge State read seam).
  *
- * Root-level (#121) candidates never read Bridge State, so these options have no effect on
- * the current output — the seam exists so state-dependent second-level candidates can be
- * composed passively without ever writing or resetting a damaged document (#119 stories
- * 22–23). The adapter passes them through from registrable sources only.
+ * Root-level (#121) candidates never read Bridge State; state-aware `install` candidates
+ * (#122) read it passively through `readMinimalBridgeStatePassive`, so a damaged document is
+ * never written, reset, or repaired (#119 stories 22–23). The adapter passes them through
+ * from registrable sources only.
  */
 export interface CompletionReadOptions {
   statePath?: string;
@@ -87,20 +91,118 @@ function fuzzyScore(query: string, label: string): number | null {
 }
 
 /**
- * Compose root-level completion candidates for `/codex-marketplace <argumentPrefix>`.
+ * The owned second-level syntax: `install` followed by whitespace and a single-token query
+ * (plugin names are lowercase kebab-case; a second token is not Bridge-owned and falls
+ * through). `install` without a trailing space stays at the root level so the trailing-space
+ * root candidate can be applied first.
+ */
+const INSTALL_SECOND_LEVEL_RE = /^install\s+(\S*)$/;
+
+/** Status vocabulary aligned with the `list` command surface (#90). */
+function installStatusLabel(state: MarketplacePluginInstallationState): string {
+  if (state === 'enabled') return '已裝啟用';
+  if (state === 'disabled') return '已裝停用';
+  return '可安裝';
+}
+
+interface InstallCandidate {
+  /** Marketplace provenance shown in the candidate description. */
+  marketplaceName: string;
+  /** 可安裝 / 已裝啟用 / 已裝停用 — install and reinstall are both selectable. */
+  status: string;
+  /** Case-insensitive fuzzy search target: plugin name + marketplace provenance. */
+  searchText: string;
+  /** Insertion token: the name when unique in the full enumeration, else the enumeration number. */
+  insertion: string;
+}
+
+/**
+ * Compose install candidates from the shared Marketplace Plugin enumeration, restricted to
+ * structurally installable entries. Unavailable Entries (unsupported source, unresolvable
+ * source, invalid plugin, identity collision) never become candidates.
  *
+ * Name uniqueness is judged against the *full* enumeration — the same domain `install <名稱>`
+ * resolves against, so a same-named sibling that is unavailable still forces the number
+ * insertion (the name would otherwise be rejected as ambiguous). The number is the plugin's
+ * number in that full enumeration, matching `list` and `install <編號>` exactly.
+ */
+function composeInstallCandidates(state: MinimalBridgeState, options: CompletionReadOptions): InstallCandidate[] {
+  const { plugins } = queryMarketplacePlugins(state, { agentDir: options.agentDir });
+  const nameCounts = new Map<string, number>();
+  for (const plugin of plugins) {
+    nameCounts.set(plugin.candidateName, (nameCounts.get(plugin.candidateName) ?? 0) + 1);
+  }
+
+  const candidates: InstallCandidate[] = [];
+  for (const plugin of plugins) {
+    if (!plugin.structurallyInstallable) continue;
+    const unique = (nameCounts.get(plugin.candidateName) ?? 0) === 1;
+    candidates.push({
+      marketplaceName: plugin.marketplaceName,
+      status: installStatusLabel(plugin.installationState),
+      searchText: `${plugin.candidateName} ${plugin.marketplaceName}`,
+      insertion: unique ? plugin.candidateName : String(plugin.number),
+    });
+  }
+  return candidates;
+}
+
+function toInstallItem(candidate: InstallCandidate): CompletionItem {
+  return {
+    value: `install ${candidate.insertion}`,
+    label: candidate.insertion,
+    description: `[${candidate.marketplaceName}] ${candidate.status}`,
+  };
+}
+
+/**
+ * Second-level `install` candidates for `/codex-marketplace install <query>`.
+ *
+ * - Empty query → every currently installable or reinstallable plugin in enumeration order.
+ * - A query → case-insensitive fuzzy match over the plugin name and Marketplace provenance;
+ *   `[]` when nothing matches (the syntax is still Bridge-owned, there are simply no
+ *   candidates).
+ *
+ * The Bridge State read is passive: empty, damaged, unreadable, or incompatible state or
+ * marketplace material contributes no candidates and is never written, reset, or repaired.
+ */
+function completeInstallArguments(query: string, options: CompletionReadOptions): CompletionItem[] {
+  const state = readMinimalBridgeStatePassive({ statePath: options.statePath, agentDir: options.agentDir });
+  const candidates = composeInstallCandidates(state, options);
+  if (query.length === 0) {
+    return candidates.map(toInstallItem);
+  }
+  const scored: { item: CompletionItem; score: number }[] = [];
+  for (const candidate of candidates) {
+    const score = fuzzyScore(query, candidate.searchText);
+    if (score !== null) {
+      scored.push({ item: toInstallItem(candidate), score });
+    }
+  }
+  scored.sort((a, b) => a.score - b.score || a.item.label.localeCompare(b.item.label));
+  return scored.map((entry) => entry.item);
+}
+
+/**
+ * Compose completion candidates for `/codex-marketplace <argumentPrefix>`.
+ *
+ * - `install ` / `install <query>` → state-aware second-level install candidates (#122).
  * - Empty prefix → all nine root candidates (Pi's exact-command interception surface).
- * - A single token → case-insensitive fuzzy-filtered subcommands; `[]` when nothing matches
- *   (the syntax is still Bridge-owned, there are simply no candidates).
- * - Whitespace-containing prefixes (second-level argument text) are not Bridge-owned in #121 → `null`,
- *   so callers fall through to Pi's own completion unchanged.
+ * - A single token → case-insensitive fuzzy-filtered subcommands; `[]` when nothing matches.
+ * - Any other whitespace-containing prefix (unowned second-level syntax) → `null`, so callers
+ *   fall through to Pi's own completion unchanged.
  *
- * The module never writes Bridge State; root candidates are derived without reading it at all.
+ * The module never writes Bridge State; root candidates are derived without reading it at all,
+ * and install candidates read it passively.
  */
 export function completeArguments(
   argumentPrefix: string,
-  _options: CompletionReadOptions = {},
+  options: CompletionReadOptions = {},
 ): CompletionItem[] | null {
+  const installMatch = INSTALL_SECOND_LEVEL_RE.exec(argumentPrefix);
+  if (installMatch) {
+    return completeInstallArguments(installMatch[1], options);
+  }
   if (/\s/.test(argumentPrefix)) return null;
 
   const query = argumentPrefix.trim();

--- a/tests/e2e/extension-autocomplete.test.ts
+++ b/tests/e2e/extension-autocomplete.test.ts
@@ -312,7 +312,7 @@ describe('state-aware install autocomplete thin Pi adapter (#122)', () => {
 
       expect(current.calls).toEqual([]);
       expect(result!.prefix).toBe('install ');
-      expect(result!.items.map((item) => item.label)).toEqual(['1', 'demo']);
+      expect(result!.items.map((item) => item.label)).toEqual(['shared (#1)', 'demo']);
       // Same-named `shared` (with an unavailable sibling) inserts its enumeration number.
       expect(result!.items[0].value).toBe('install 1');
       expect(result!.items[0].description).toContain('[alpha-market]');
@@ -341,6 +341,31 @@ describe('state-aware install autocomplete thin Pi adapter (#122)', () => {
       expect(result!.prefix).toBe('install dem');
       expect(result!.items.map((item) => item.label)).toEqual(['demo']);
       expect(result!.items[0].value).toBe('install demo');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('does not intercept a forced install request with a mid-line cursor and trailing text', async () => {
+    const fixture = makeInstallFixture();
+    try {
+      const captured = captureExtension();
+      const current = fakeCurrentProvider({
+        suggestions: { items: [{ value: 'x', label: 'x' }], prefix: 'x' },
+      });
+      const wrapper = createBridgeAutocompleteProvider(current, { statePath: fixture.statePath });
+
+      // Cursor in the middle of the line, text after it: applying a candidate would produce
+      // a malformed line, so the wrapper must not own this context (root branch has the same
+      // end-of-line guard) and delegates to the host provider.
+      const line = '/codex-marketplace install dem junk';
+      const result = await wrapper.getSuggestions([line], 0, '/codex-marketplace install dem'.length, {
+        signal: new AbortController().signal,
+        force: true,
+      });
+
+      expect(current.calls).toEqual(['getSuggestions']);
+      expect(result).toEqual({ items: [{ value: 'x', label: 'x' }], prefix: 'x' });
     } finally {
       fixture.cleanup();
     }

--- a/tests/e2e/extension-autocomplete.test.ts
+++ b/tests/e2e/extension-autocomplete.test.ts
@@ -1,11 +1,56 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import type { AutocompleteItem, AutocompleteProvider, AutocompleteSuggestions } from '@earendil-works/pi-tui';
 import { CombinedAutocompleteProvider } from '@earendil-works/pi-tui';
 
 import registerBridgeExtension from '../../extensions/pi/index.js';
+import { createBridgeAutocompleteProvider } from '../../extensions/pi/autocomplete.js';
 
 const ROOT_LABELS = ['add', 'list', 'install', 'update', 'disable', 'enable', 'remove', 'forget', 'help'];
+
+// ---- #122 fixture: two local marketplaces (one same-named sibling unavailable #91) ----
+// Full enumeration: 1=shared(alpha, local), 2=demo(alpha, local, installed+enabled) and
+// 3=shared(beta, github → unavailable). Candidates: `shared` inserts its enumeration number
+// (name is ambiguous in the full enumeration), `demo` keeps its unique name.
+function makeInstallFixture(): { root: string; statePath: string; cleanup(): void } {
+  const root = mkdtempSync(join(tmpdir(), 'bridge-e2e-install-'));
+  const statePath = join(root, 'state.json');
+  const mktA = join(root, 'mkt-a');
+  const mktB = join(root, 'mkt-b');
+  const writeCatalog = (mktRoot: string, name: string, entries: unknown[]): void => {
+    const dir = join(mktRoot, '.agents', 'plugins');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'marketplace.json'), JSON.stringify({ name, plugins: entries }));
+  };
+  writeCatalog(mktA, 'alpha-market', [
+    { name: 'shared', source: { source: 'local', path: './plugins/shared-a' } },
+    { name: 'demo', source: { source: 'local', path: './plugins/demo' } },
+  ]);
+  writeCatalog(mktB, 'beta-market', [
+    { name: 'shared', source: { source: 'github', repo: 'acme/shared-b' } },
+  ]);
+  writeFileSync(
+    statePath,
+    JSON.stringify(
+      {
+        schemaVersion: 1,
+        registrations: [
+          { id: 'reg-a', marketplaceName: 'alpha-market', format: 'codex', sourceKind: 'local', source: mktA },
+          { id: 'reg-b', marketplaceName: 'beta-market', format: 'codex', sourceKind: 'local', source: mktB },
+        ],
+        installations: [
+          { id: 'inst-demo', pluginId: 'demo', enabled: true, installationState: 'enabled', registrationId: 'reg-a', manifestName: 'demo', sourceKind: 'local', source: mktA, skills: [] },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+  return { root, statePath, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
 
 interface CapturedCommand {
   handler(args: string, ctx: unknown): Promise<void>;
@@ -95,7 +140,10 @@ describe('/codex-marketplace autocomplete thin Pi adapter (#121)', () => {
     const narrowed = command.getArgumentCompletions!('INSTL');
     expect(narrowed!.map((item) => item.label)).toEqual(['install']);
 
-    expect(command.getArgumentCompletions!('install my-plugin')).toBeNull();
+    // Non-install argument text is not Bridge-owned; second-token install text neither.
+    expect(command.getArgumentCompletions!('list ')).toBeNull();
+    expect(command.getArgumentCompletions!('add some/path')).toBeNull();
+    expect(command.getArgumentCompletions!('install foo bar')).toBeNull();
   });
 
   it('installs an autocomplete provider factory through session_start', () => {
@@ -198,19 +246,24 @@ describe('/codex-marketplace autocomplete thin Pi adapter (#121)', () => {
     expect(current.calls).toEqual(['getSuggestions']);
   });
 
-  it('does not chain-reopen the subcommand list after an applied argument (next Tab is delegated, force path)', async () => {
+  it('does not chain-reopen the root subcommand list after an applied argument — the next forced Tab owns the install context (#122)', async () => {
     const captured = captureExtension();
     const current = fakeCurrentProvider();
-    const wrapper = installFactory(captured)(current) as AutocompleteProvider;
 
     // After applying "install " the editor holds "/codex-marketplace install "; a subsequent
-    // Tab is a forced request and must not re-intercept the line as the exact command.
-    await wrapper.getSuggestions(['/codex-marketplace install '], 0, 25, {
+    // Tab is a forced request. It must not re-intercept the line as the exact root command
+    // (that would chain-reopen the nine subcommands); it owns the second-level install
+    // context instead, reading the (empty, hermetic) state passively.
+    const wrapper = createBridgeAutocompleteProvider(current, { statePath: join(tmpdir(), 'bridge-e2e-no-such-state.json') });
+
+    const result = await wrapper.getSuggestions(['/codex-marketplace install '], 0, '/codex-marketplace install '.length, {
       signal: new AbortController().signal,
       force: true,
     });
 
-    expect(current.calls).toEqual(['getSuggestions']);
+    expect(current.calls).toEqual([]);
+    expect(result!.prefix).toBe('install ');
+    expect(result!.items).toEqual([]);
   });
 
   it('registers nothing terminal-only and keeps command execution when the host ui no-ops (RPC/JSON/print modes)', () => {
@@ -239,5 +292,110 @@ describe('/codex-marketplace autocomplete thin Pi adapter (#121)', () => {
     expect(typeof command!.getArgumentCompletions).toBe('function');
     // Command execution behavior is unaffected by the no-op ui.
     expect(typeof command!.handler).toBe('function');
+  });
+});
+
+describe('state-aware install autocomplete thin Pi adapter (#122)', () => {
+  it('intercepts a forced Tab inside `install ` with state-aware candidates and does not consult the current provider', async () => {
+    const fixture = makeInstallFixture();
+    try {
+      const captured = captureExtension();
+      const current = fakeCurrentProvider();
+      // Explicit readOptions keep the test hermetic (defaults would read the real agent dir).
+      const wrapper = createBridgeAutocompleteProvider(current, { statePath: fixture.statePath });
+
+      const line = '/codex-marketplace install ';
+      const result = await wrapper.getSuggestions([line], 0, line.length, {
+        signal: new AbortController().signal,
+        force: true,
+      });
+
+      expect(current.calls).toEqual([]);
+      expect(result!.prefix).toBe('install ');
+      expect(result!.items.map((item) => item.label)).toEqual(['1', 'demo']);
+      // Same-named `shared` (with an unavailable sibling) inserts its enumeration number.
+      expect(result!.items[0].value).toBe('install 1');
+      expect(result!.items[0].description).toContain('[alpha-market]');
+      // Unique name keeps the name form; reinstall of the enabled plugin is offered.
+      expect(result!.items[1].value).toBe('install demo');
+      expect(result!.items[1].description).toContain('已裝啟用');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('filters forced install candidates by the typed query and returns the matching argument prefix', async () => {
+    const fixture = makeInstallFixture();
+    try {
+      const captured = captureExtension();
+      const current = fakeCurrentProvider();
+      const wrapper = createBridgeAutocompleteProvider(current, { statePath: fixture.statePath });
+
+      const line = '/codex-marketplace install dem';
+      const result = await wrapper.getSuggestions([line], 0, line.length, {
+        signal: new AbortController().signal,
+        force: true,
+      });
+
+      expect(current.calls).toEqual([]);
+      expect(result!.prefix).toBe('install dem');
+      expect(result!.items.map((item) => item.label)).toEqual(['demo']);
+      expect(result!.items[0].value).toBe('install demo');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('delegates natural (non-forced) requests inside the install argument context to the host provider', async () => {
+    const captured = captureExtension();
+    const current = fakeCurrentProvider({
+      suggestions: { items: [{ value: 'x', label: 'x' }], prefix: 'x' },
+    });
+    const wrapper = installFactory(captured)(current) as AutocompleteProvider;
+
+    const line = '/codex-marketplace install dem';
+    const result = await wrapper.getSuggestions([line], 0, line.length, {
+      signal: new AbortController().signal,
+      force: false,
+    });
+
+    // force=false is the host's natural argument-completion path (getArgumentCompletions
+    // owns it); the wrapper must not double-intercept.
+    expect(current.calls).toEqual(['getSuggestions']);
+    expect(result).toEqual({ items: [{ value: 'x', label: 'x' }], prefix: 'x' });
+  });
+
+  it('applies an install candidate through Pi 0.84.2 real combined provider, cursor at the inserted argument end', async () => {
+    const fixture = makeInstallFixture();
+    try {
+      const captured = captureExtension();
+      const command = captured.commands.get('codex-marketplace')!;
+      const wrapper = createBridgeAutocompleteProvider(
+        new CombinedAutocompleteProvider(
+          [{ name: 'codex-marketplace', getArgumentCompletions: command.getArgumentCompletions }],
+          '/tmp',
+          null,
+        ),
+        { statePath: fixture.statePath },
+      );
+
+      const line = '/codex-marketplace install ';
+      const suggestions = await wrapper.getSuggestions([line], 0, line.length, {
+        signal: new AbortController().signal,
+        force: true,
+      });
+      const demo = suggestions!.items.find((item) => item.value === 'install demo')!;
+      const applied = wrapper.applyCompletion([line], 0, line.length, demo, suggestions!.prefix);
+      expect(applied.lines[0]).toBe('/codex-marketplace install demo');
+      expect(applied.cursorCol).toBe('/codex-marketplace install demo'.length);
+
+      // Number insertion for the same-named candidate resolves to a working command too.
+      const shared = suggestions!.items.find((item) => item.value === 'install 1')!;
+      const appliedShared = wrapper.applyCompletion([line], 0, line.length, shared, suggestions!.prefix);
+      expect(appliedShared.lines[0]).toBe('/codex-marketplace install 1');
+      expect(appliedShared.cursorCol).toBe('/codex-marketplace install 1'.length);
+    } finally {
+      fixture.cleanup();
+    }
   });
 });

--- a/tests/unit/bridge/completion.test.ts
+++ b/tests/unit/bridge/completion.test.ts
@@ -299,6 +299,39 @@ describe('state-aware install completion (#122)', () => {
     }
   });
 
+  it('never inserts a name the command surface could not resolve (canonical integer or whitespace names use the enumeration number)', () => {
+    const fixture = makeFixture();
+    try {
+      const mktRoot = join(fixture.root, 'mkt-a');
+      mkdirSync(mktRoot, { recursive: true });
+      const spec: LocalMarketplaceSpec = { name: 'alpha-market', id: 'reg-a', root: mktRoot };
+      // Names are unique and structurally installable, but the command surface would
+      // misparse them when applied as INSERT <name>: "42" is read as enumeration number 42,
+      // and "my plugin" is split into two tokens.
+      makeLocalMarketplace(fixture, spec, [
+        { name: 'fine', source: { source: 'local', path: './plugins/fine' } },
+        { name: '42', source: { source: 'local', path: './plugins/forty-two' } },
+        { name: 'my plugin', source: { source: 'local', path: './plugins/my-plugin' } },
+      ]);
+      writeState(fixture, registrationsState(fixture, [registration(spec)]));
+
+      const result = completeArguments('install ', { statePath: fixture.statePath })!;
+
+      // Enumeration order: 1=fine(name-insertable), 2=42, 3=my plugin (both number-form).
+      expect(result.map((item) => item.label)).toEqual(['fine', '2', '3']);
+      expect(result[0].value).toBe('install fine');
+      const numericName = result.find((item) => item.label === '2')!;
+      expect(numericName.value).toBe('install 2');
+      expect(numericName.description).toContain('[alpha-market]');
+      const whitespaceName = result.find((item) => item.label === '3')!;
+      expect(whitespaceName.value).toBe('install 3');
+      expect(result.some((item) => item.value === 'install 42')).toBe(false);
+      expect(result.some((item) => item.value === 'install my plugin')).toBe(false);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
   it('falls back to the number when a same-named sibling is unavailable (name resolution would be ambiguous)', () => {
     const fixture = makeFixture();
     try {

--- a/tests/unit/bridge/completion.test.ts
+++ b/tests/unit/bridge/completion.test.ts
@@ -276,11 +276,12 @@ describe('state-aware install completion (#122)', () => {
 
       // Same-named `shared` plugins insert their current enumeration numbers (1 and 4 — the
       // full enumeration counts the unavailable `edge` entry at 3 in between, exactly like
-      // `list` and `install <編號>`), each showing its Marketplace provenance.
+      // `list` and `install <編號>`), each showing its Marketplace provenance and a label that
+      // identifies which plugin the number selects.
       const shared = result.filter((item) => item.label === 'shared');
       expect(shared).toHaveLength(0); // numbers are inserted instead of the ambiguous name
       const sharedByValue = result.filter((item) => item.value === 'install 1' || item.value === 'install 4');
-      expect(sharedByValue.map((item) => item.label)).toEqual(['1', '4']);
+      expect(sharedByValue.map((item) => item.label)).toEqual(['shared (#1)', 'shared (#4)']);
       for (const item of sharedByValue) {
         expect(item.description).toMatch(/\[(alpha-market|beta-market)\]/);
       }
@@ -318,12 +319,12 @@ describe('state-aware install completion (#122)', () => {
       const result = completeArguments('install ', { statePath: fixture.statePath })!;
 
       // Enumeration order: 1=fine(name-insertable), 2=42, 3=my plugin (both number-form).
-      expect(result.map((item) => item.label)).toEqual(['fine', '2', '3']);
+      expect(result.map((item) => item.label)).toEqual(['fine', '42 (#2)', 'my plugin (#3)']);
       expect(result[0].value).toBe('install fine');
-      const numericName = result.find((item) => item.label === '2')!;
+      const numericName = result.find((item) => item.label === '42 (#2)')!;
       expect(numericName.value).toBe('install 2');
       expect(numericName.description).toContain('[alpha-market]');
-      const whitespaceName = result.find((item) => item.label === '3')!;
+      const whitespaceName = result.find((item) => item.label === 'my plugin (#3)')!;
       expect(whitespaceName.value).toBe('install 3');
       expect(result.some((item) => item.value === 'install 42')).toBe(false);
       expect(result.some((item) => item.value === 'install my plugin')).toBe(false);
@@ -357,7 +358,7 @@ describe('state-aware install completion (#122)', () => {
       // rejected as ambiguous, so the installable candidate must insert its enumeration number.
       expect(result.find((item) => item.label === 'shared')).toBeUndefined();
       const shared = result.find((item) => item.value === 'install 1');
-      expect(shared!.label).toBe('1');
+      expect(shared!.label).toBe('shared (#1)');
       expect(shared!.description).toContain('[alpha-market]');
       expect(result.find((item) => item.value === 'install shared')).toBeUndefined();
       expect(result.find((item) => item.label === 'other')!.value).toBe('install other');

--- a/tests/unit/bridge/completion.test.ts
+++ b/tests/unit/bridge/completion.test.ts
@@ -1,10 +1,12 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import { completeArguments } from '../../../src/bridge/completion.js';
-import { HELP_TEXT } from '../../../src/bridge/command.js';
+import { HELP_TEXT, runCommand } from '../../../src/bridge/command.js';
+import type { MinimalBridgeState } from '../../../src/bridge/state.js';
+import { getCacheDir, getCacheEntriesDir } from '../../../src/cache/paths.js';
 
 const ROOT_LABELS = ['add', 'list', 'install', 'update', 'disable', 'enable', 'remove', 'forget', 'help'];
 
@@ -16,6 +18,71 @@ function helpDescriptions(): Map<string, string> {
     if (match) map.set(match[1], match[2].trim());
   }
   return map;
+}
+
+// ---- #122 fixtures: a local marketplace root + a Bridge State pointing at it ----
+
+function writeCodexCatalog(root: string, name: string, entries: unknown[]): void {
+  const path = join(root, '.agents', 'plugins', 'marketplace.json');
+  mkdirSync(join(root, '.agents', 'plugins'), { recursive: true });
+  writeFileSync(path, JSON.stringify({ name, plugins: entries }));
+}
+
+interface StateFixture {
+  /** Temp dir holding the marketplace material and the state document. */
+  root: string;
+  /** Directory that must be removed by the caller in finally. */
+  cleanup(): void;
+  statePath: string;
+  agentDir: string;
+}
+
+function makeFixture(): StateFixture {
+  const root = mkdtempSync(join(tmpdir(), 'bridge-completion-install-'));
+  return {
+    root,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+    statePath: join(root, 'state.json'),
+    agentDir: join(root, 'agent'),
+  };
+}
+
+interface LocalMarketplaceSpec {
+  name: string;
+  /** registration id used by installations that target this marketplace. */
+  id: string;
+  /** local root containing the catalog. */
+  root: string;
+}
+
+/**
+ * Write a canonical local marketplace catalog (an entry `local` with `./path`, `github`
+ * entries are structurally unavailable #91) and return a state referencing it.
+ */
+function makeLocalMarketplace(fixture: StateFixture, spec: LocalMarketplaceSpec, entries: unknown[]): void {
+  writeCodexCatalog(spec.root, spec.name, entries);
+}
+
+function registration(spec: LocalMarketplaceSpec): MinimalBridgeState['registrations'][number] {
+  return {
+    id: spec.id,
+    marketplaceName: spec.name,
+    format: 'codex',
+    sourceKind: 'local',
+    source: spec.root,
+  };
+}
+
+function writeState(fixture: StateFixture, state: MinimalBridgeState): void {
+  writeFileSync(fixture.statePath, JSON.stringify(state, null, 2), 'utf-8');
+}
+
+function emptyState(fixture: StateFixture): MinimalBridgeState {
+  return { schemaVersion: 1, registrations: [], installations: [] };
+}
+
+function registrationsState(fixture: StateFixture, registrations: MinimalBridgeState['registrations']): MinimalBridgeState {
+  return { schemaVersion: 1, registrations, installations: [] };
 }
 
 describe('Bridge completion seam (#121)', () => {
@@ -64,10 +131,20 @@ describe('Bridge completion seam (#121)', () => {
     expect(completeArguments('zzz')).toEqual([]);
   });
 
+  it('keeps a bare `install` at the root level so the trailing-space candidate can apply first', () => {
+    // `install` without a trailing space is first-level syntax (#122): applying it inserts
+    // `install ` and the next Tab then composes the second-level candidates.
+    const result = completeArguments('install');
+    expect(result!.map((item) => item.label)).toEqual(['install']);
+    expect(result![0].value).toBe('install ');
+  });
+
   it('returns null when the argument prefix is not Bridge-owned syntax', () => {
-    // Second-level argument text is out of scope for #121 — Bridge must not own it.
-    expect(completeArguments('install my-plugin')).toBeNull();
+    // Non-install second-level argument text is not Bridge-owned (#121, #122) — the module
+    // must not own it, and callers fall through to Pi's own completion.
     expect(completeArguments('list ')).toBeNull();
+    expect(completeArguments('add some/path')).toBeNull();
+    expect(completeArguments('disable my-plugin')).toBeNull();
   });
 
   it('mirrors the command surface description vocabulary without drift', () => {
@@ -79,20 +156,296 @@ describe('Bridge completion seam (#121)', () => {
     }
   });
 
-  it('is passive: composing candidates never writes or resets a damaged Bridge State document', () => {
-    const tmpDir = mkdtempSync(join(tmpdir(), 'bridge-completion-passive-'));
+  it('is passive: composing root candidates never writes or resets a damaged Bridge State document', () => {
+    const fixture = makeFixture();
     try {
-      const statePath = join(tmpDir, 'state.json');
       const damaged = 'INVALID JSON CONTENT';
-      writeFileSync(statePath, damaged, 'utf-8');
+      writeFileSync(fixture.statePath, damaged, 'utf-8');
 
-      const result = completeArguments('', { statePath });
+      const result = completeArguments('', { statePath: fixture.statePath });
 
       expect(result).not.toBeNull();
       // The damaged document must survive untouched — autocomplete is read-only (#119 22–23).
-      expect(readFileSync(statePath, 'utf-8')).toBe(damaged);
+      expect(readFileSync(fixture.statePath, 'utf-8')).toBe(damaged);
     } finally {
-      rmSync(tmpDir, { recursive: true, force: true });
+      fixture.cleanup();
     }
+  });
+});
+
+describe('state-aware install completion (#122)', () => {
+  it('lists every installable plugin (install and reinstall) for an empty `install ` prefix', () => {
+    const fixture = makeFixture();
+    try {
+      const mktRoot = join(fixture.root, 'mkt-a');
+      mkdirSync(mktRoot, { recursive: true });
+      const spec: LocalMarketplaceSpec = { name: 'alpha-market', id: 'reg-a', root: mktRoot };
+      makeLocalMarketplace(fixture, spec, [
+        { name: 'ready', source: { source: 'local', path: './plugins/ready' } },
+        { name: 'reinstall-me', source: { source: 'local', path: './plugins/reinstall-me' } },
+      ]);
+      // An unavailable (github) entry occupies a number but is never a candidate (#91).
+      const state: MinimalBridgeState = registrationsState(fixture, [registration(spec)]);
+      state.installations.push(
+        { id: 'inst-1', pluginId: 'reinstall-me', enabled: true, installationState: 'enabled', registrationId: 'reg-a', manifestName: 'reinstall-me', sourceKind: 'local', source: mktRoot, skills: [] },
+      );
+      writeState(fixture, state);
+
+      const result = completeArguments('install ', { statePath: fixture.statePath });
+
+      expect(result!.map((item) => item.label)).toEqual(['ready', 'reinstall-me']);
+      for (const item of result!) {
+        expect(item.value).toBe(`install ${item.label}`);
+        expect(item.description).toContain('[alpha-market]');
+      }
+      expect(result!.some((item) => item.description!.includes('可安裝'))).toBe(true);
+      expect(result!.some((item) => item.description!.includes('已裝啟用'))).toBe(true);
+      expect(result!.every((item) => item.label !== 'unavailable-entry')).toBe(true);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('includes installed-disabled plugins so reinstalling them is selectable', () => {
+    const fixture = makeFixture();
+    try {
+      const mktRoot = join(fixture.root, 'mkt-a');
+      mkdirSync(mktRoot, { recursive: true });
+      const spec: LocalMarketplaceSpec = { name: 'alpha-market', id: 'reg-a', root: mktRoot };
+      makeLocalMarketplace(fixture, spec, [
+        { name: 'paused', source: { source: 'local', path: './plugins/paused' } },
+      ]);
+      const state = registrationsState(fixture, [registration(spec)]);
+      state.installations.push(
+        { id: 'inst-1', pluginId: 'paused', enabled: false, installationState: 'disabled', registrationId: 'reg-a', manifestName: 'paused', sourceKind: 'local', source: mktRoot, skills: [] },
+      );
+      writeState(fixture, state);
+
+      const result = completeArguments('install ', { statePath: fixture.statePath });
+
+      expect(result!.map((item) => item.label)).toEqual(['paused']);
+      expect(result![0].value).toBe('install paused');
+      expect(result![0].description).toContain('已裝停用');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('never offers Unavailable Entries (git / missing-local / invalid) as candidates', () => {
+    const fixture = makeFixture();
+    try {
+      const mktRoot = join(fixture.root, 'mkt-a');
+      mkdirSync(mktRoot, { recursive: true });
+      const spec: LocalMarketplaceSpec = { name: 'alpha-market', id: 'reg-a', root: mktRoot };
+      makeLocalMarketplace(fixture, spec, [
+        { name: 'git-plugin', source: { source: 'github', repo: 'acme/git-plugin' } },
+        { name: 'no-path', source: { source: 'local' } },
+        { name: 'good', source: { source: 'local', path: './plugins/good' } },
+      ]);
+      writeState(fixture, registrationsState(fixture, [registration(spec)]));
+
+      const result = completeArguments('install ', { statePath: fixture.statePath });
+
+      expect(result!.map((item) => item.label)).toEqual(['good']);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('inserts the unique name and uses per-marketplace numbers for same-named plugins, matching the full list enumeration', async () => {
+    const fixture = makeFixture();
+    try {
+      const rootA = join(fixture.root, 'mkt-a');
+      const rootB = join(fixture.root, 'mkt-b');
+      mkdirSync(rootA, { recursive: true });
+      mkdirSync(rootB, { recursive: true });
+      const specA: LocalMarketplaceSpec = { name: 'alpha-market', id: 'reg-a', root: rootA };
+      const specB: LocalMarketplaceSpec = { name: 'beta-market', id: 'reg-b', root: rootB };
+      // Full enumeration order: 1=shared(A), 2=unique(A), 3=edge(B, unavailable), 4=shared(B).
+      makeLocalMarketplace(fixture, specA, [
+        { name: 'shared', source: { source: 'local', path: './plugins/shared-a' } },
+        { name: 'unique', source: { source: 'local', path: './plugins/unique-a' } },
+      ]);
+      makeLocalMarketplace(fixture, specB, [
+        { name: 'edge', source: { source: 'github', repo: 'acme/edge' } },
+        { name: 'shared', source: { source: 'local', path: './plugins/shared-b' } },
+      ]);
+      writeState(fixture, registrationsState(fixture, [registration(specA), registration(specB)]));
+
+      const result = completeArguments('install ', { statePath: fixture.statePath })!;
+
+      // Same-named `shared` plugins insert their current enumeration numbers (1 and 4 — the
+      // full enumeration counts the unavailable `edge` entry at 3 in between, exactly like
+      // `list` and `install <編號>`), each showing its Marketplace provenance.
+      const shared = result.filter((item) => item.label === 'shared');
+      expect(shared).toHaveLength(0); // numbers are inserted instead of the ambiguous name
+      const sharedByValue = result.filter((item) => item.value === 'install 1' || item.value === 'install 4');
+      expect(sharedByValue.map((item) => item.label)).toEqual(['1', '4']);
+      for (const item of sharedByValue) {
+        expect(item.description).toMatch(/\[(alpha-market|beta-market)\]/);
+      }
+      // The unique name keeps the name form; the unavailable edge entry is never a candidate.
+      const unique = result.find((item) => item.label === 'unique');
+      expect(unique!.value).toBe('install unique');
+      expect(result.some((item) => item.label === 'edge')).toBe(false);
+
+      // Cross-check: the insertion numbers are identical to the `list` display numbering.
+      const list = await runCommand(['list'], { statePath: fixture.statePath });
+      expect(list.output).toMatch(/1\s+shared\s+\[alpha-market\]/);
+      expect(list.output).toMatch(/3\s+edge\s+\[beta-market\].*unavailable/);
+      expect(list.output).toMatch(/4\s+shared\s+\[beta-market\]/);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('falls back to the number when a same-named sibling is unavailable (name resolution would be ambiguous)', () => {
+    const fixture = makeFixture();
+    try {
+      const rootA = join(fixture.root, 'mkt-a');
+      const rootB = join(fixture.root, 'mkt-b');
+      mkdirSync(rootA, { recursive: true });
+      mkdirSync(rootB, { recursive: true });
+      const specA: LocalMarketplaceSpec = { name: 'alpha-market', id: 'reg-a', root: rootA };
+      const specB: LocalMarketplaceSpec = { name: 'beta-market', id: 'reg-b', root: rootB };
+      // 1=shared(A installable), 2=shared(B git unavailable), 3=other installable.
+      makeLocalMarketplace(fixture, specA, [
+        { name: 'shared', source: { source: 'local', path: './plugins/shared-a' } },
+      ]);
+      makeLocalMarketplace(fixture, specB, [
+        { name: 'shared', source: { source: 'github', repo: 'acme/shared-b' } },
+        { name: 'other', source: { source: 'local', path: './plugins/other' } },
+      ]);
+      writeState(fixture, registrationsState(fixture, [registration(specA), registration(specB)]));
+
+      const result = completeArguments('install ', { statePath: fixture.statePath })!;
+
+      // `install shared` would match both entries (the unavailable one included) and be
+      // rejected as ambiguous, so the installable candidate must insert its enumeration number.
+      expect(result.find((item) => item.label === 'shared')).toBeUndefined();
+      const shared = result.find((item) => item.value === 'install 1');
+      expect(shared!.label).toBe('1');
+      expect(shared!.description).toContain('[alpha-market]');
+      expect(result.find((item) => item.value === 'install shared')).toBeUndefined();
+      expect(result.find((item) => item.label === 'other')!.value).toBe('install other');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('filters by case-insensitive fuzzy match over plugin name and marketplace provenance', () => {
+    const fixture = makeFixture();
+    try {
+      const rootA = join(fixture.root, 'mkt-a');
+      const rootB = join(fixture.root, 'mkt-b');
+      mkdirSync(rootA, { recursive: true });
+      mkdirSync(rootB, { recursive: true });
+      const specA: LocalMarketplaceSpec = { name: 'alpha-market', id: 'reg-a', root: rootA };
+      const specB: LocalMarketplaceSpec = { name: 'beta-market', id: 'reg-b', root: rootB };
+      makeLocalMarketplace(fixture, specA, [
+        { name: 'my-plugin', source: { source: 'local', path: './plugins/my-plugin' } },
+      ]);
+      makeLocalMarketplace(fixture, specB, [
+        { name: 'alpha-tool', source: { source: 'local', path: './plugins/alpha-tool' } },
+      ]);
+      writeState(fixture, registrationsState(fixture, [registration(specA), registration(specB)]));
+
+      // Mixed-case partial over the plugin name.
+      const byName = completeArguments('install MyPln', { statePath: fixture.statePath })!;
+      expect(byName.map((item) => item.label)).toEqual(['my-plugin']);
+
+      // Fuzzy partial over the marketplace provenance.
+      const byMarket = completeArguments('install bta', { statePath: fixture.statePath })!;
+      expect(byMarket.map((item) => item.label)).toEqual(['alpha-tool']);
+
+      // Non-contiguous query over the combined name＋provenance search text.
+      const nonContig = completeArguments('install mlp', { statePath: fixture.statePath })!;
+      expect(nonContig.map((item) => item.label)).toEqual(['my-plugin']);
+
+      expect(completeArguments('install zzz', { statePath: fixture.statePath })).toEqual([]);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('returns an empty set when there are no registrations, entries, or candidates', () => {
+    const fixture = makeFixture();
+    try {
+      writeState(fixture, emptyState(fixture));
+      expect(completeArguments('install ', { statePath: fixture.statePath })).toEqual([]);
+      expect(completeArguments('install some-name', { statePath: fixture.statePath })).toEqual([]);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('contributes no candidates for a registration whose catalog errors, but keeps others enumerable', () => {
+    const fixture = makeFixture();
+    try {
+      const brokenRoot = join(fixture.root, 'mkt-broken');
+      const okRoot = join(fixture.root, 'mkt-ok');
+      mkdirSync(brokenRoot, { recursive: true });
+      mkdirSync(okRoot, { recursive: true });
+      // Broken catalog: file exists but is not valid JSON.
+      mkdirSync(join(brokenRoot, '.agents', 'plugins'), { recursive: true });
+      writeFileSync(join(brokenRoot, '.agents', 'plugins', 'marketplace.json'), 'not json {', 'utf-8');
+      const specBroken: LocalMarketplaceSpec = { name: 'broken-market', id: 'reg-broken', root: brokenRoot };
+      const specOk: LocalMarketplaceSpec = { name: 'ok-market', id: 'reg-ok', root: okRoot };
+      makeLocalMarketplace(fixture, specOk, [
+        { name: 'fine', source: { source: 'local', path: './plugins/fine' } },
+      ]);
+      writeState(fixture, registrationsState(fixture, [registration(specBroken), registration(specOk)]));
+
+      const result = completeArguments('install ', { statePath: fixture.statePath })!;
+
+      expect(result.map((item) => item.label)).toEqual(['fine']);
+      // The broken registration is skipped entirely (no numbered gaps), matching `list`.
+      expect(result[0].value).toBe('install fine');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('contributes no candidates when a git registration lacks its cache material', () => {
+    const fixture = makeFixture();
+    try {
+      const SNAPSHOT = 'a'.repeat(64);
+      const gitRoot = join(getCacheEntriesDir(getCacheDir(fixture.agentDir)), SNAPSHOT);
+      mkdirSync(gitRoot, { recursive: true });
+      // Catalog exists under the cache entry but the registration has no usable snapshot
+      // pointer → resolveMarketplaceRoot cannot resolve it.
+      makeLocalMarketplace(fixture, { name: 'git-market', id: 'reg-git', root: gitRoot }, [
+        { name: 'cached-plugin', source: { source: 'local', path: './plugins/cached-plugin' } },
+      ]);
+      const state = registrationsState(fixture, [
+        { id: 'reg-git', marketplaceName: 'git-market', format: 'claude', sourceKind: 'git', source: 'https://github.com/acme/skills', snapshot: undefined },
+      ]);
+      writeState(fixture, state);
+
+      expect(completeArguments('install ', { statePath: fixture.statePath, agentDir: fixture.agentDir })).toEqual([]);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('is passive for damaged Bridge State: no candidates and the file content is untouched', () => {
+    const fixture = makeFixture();
+    try {
+      const damaged = 'INVALID JSON CONTENT';
+      writeFileSync(fixture.statePath, damaged, 'utf-8');
+
+      const result = completeArguments('install ', { statePath: fixture.statePath });
+
+      expect(result).toEqual([]);
+      // Malformed Bridge State must be byte-identical before and after completion (#122).
+      expect(readFileSync(fixture.statePath, 'utf-8')).toBe(damaged);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('returns null for a second token after the plugin query (not Bridge-owned)', () => {
+    expect(completeArguments('install foo bar')).toBeNull();
+    expect(completeArguments('install   baz qux')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

承 #119（分層自動補完）與 #121（九個根層候選）：`install` 選取後再按一次 Tab 或繼續輸入，即出現狀態感知的第二層候選——列出目前可安裝或重裝的 Plugin。

## Changes

- **src/bridge/completion.ts**：`completeArguments` 擁有 `install `／`install <query>` 第二層語法：
  - 候選由共享 Marketplace Plugin 列舉（`queryMarketplacePlugins`，與 `list`／`install <編號>` 同一條列舉規則）被動產生，僅限結構上可安裝的 entry（可安裝／已裝啟用／已裝停用，install 與 reinstall 皆可選）。
  - **Unavailable Entry 一律不成為候選**（unsupported source／unresolvable source／invalid plugin／identity collision）。
  - 名稱在目前**完整列舉**中唯一 → 以名稱插入（`/codex-marketplace install <名稱>`）；跨 Marketplace 同名 → 以目前列舉編號插入，description 顯示 Marketplace provenance。相同名稱帳面歧義與 `install <名稱>` 的解析域一致，編號與 `list` 顯示及 `install <編號>` 完全一致。
  - Plugin 名稱與 Marketplace provenance 不分大小寫、非連續模糊搜尋。
  - 全程 `readMinimalBridgeStatePassive`：Bridge State 或 marketplace material 空白／損壞／不可讀／不相容時不提供 state-dependent 候選，也不寫入、重置或修復任何文件。
- **extensions/pi/autocomplete.ts**：force（Tab）請求位於 `/codex-marketplace install ` 時由 wrapper 攔截——host 的 combined provider 在 `force=true` 會跳過 argument completion 改走 file completion；自然輸入（`force=false`）仍經 `getArgumentCompletions` 走到同一候選邏輯。其餘語法維持全部委派。
- **extensions/pi/index.ts**：註解與 `getArgumentCompletions` 接線敘述同步（行為不變）。

## Tests

- unit（completion.test.ts，+11）與 e2e（extension-autocomplete.test.ts，+4）共 +15 個 observable tests：
  - 空 prefix 列出全部可安裝／重裝候選；Unavailable 排除；唯一名稱 vs 同名編號插入。
  - 同名跨 marketplace 的插入編號與 `list` 顯示編號 **交叉驗證一致**（含 unavailable entry 佔據中間編號）。
  - 混合大小寫與 fuzzy partial 篩選；空集合；catalog 錯誤、缺失 cache。
  - malformed Bridge State：completion 前後檔案內容 **byte 完全相同**。
  - 真實 `CombinedAutocompleteProvider` 套用候選後游標位於插入值尾端（名稱與編號兩條路徑）。

`npm run typecheck` ✓；`npm test` 295 passed（baseline 279 + 15）。