### PR TITLE
feat: 提供 Installation lifecycle autocomplete (#123)

### DIFF
--- a/extensions/pi/autocomplete.ts
+++ b/extensions/pi/autocomplete.ts
@@ -1,15 +1,16 @@
 /**
- * Narrow Bridge autocomplete provider — thin Pi adapter (TUI session only) (#119, #121, #122).
+ * Narrow Bridge autocomplete provider — thin Pi adapter (TUI session only) (#119, #121–#123).
  *
  * Pi 0.84.2's built-in combined provider completes the slash-command name and inserts a
  * trailing space without exposing empty-prefix argument completion (root subcommands) when
  * the editor holds exactly `/codex-marketplace`. This wrapper intercepts that exact editor
- * content and presents the nine root candidates. It also owns the second-level `install`
- * argument context on forced (Tab) requests, which Pi 0.84.2 routes to file completion
- * instead of slash-command argument completion (its argument path only runs when `force` is
- * false) — the wrapper returns the state-aware install candidates there. Everything else —
- * other slash commands, text, file/path completion, suggestion generation and completion
- * application — delegates unchanged to the host's current provider.
+ * content and presents the nine root candidates. It also owns the second-level argument
+ * contexts (`install` #122 and the Installation lifecycle `enable` / `disable` / `remove`
+ * #123) on forced (Tab) requests, which Pi 0.84.2 routes to file completion instead of
+ * slash-command argument completion (its argument path only runs when `force` is false) —
+ * the wrapper returns the state-aware candidates there. Everything else — other slash
+ * commands, text, file/path completion, suggestion generation and completion application —
+ * delegates unchanged to the host's current provider.
  *
  * The wrapper is installed from a `session_start` handler via `ctx.ui.addAutocompleteProvider`,
  * which interactive (TUI) mode wires into the editor and RPC/JSON/print modes no-op, so a
@@ -23,8 +24,11 @@ import { completeArguments, type CompletionReadOptions } from '../../src/bridge/
 /** The exact editor content this provider owns. */
 export const EXACT_COMMAND = '/codex-marketplace';
 
-/** The second-level install argument context owned on forced requests: `/codex-marketplace install `. */
-export const INSTALL_ARGUMENT_PREFIX = `${EXACT_COMMAND} install `;
+/**
+ * The Bridge-owned second-level argument contexts on forced requests: `install` plus the
+ * installation lifecycle actions — each followed by the trailing space root candidates insert.
+ */
+export const SECOND_LEVEL_ARGUMENT_RE = /^\/codex-marketplace (?:install|enable|disable|remove) /;
 
 /**
  * Wrap the host's current autocomplete provider. Suggestion generation intercepts only the
@@ -53,19 +57,15 @@ export function createBridgeAutocompleteProvider(
           };
         }
       }
-      // Second-level install interception (#122): forced (Tab) requests inside `install `
-      // are Bridge-owned — the host's combined provider would route them to file completion.
+      // Second-level argument interception (#122, #123): forced (Tab) requests inside a
+      // Bridge-owned argument context (`install ` / `enable ` / `disable ` / `remove `) are
+      // Bridge-owned — the host's combined provider would route them to file completion.
       // Natural typing (force=false) is delegated and reaches the same candidates through the
       // command's getArgumentCompletions. Like the root branch, the cursor must be at the end
       // of the line: a mid-line cursor with trailing text would otherwise produce a malformed
       // line after applying a candidate. The prefix returned is the text after the command
-      // name (`install ` or `install <query>`), matching the host's argument-text semantics.
-      if (
-        options.force
-        && cursorCol === line.length
-        && line.startsWith(INSTALL_ARGUMENT_PREFIX)
-        && cursorCol >= INSTALL_ARGUMENT_PREFIX.length
-      ) {
+      // name (`install <query>` etc.), matching the host's argument-text semantics.
+      if (options.force && cursorCol === line.length && SECOND_LEVEL_ARGUMENT_RE.test(line)) {
         const argumentText = line.slice(EXACT_COMMAND.length + 1, cursorCol);
         const items = completeArguments(argumentText, readOptions);
         if (items) {

--- a/extensions/pi/index.ts
+++ b/extensions/pi/index.ts
@@ -18,10 +18,11 @@ import { completeArguments } from '../../src/bridge/completion.js';
 import { createBridgeAutocompleteProvider } from './autocomplete.js';
 
 export default function (pi: ExtensionAPI) {
-  // Root-level autocomplete (#121) + second-level install autocomplete (#122): stack a narrow
-  // provider for the exact `/codex-marketplace` editor text and the forced `install ` argument
-  // context (Pi otherwise completes just the command name plus a space, and routes forced
-  // argument Tabs to file completion). session_start supplies the full TUI ui context;
+  // Root-level autocomplete (#121) + second-level autocomplete (#122–#123): stack a narrow
+  // provider for the exact `/codex-marketplace` editor text and the forced `install ` and
+  // Installation lifecycle (`enable ` / `disable ` / `remove `) argument contexts (Pi
+  // otherwise completes just the command name plus a space, and routes forced argument Tabs
+  // to file completion). session_start supplies the full TUI ui context;
   // RPC/JSON/print modes no-op ctx.ui.addAutocompleteProvider, so a terminal-only provider is
   // never registered outside a TUI session and command execution is unchanged.
   pi.on('session_start', (_event, ctx) => {
@@ -44,9 +45,9 @@ export default function (pi: ExtensionAPI) {
 
   pi.registerCommand('codex-marketplace', {
     description: 'codex / claude marketplace 管理（add/list/install/update/disable/enable/remove/forget/help）',
-    // Standard argument completion (#121, #122): typed subcommand and `install <query>`
-    // prefixes go through Pi's normal autocomplete; unowned syntax returns null so Pi falls
-    // through to its own behavior.
+    // Standard argument completion (#121–#123): typed subcommand and `install <query>` /
+    // lifecycle `<query>` prefixes go through Pi's normal autocomplete; unowned syntax
+    // returns null so Pi falls through to its own behavior.
     getArgumentCompletions: (argumentPrefix: string) => completeArguments(argumentPrefix),
     handler: async (args: string, ctx: ExtensionCommandContext) => {
       const rawArgs = (args ?? '').trim();

--- a/src/bridge/completion.ts
+++ b/src/bridge/completion.ts
@@ -14,7 +14,12 @@
  */
 
 import { queryMarketplacePlugins, type MarketplacePluginInstallationState } from './plugin-query.js';
-import { readMinimalBridgeStatePassive, type MinimalBridgeState } from './state.js';
+import {
+  isInstallationEnabled,
+  readMinimalBridgeStatePassive,
+  type MinimalBridgeState,
+  type MinimalInstallation,
+} from './state.js';
 
 export interface CompletionItem {
   /** Insertion value. Argument-taking subcommands carry a trailing space (#121). */
@@ -97,6 +102,15 @@ function fuzzyScore(query: string, label: string): number | null {
  * root candidate can be applied first.
  */
 const INSTALL_SECOND_LEVEL_RE = /^install\s+(\S*)$/;
+
+/**
+ * The owned Installation lifecycle second-level syntax (#123): `enable` / `disable` /
+ * `remove` followed by whitespace and a single-token query. Like `install`, each command
+ * without a trailing space stays at the root level; a second token is not Bridge-owned.
+ */
+const LIFECYCLE_SECOND_LEVEL_RE = /^(enable|disable|remove)\s+(\S*)$/;
+
+export type LifecycleAction = 'enable' | 'disable' | 'remove';
 
 /** Status vocabulary aligned with the `list` command surface (#90). */
 function installStatusLabel(state: MarketplacePluginInstallationState): string {
@@ -217,6 +231,120 @@ function completeInstallArguments(query: string, options: CompletionReadOptions)
   return scored.map((entry) => entry.item);
 }
 
+interface LifecycleCandidate {
+  /** The Installation name the command surface resolves on (manifestName → pluginId → id). */
+  name: string;
+  /** Marketplace provenance shown in the candidate description. */
+  marketplaceName: string;
+  /** 已裝啟用 / 已裝停用 — the Installation lifecycle status (#123). */
+  status: string;
+  /** Case-insensitive fuzzy search target: plugin name + marketplace provenance. */
+  searchText: string;
+  /** Durable Installation state — consumed by the action filter, not rendered. */
+  enabled: boolean;
+}
+
+function lifecycleStatusLabel(enabled: boolean): string {
+  return enabled ? '已裝啟用' : '已裝停用';
+}
+
+function installationName(inst: MinimalInstallation): string {
+  return inst.manifestName || inst.pluginId || inst.id;
+}
+
+/**
+ * Whether a name-typed `enable|disable|remove <name>` invocation would resolve exactly this
+ * Installation: the command matches `manifestName` OR `pluginId` OR `id` over every
+ * Installation (#93), so the token must be unique across all records, and must survive the
+ * command's whitespace token split.
+ */
+function lifecycleNameUsable(state: MinimalBridgeState, name: string): boolean {
+  if (name.length === 0 || /\s/.test(name)) return false;
+  let matches = 0;
+  for (const other of state.installations) {
+    if (other.manifestName === name || other.pluginId === name || other.id === name) matches += 1;
+  }
+  return matches === 1;
+}
+
+/**
+ * Compose Installation lifecycle candidates directly from Bridge State (#123). Lifecycle
+ * commands resolve on Installation records — not on catalog entries — so a record stays
+ * selectable even when its registration or marketplace material has become unreadable; only
+ * the provenance display degrades to the registration id.
+ *
+ * Ambiguity uses the full command resolution predicate over every Installation: a token that
+ * could resolve more than one record (cross-Marketplace same name, or a pluginId/id
+ * collision) is never offered, because the typed command would be rejected as ambiguous.
+ */
+function composeLifecycleCandidates(state: MinimalBridgeState): LifecycleCandidate[] {
+  const regNames = new Map(state.registrations.map((reg) => [reg.id, reg.marketplaceName || reg.alias || reg.id]));
+  const candidates: LifecycleCandidate[] = [];
+  for (const inst of state.installations) {
+    const name = installationName(inst);
+    if (!lifecycleNameUsable(state, name)) continue;
+    const marketplaceName = regNames.get(inst.registrationId) ?? inst.registrationId;
+    const enabled = isInstallationEnabled(inst);
+    candidates.push({
+      name,
+      marketplaceName,
+      status: lifecycleStatusLabel(enabled),
+      searchText: `${name} ${marketplaceName}`,
+      enabled,
+    });
+  }
+  return candidates;
+}
+
+function lifecycleCandidateIncluded(action: LifecycleAction, enabled: boolean): boolean {
+  if (action === 'enable') return !enabled;
+  if (action === 'disable') return enabled;
+  return true; // remove: every Installed Plugin, regardless of state
+}
+
+function toLifecycleItem(action: LifecycleAction, candidate: LifecycleCandidate): CompletionItem {
+  return {
+    value: `${action} ${candidate.name}`,
+    label: candidate.name,
+    description: `[${candidate.marketplaceName}] ${candidate.status}`,
+  };
+}
+
+/**
+ * Second-level `enable` / `disable` / `remove` candidates for `/codex-marketplace <action> <query>`.
+ *
+ * - `enable <query>` → disabled Installations only.
+ * - `disable <query>` → enabled Installations only.
+ * - `remove <query>` → every Installed Plugin, whatever its state.
+ * - Empty query → every actionable Installation in state order; a query → case-insensitive
+ *   fuzzy match over the name and Marketplace provenance; `[]` when nothing matches.
+ *
+ * The Bridge State read is passive: empty, damaged, unreadable, or incompatible state
+ * contributes no candidates and is never written, reset, or repaired (#119 stories 22–23).
+ */
+function completeLifecycleArguments(
+  action: LifecycleAction,
+  query: string,
+  options: CompletionReadOptions,
+): CompletionItem[] {
+  const state = readMinimalBridgeStatePassive({ statePath: options.statePath, agentDir: options.agentDir });
+  const candidates = composeLifecycleCandidates(state).filter((candidate) =>
+    lifecycleCandidateIncluded(action, candidate.enabled),
+  );
+  if (query.length === 0) {
+    return candidates.map((candidate) => toLifecycleItem(action, candidate));
+  }
+  const scored: { item: CompletionItem; score: number }[] = [];
+  for (const candidate of candidates) {
+    const score = fuzzyScore(query, candidate.searchText);
+    if (score !== null) {
+      scored.push({ item: toLifecycleItem(action, candidate), score });
+    }
+  }
+  scored.sort((a, b) => a.score - b.score || a.item.label.localeCompare(b.item.label));
+  return scored.map((entry) => entry.item);
+}
+
 /**
  * Compose completion candidates for `/codex-marketplace <argumentPrefix>`.
  *
@@ -236,6 +364,10 @@ export function completeArguments(
   const installMatch = INSTALL_SECOND_LEVEL_RE.exec(argumentPrefix);
   if (installMatch) {
     return completeInstallArguments(installMatch[1], options);
+  }
+  const lifecycleMatch = LIFECYCLE_SECOND_LEVEL_RE.exec(argumentPrefix);
+  if (lifecycleMatch) {
+    return completeLifecycleArguments(lifecycleMatch[1] as LifecycleAction, lifecycleMatch[2], options);
   }
   if (/\s/.test(argumentPrefix)) return null;
 

--- a/tests/e2e/extension-autocomplete.test.ts
+++ b/tests/e2e/extension-autocomplete.test.ts
@@ -424,3 +424,179 @@ describe('state-aware install autocomplete thin Pi adapter (#122)', () => {
     }
   });
 });
+
+// ---- #123 fixture: two marketplaces, one enabled and one disabled Installation ----
+function makeLifecycleFixture(): { root: string; statePath: string; cleanup(): void } {
+  const root = mkdtempSync(join(tmpdir(), 'bridge-e2e-lifecycle-'));
+  const statePath = join(root, 'state.json');
+  writeFileSync(
+    statePath,
+    JSON.stringify(
+      {
+        schemaVersion: 1,
+        registrations: [
+          { id: 'reg-a', marketplaceName: 'alpha-market', format: 'codex', sourceKind: 'local', source: join(root, 'mkt-a') },
+          { id: 'reg-b', marketplaceName: 'beta-market', format: 'codex', sourceKind: 'local', source: join(root, 'mkt-b') },
+        ],
+        installations: [
+          { id: 'inst-demo', pluginId: 'demo', enabled: true, installationState: 'enabled', registrationId: 'reg-a', manifestName: 'demo', sourceKind: 'local', source: join(root, 'mkt-a'), skills: [] },
+          { id: 'inst-paused', pluginId: 'paused', enabled: false, installationState: 'disabled', registrationId: 'reg-b', manifestName: 'paused', sourceKind: 'local', source: join(root, 'mkt-b'), skills: [] },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+  return { root, statePath, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+describe('Installation lifecycle autocomplete thin Pi adapter (#123)', () => {
+  it('intercepts a forced Tab inside `enable ` / `disable ` / `remove ` with state-aware candidates', async () => {
+    const fixture = makeLifecycleFixture();
+    try {
+      const current = fakeCurrentProvider();
+      const wrapper = createBridgeAutocompleteProvider(current, { statePath: fixture.statePath });
+
+      const disable = await wrapper.getSuggestions(['/codex-marketplace disable '], 0, '/codex-marketplace disable '.length, {
+        signal: new AbortController().signal,
+        force: true,
+      });
+      expect(current.calls).toEqual([]);
+      expect(disable!.prefix).toBe('disable ');
+      expect(disable!.items.map((item) => item.value)).toEqual(['disable demo']);
+      expect(disable!.items[0].description).toContain('[alpha-market]');
+
+      const enable = await wrapper.getSuggestions(['/codex-marketplace enable '], 0, '/codex-marketplace enable '.length, {
+        signal: new AbortController().signal,
+        force: true,
+      });
+      expect(enable!.prefix).toBe('enable ');
+      expect(enable!.items.map((item) => item.value)).toEqual(['enable paused']);
+      expect(enable!.items[0].description).toContain('[beta-market]');
+
+      const remove = await wrapper.getSuggestions(['/codex-marketplace remove '], 0, '/codex-marketplace remove '.length, {
+        signal: new AbortController().signal,
+        force: true,
+      });
+      expect(remove!.prefix).toBe('remove ');
+      expect(remove!.items.map((item) => item.value)).toEqual(['remove demo', 'remove paused']);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('filters forced lifecycle candidates by the typed query and returns the matching argument prefix', async () => {
+    const fixture = makeLifecycleFixture();
+    try {
+      const captured = captureExtension();
+      const current = fakeCurrentProvider();
+      const wrapper = createBridgeAutocompleteProvider(current, { statePath: fixture.statePath });
+
+      const line = '/codex-marketplace disable dem';
+      const result = await wrapper.getSuggestions([line], 0, line.length, {
+        signal: new AbortController().signal,
+        force: true,
+      });
+
+      expect(current.calls).toEqual([]);
+      expect(result!.prefix).toBe('disable dem');
+      expect(result!.items.map((item) => item.label)).toEqual(['demo']);
+      expect(result!.items[0].value).toBe('disable demo');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('does not intercept a forced lifecycle request with a mid-line cursor and trailing text', async () => {
+    const fixture = makeLifecycleFixture();
+    try {
+      const captured = captureExtension();
+      const current = fakeCurrentProvider({
+        suggestions: { items: [{ value: 'x', label: 'x' }], prefix: 'x' },
+      });
+      const wrapper = createBridgeAutocompleteProvider(current, { statePath: fixture.statePath });
+
+      const line = '/codex-marketplace disable dem junk';
+      const result = await wrapper.getSuggestions([line], 0, '/codex-marketplace disable dem'.length, {
+        signal: new AbortController().signal,
+        force: true,
+      });
+
+      expect(current.calls).toEqual(['getSuggestions']);
+      expect(result).toEqual({ items: [{ value: 'x', label: 'x' }], prefix: 'x' });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('delegates natural (non-forced) requests inside a lifecycle argument context to the host provider', async () => {
+    const captured = captureExtension();
+    const current = fakeCurrentProvider({
+      suggestions: { items: [{ value: 'x', label: 'x' }], prefix: 'x' },
+    });
+    const wrapper = installFactory(captured)(current) as AutocompleteProvider;
+
+    const line = '/codex-marketplace disable dem';
+    const result = await wrapper.getSuggestions([line], 0, line.length, {
+      signal: new AbortController().signal,
+      force: false,
+    });
+
+    // force=false is the host's natural argument-completion path (getArgumentCompletions
+    // owns it); the wrapper must not double-intercept.
+    expect(current.calls).toEqual(['getSuggestions']);
+    expect(result).toEqual({ items: [{ value: 'x', label: 'x' }], prefix: 'x' });
+  });
+
+  it('applies a lifecycle candidate through Pi 0.84.2 real combined provider, cursor at the inserted argument end', async () => {
+    const fixture = makeLifecycleFixture();
+    try {
+      const captured = captureExtension();
+      const command = captured.commands.get('codex-marketplace')!;
+      const wrapper = createBridgeAutocompleteProvider(
+        new CombinedAutocompleteProvider(
+          [{ name: 'codex-marketplace', getArgumentCompletions: command.getArgumentCompletions }],
+          '/tmp',
+          null,
+        ),
+        { statePath: fixture.statePath },
+      );
+
+      const line = '/codex-marketplace disable ';
+      const suggestions = await wrapper.getSuggestions([line], 0, line.length, {
+        signal: new AbortController().signal,
+        force: true,
+      });
+      const demo = suggestions!.items.find((item) => item.value === 'disable demo')!;
+      const applied = wrapper.applyCompletion([line], 0, line.length, demo, suggestions!.prefix);
+      expect(applied.lines[0]).toBe('/codex-marketplace disable demo');
+      expect(applied.cursorCol).toBe('/codex-marketplace disable demo'.length);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('does not chain-reopen the root subcommand list after an applied lifecycle argument (#123)', async () => {
+    const fixture = makeLifecycleFixture();
+    try {
+      const captured = captureExtension();
+      const current = fakeCurrentProvider();
+      const wrapper = createBridgeAutocompleteProvider(current, { statePath: fixture.statePath });
+
+      // After applying "disable " the editor holds "/codex-marketplace disable "; a subsequent
+      // Tab is a forced request. It must not re-intercept the line as the exact root command
+      // (that would chain-reopen the nine subcommands); it owns the second-level lifecycle
+      // context instead.
+      const result = await wrapper.getSuggestions(['/codex-marketplace disable '], 0, '/codex-marketplace disable '.length, {
+        signal: new AbortController().signal,
+        force: true,
+      });
+
+      expect(current.calls).toEqual([]);
+      expect(result!.prefix).toBe('disable ');
+      expect(result!.items.map((item) => item.label)).toEqual(['demo']);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});

--- a/tests/unit/bridge/completion.test.ts
+++ b/tests/unit/bridge/completion.test.ts
@@ -140,11 +140,12 @@ describe('Bridge completion seam (#121)', () => {
   });
 
   it('returns null when the argument prefix is not Bridge-owned syntax', () => {
-    // Non-install second-level argument text is not Bridge-owned (#121, #122) — the module
-    // must not own it, and callers fall through to Pi's own completion.
+    // Non-lifecycle second-level argument text is not Bridge-owned (#121–#123) — the module
+    // must not own it, and callers fall through to Pi's own completion. `forget` stays unowned:
+    // its registration candidates belong to #124, not the Installation lifecycle (#123).
     expect(completeArguments('list ')).toBeNull();
     expect(completeArguments('add some/path')).toBeNull();
-    expect(completeArguments('disable my-plugin')).toBeNull();
+    expect(completeArguments('forget my-market')).toBeNull();
   });
 
   it('mirrors the command surface description vocabulary without drift', () => {
@@ -481,5 +482,292 @@ describe('state-aware install completion (#122)', () => {
   it('returns null for a second token after the plugin query (not Bridge-owned)', () => {
     expect(completeArguments('install foo bar')).toBeNull();
     expect(completeArguments('install   baz qux')).toBeNull();
+  });
+});
+
+describe('state-aware Installation lifecycle completion (#123)', () => {
+  function lifecycleReg(id: string, name: string): MinimalBridgeState['registrations'][number] {
+    return { id, marketplaceName: name, format: 'codex', sourceKind: 'local', source: `/tmp/${id}` };
+  }
+
+  function installation(
+    fields: Partial<MinimalBridgeState['installations'][number]>,
+  ): MinimalBridgeState['installations'][number] {
+    return {
+      id: 'inst-x',
+      pluginId: 'plugin-x',
+      enabled: true,
+      installationState: 'enabled',
+      registrationId: 'reg-a',
+      manifestName: 'plugin-x',
+      sourceKind: 'local',
+      source: '/tmp/plugin-x',
+      skills: [],
+      ...fields,
+    };
+  }
+
+  function lifecycleState(
+    fixture: StateFixture,
+    regs: MinimalBridgeState['registrations'],
+    insts: MinimalBridgeState['installations'],
+  ): void {
+    writeState(fixture, { schemaVersion: 1, registrations: regs, installations: insts });
+  }
+
+  it('`enable ` lists only disabled Installations and `disable ` only enabled ones', () => {
+    const fixture = makeFixture();
+    try {
+      lifecycleState(
+        fixture,
+        [lifecycleReg('reg-a', 'alpha-market'), lifecycleReg('reg-b', 'beta-market')],
+        [
+          installation({ id: 'inst-a', pluginId: 'alpha-plugin', manifestName: 'alpha-plugin', registrationId: 'reg-a' }),
+          installation({ id: 'inst-b', pluginId: 'beta-plugin', manifestName: 'beta-plugin', registrationId: 'reg-b', enabled: false, installationState: 'disabled' }),
+        ],
+      );
+
+      const enable = completeArguments('enable ', { statePath: fixture.statePath })!;
+      expect(enable.map((item) => item.value)).toEqual(['enable beta-plugin']);
+      expect(enable.map((item) => item.label)).toEqual(['beta-plugin']);
+      for (const item of enable) {
+        expect(item.description).toContain('[beta-market]');
+      }
+
+      const disable = completeArguments('disable ', { statePath: fixture.statePath })!;
+      expect(disable.map((item) => item.value)).toEqual(['disable alpha-plugin']);
+      for (const item of disable) {
+        expect(item.description).toContain('[alpha-market]');
+      }
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('`remove ` lists every Installed Plugin regardless of state, with provenance in the description', () => {
+    const fixture = makeFixture();
+    try {
+      lifecycleState(
+        fixture,
+        [lifecycleReg('reg-a', 'alpha-market'), lifecycleReg('reg-b', 'beta-market')],
+        [
+          installation({ id: 'inst-a', pluginId: 'alpha-plugin', manifestName: 'alpha-plugin', registrationId: 'reg-a' }),
+          installation({ id: 'inst-b', pluginId: 'beta-plugin', manifestName: 'beta-plugin', registrationId: 'reg-b', enabled: false, installationState: 'disabled' }),
+        ],
+      );
+
+      const remove = completeArguments('remove ', { statePath: fixture.statePath })!;
+      expect(remove.map((item) => item.value)).toEqual(['remove alpha-plugin', 'remove beta-plugin']);
+      expect(remove[0].description).toContain('[alpha-market]');
+      expect(remove[0].description).toContain('已裝啟用');
+      expect(remove[1].description).toContain('[beta-market]');
+      expect(remove[1].description).toContain('已裝停用');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('omits cross-Marketplace same-named Installations that a name command cannot resolve uniquely', () => {
+    const fixture = makeFixture();
+    try {
+      lifecycleState(
+        fixture,
+        [lifecycleReg('reg-a', 'alpha-market'), lifecycleReg('reg-b', 'beta-market')],
+        [
+          installation({ id: 'inst-a', pluginId: 'shared', manifestName: 'shared', registrationId: 'reg-a' }),
+          installation({ id: 'inst-b', pluginId: 'shared', manifestName: 'shared', registrationId: 'reg-b', enabled: false, installationState: 'disabled' }),
+          installation({ id: 'inst-c', pluginId: 'other', manifestName: 'other', registrationId: 'reg-b' }),
+        ],
+      );
+
+      // `disable shared` would match both Installations and be rejected as ambiguous (#93),
+      // so neither same-named record may be offered as a candidate on any lifecycle action.
+      expect(completeArguments('disable ', { statePath: fixture.statePath })!.map((i) => i.value)).toEqual(['disable other']);
+      expect(completeArguments('enable ', { statePath: fixture.statePath })!.map((i) => i.value)).toEqual([]);
+      expect(completeArguments('remove ', { statePath: fixture.statePath })!.map((i) => i.value)).toEqual(['remove other']);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('applies the ambiguity rule across every identity field the command resolves on', () => {
+    const fixture = makeFixture();
+    try {
+      // A resolves by manifestName `x`; B carries the same token as its pluginId. A name-typed
+      // `disable x` matches both records (manifestName OR pluginId OR id, #93), so A is
+      // ambiguous and omitted, while B stays selectable through its own unique manifestName.
+      lifecycleState(
+        fixture,
+        [lifecycleReg('reg-a', 'alpha-market')],
+        [
+          installation({ id: 'inst-a', pluginId: 'a', manifestName: 'x', registrationId: 'reg-a' }),
+          installation({ id: 'inst-b', pluginId: 'x', manifestName: 'b', registrationId: 'reg-a' }),
+        ],
+      );
+
+      expect(completeArguments('disable ', { statePath: fixture.statePath })!.map((i) => i.value)).toEqual(['disable b']);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('keeps candidates when the registration record is gone, showing registrationId as provenance', () => {
+    const fixture = makeFixture();
+    try {
+      lifecycleState(
+        fixture,
+        [],
+        [installation({ id: 'inst-a', pluginId: 'orphan', manifestName: 'orphan', registrationId: 'reg-gone', enabled: false, installationState: 'disabled' })],
+      );
+
+      const enable = completeArguments('enable ', { statePath: fixture.statePath })!;
+      expect(enable.map((item) => item.value)).toEqual(['enable orphan']);
+      expect(enable[0].description).toContain('[reg-gone]');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('filters by case-insensitive fuzzy match over plugin name and Marketplace provenance', () => {
+    const fixture = makeFixture();
+    try {
+      lifecycleState(
+        fixture,
+        [lifecycleReg('reg-a', 'alpha-market'), lifecycleReg('reg-b', 'beta-market')],
+        [
+          installation({ id: 'inst-a', pluginId: 'my-plugin', manifestName: 'my-plugin', registrationId: 'reg-a' }),
+          installation({ id: 'inst-b', pluginId: 'alpha-tool', manifestName: 'alpha-tool', registrationId: 'reg-b', enabled: false, installationState: 'disabled' }),
+        ],
+      );
+
+      // Mixed-case partial over the plugin name.
+      const byName = completeArguments('remove MyPln', { statePath: fixture.statePath })!;
+      expect(byName.map((item) => item.label)).toEqual(['my-plugin']);
+
+      // Fuzzy partial over the Marketplace provenance.
+      const byMarket = completeArguments('remove bta', { statePath: fixture.statePath })!;
+      expect(byMarket.map((item) => item.label)).toEqual(['alpha-tool']);
+
+      // Non-contiguous query over the combined name＋provenance search text.
+      const nonContig = completeArguments('remove mlp', { statePath: fixture.statePath })!;
+      expect(nonContig.map((item) => item.label)).toEqual(['my-plugin']);
+
+      // A query that matches only the enabled candidate is still within the remove action.
+      const removeAll = completeArguments('remove ', { statePath: fixture.statePath })!;
+      expect(removeAll.map((item) => item.label)).toEqual(['my-plugin', 'alpha-tool']);
+
+      expect(completeArguments('remove zzz', { statePath: fixture.statePath })).toEqual([]);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('returns no candidates for an empty actionable set or an empty state', () => {
+    const fixture = makeFixture();
+    try {
+      lifecycleState(fixture, [lifecycleReg('reg-a', 'alpha-market')], [
+        installation({ id: 'inst-a', pluginId: 'only', manifestName: 'only', registrationId: 'reg-a' }),
+      ]);
+      // The only Installation is enabled: `enable ` has nothing actionable.
+      expect(completeArguments('enable ', { statePath: fixture.statePath })).toEqual([]);
+      expect(completeArguments('enable only', { statePath: fixture.statePath })).toEqual([]);
+
+      lifecycleState(fixture, [lifecycleReg('reg-a', 'alpha-market')], [
+        installation({ id: 'inst-a', pluginId: 'only', manifestName: 'only', registrationId: 'reg-a', enabled: false, installationState: 'disabled' }),
+      ]);
+      expect(completeArguments('disable ', { statePath: fixture.statePath })).toEqual([]);
+
+      lifecycleState(fixture, [], []);
+      expect(completeArguments('enable ', { statePath: fixture.statePath })).toEqual([]);
+      expect(completeArguments('disable ', { statePath: fixture.statePath })).toEqual([]);
+      expect(completeArguments('remove ', { statePath: fixture.statePath })).toEqual([]);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('reflects the latest Installation State on every completion request', () => {
+    const fixture = makeFixture();
+    try {
+      const regs = [lifecycleReg('reg-a', 'alpha-market')];
+      lifecycleState(fixture, regs, [
+        installation({ id: 'inst-a', pluginId: 'toggle', manifestName: 'toggle', registrationId: 'reg-a' }),
+      ]);
+      expect(completeArguments('disable ', { statePath: fixture.statePath })!.map((i) => i.value)).toEqual(['disable toggle']);
+      expect(completeArguments('enable ', { statePath: fixture.statePath })).toEqual([]);
+
+      // Simulate the user running `disable` between requests: the next completion reflects it.
+      lifecycleState(fixture, regs, [
+        installation({ id: 'inst-a', pluginId: 'toggle', manifestName: 'toggle', registrationId: 'reg-a', enabled: false, installationState: 'disabled' }),
+      ]);
+      expect(completeArguments('disable ', { statePath: fixture.statePath })).toEqual([]);
+      expect(completeArguments('enable ', { statePath: fixture.statePath })!.map((i) => i.value)).toEqual(['enable toggle']);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('is passive for damaged Bridge State: no candidates and the file content is untouched', () => {
+    const fixture = makeFixture();
+    try {
+      const damaged = 'INVALID JSON CONTENT';
+      writeFileSync(fixture.statePath, damaged, 'utf-8');
+
+      for (const prefix of ['enable ', 'disable ', 'remove ']) {
+        expect(completeArguments(prefix, { statePath: fixture.statePath })).toEqual([]);
+        // Malformed Bridge State must be byte-identical before and after completion (#123).
+        expect(readFileSync(fixture.statePath, 'utf-8')).toBe(damaged);
+      }
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('keeps a bare `enable` / `disable` / `remove` at the root level so the trailing-space candidate can apply first', () => {
+    const fixture = makeFixture();
+    try {
+      for (const label of ['enable', 'disable', 'remove']) {
+        const result = completeArguments(label, { statePath: fixture.statePath })!;
+        expect(result.map((item) => item.label)).toEqual([label]);
+        expect(result[0].value).toBe(`${label} `);
+      }
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('never offers an Installation whose name the whitespace-splitting command cannot resolve', () => {
+    const fixture = makeFixture();
+    try {
+      lifecycleState(
+        fixture,
+        [lifecycleReg('reg-a', 'alpha-market')],
+        [
+          installation({ id: 'inst-a', pluginId: 'good', manifestName: 'good', registrationId: 'reg-a', enabled: false, installationState: 'disabled' }),
+          installation({ id: 'inst-b', pluginId: 'my plugin', manifestName: 'my plugin', registrationId: 'reg-a' }),
+        ],
+      );
+
+      // `remove my plugin` splits into two tokens and never resolves an Installation; the
+      // candidate must not be offered.
+      expect(completeArguments('remove ', { statePath: fixture.statePath })!.map((i) => i.value)).toEqual(['remove good']);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('returns null for a third token and for unowned second-level syntax', () => {
+    const fixture = makeFixture();
+    try {
+      lifecycleState(fixture, [], []);
+      // A single-token argument query is Bridge-owned; a second token is not.
+      expect(completeArguments('remove foo bar', { statePath: fixture.statePath })).toBeNull();
+      expect(completeArguments('disable   baz qux', { statePath: fixture.statePath })).toBeNull();
+      // `forget` and `list` second-level arguments are not owned by #123.
+      expect(completeArguments('forget mkt', { statePath: fixture.statePath })).toBeNull();
+      expect(completeArguments('list ', { statePath: fixture.statePath })).toBeNull();
+    } finally {
+      fixture.cleanup();
+    }
   });
 });


### PR DESCRIPTION
## Summary

承 #119（分層自動補完）、#121（九個根層候選）與 #122（install 第二層）：`enable`／`disable`／`remove` 選取後再按一次 Tab 或繼續輸入，即出現狀態感知的 Installation lifecycle 候選——只列出當下可執行的已安裝 Plugin。

## Changes

- **src/bridge/completion.ts**：`completeArguments` 擁有 `enable`／`disable`／`remove` 第二層語法（`<action> <query>`）：
  - 候選直接由 Bridge State 的 **Installation 記錄**被動組合（lifecycle 指令解析對象是 Installation 而非 catalog entry——registration 或 marketplace material 不可讀時記錄仍可選，provenance 顯示退位為 registrationId）。
  - action 過濾與命令執行同域：`enable` 只列出 disabled、`disable` 只列出 enabled、`remove` 列出全部已安裝（不受狀態限制）。
  - **歧義省略**：套用命令的完整解析述詞（`manifestName` OR `pluginId` OR `id`）跨全部 Installations——同名或多欄位碰撞的 token 一律不提供候選（選了必失敗的指令不出現在選單），不新增命令語法或 identity。
  - Plugin 名稱與 Marketplace provenance 不分大小寫、非連續模糊搜尋；description 顯示 `[Marketplace] 已裝啟用｜已裝停用`。
  - 全程 `readMinimalBridgeStatePassive`：空集合／damaged Bridge State 不提供 state-dependent 候選，也不寫入、重置或修復任何文件；每次 completion request 都重新讀取。
- **extensions/pi/autocomplete.ts**：forced（Tab）請求位於 Bridge-owned 第二層語法（`install`／`enable`／`disable`／`remove` 加尾端空格）時由 wrapper 攔截——host 的 combined provider 在 `force=true` 會跳過 argument completion 改走 file completion；自然輸入（`force=false`）仍經 `getArgumentCompletions` 走到同一候選邏輯；其餘語法維持全部委派。
- **extensions/pi/index.ts**：註解與 `getArgumentCompletions` 接線敘述同步（行為不變）。

## Tests

- unit（completion.test.ts，+12）與 e2e（extension-autocomplete.test.ts，+6）共 +18 個 observable tests：
  - `enable`／`disable`／`remove` 各自只列出對應 actionable 集合；`remove` 含啟用與停用兩種狀態。
  - 跨 Marketplace 同名 Installation 一律省略（`disable shared` 會歧義失敗）；以 manifestName／pluginId 碰撞的 identity 欄位邊界也有覆蓋。
  - 名稱與 provenance 模糊搜尋（混合大小寫、非連續）；空 actionable set／空 state 無候選。
  - 完成動作後再次請求 completion 立即反映新狀態；registration 已消失的 orphan Installation 以 registrationId 顯示 provenance。
  - malformed Bridge State：completion 前後檔案內容 **byte 完全相同**。
  - 真實 `CombinedAutocompleteProvider` 套用候選後游標位於插入值尾端；forced Tab 不會 chain-reopen 根層清單。

`npm run typecheck` ✓；`npm test` 315 passed（baseline 297 + 18）。