### PR TITLE
feat: 提供 Marketplace Registration autocomplete 並保留 add 原生補完 (#124)

### DIFF
--- a/extensions/pi/autocomplete.ts
+++ b/extensions/pi/autocomplete.ts
@@ -1,16 +1,18 @@
 /**
- * Narrow Bridge autocomplete provider — thin Pi adapter (TUI session only) (#119, #121–#123).
+ * Narrow Bridge autocomplete provider — thin Pi adapter (TUI session only) (#119, #121–#124).
  *
  * Pi 0.84.2's built-in combined provider completes the slash-command name and inserts a
  * trailing space without exposing empty-prefix argument completion (root subcommands) when
  * the editor holds exactly `/codex-marketplace`. This wrapper intercepts that exact editor
  * content and presents the nine root candidates. It also owns the second-level argument
- * contexts (`install` #122 and the Installation lifecycle `enable` / `disable` / `remove`
- * #123) on forced (Tab) requests, which Pi 0.84.2 routes to file completion instead of
- * slash-command argument completion (its argument path only runs when `force` is false) —
- * the wrapper returns the state-aware candidates there. Everything else — other slash
- * commands, text, file/path completion, suggestion generation and completion application —
- * delegates unchanged to the host's current provider.
+ * contexts (`install` #122, the Installation lifecycle `enable` / `disable` / `remove` #123,
+ * and the Marketplace Registration `list` / `forget` #124) on forced (Tab) requests, which
+ * Pi 0.84.2 routes to file completion instead of slash-command argument completion (its
+ * argument path only runs when `force` is false) — the wrapper returns the state-aware
+ * candidates there. `add` stays free-form (#124): its forced Tab keeps Pi's native
+ * filesystem completion, and a typed Git locator or path is never constrained by Bridge
+ * candidates. Everything else — other slash commands, text, file/path completion, suggestion
+ * generation and completion application — delegates unchanged to the host's current provider.
  *
  * The wrapper is installed from a `session_start` handler via `ctx.ui.addAutocompleteProvider`,
  * which interactive (TUI) mode wires into the editor and RPC/JSON/print modes no-op, so a
@@ -26,9 +28,11 @@ export const EXACT_COMMAND = '/codex-marketplace';
 
 /**
  * The Bridge-owned second-level argument contexts on forced requests: `install` plus the
- * installation lifecycle actions — each followed by the trailing space root candidates insert.
+ * installation lifecycle actions plus the Marketplace Registration commands — each followed
+ * by the trailing space root candidates insert. `add` is deliberately absent (#124): its
+ * argument is an arbitrary path or Git locator that stays under Pi's native completion.
  */
-export const SECOND_LEVEL_ARGUMENT_RE = /^\/codex-marketplace (?:install|enable|disable|remove) /;
+export const SECOND_LEVEL_ARGUMENT_RE = /^\/codex-marketplace (?:install|list|forget|enable|disable|remove) /;
 
 /**
  * Wrap the host's current autocomplete provider. Suggestion generation intercepts only the
@@ -57,14 +61,16 @@ export function createBridgeAutocompleteProvider(
           };
         }
       }
-      // Second-level argument interception (#122, #123): forced (Tab) requests inside a
-      // Bridge-owned argument context (`install ` / `enable ` / `disable ` / `remove `) are
-      // Bridge-owned — the host's combined provider would route them to file completion.
-      // Natural typing (force=false) is delegated and reaches the same candidates through the
-      // command's getArgumentCompletions. Like the root branch, the cursor must be at the end
-      // of the line: a mid-line cursor with trailing text would otherwise produce a malformed
-      // line after applying a candidate. The prefix returned is the text after the command
-      // name (`install <query>` etc.), matching the host's argument-text semantics.
+      // Second-level argument interception (#122, #123, #124): forced (Tab) requests inside a
+      // Bridge-owned argument context (`install ` / `enable ` / `disable ` / `remove ` /
+      // `list ` / `forget `) are Bridge-owned — the host's combined provider would route them
+      // to file completion. Natural typing (force=false) is delegated and reaches the same
+      // candidates through the command's getArgumentCompletions. Like the root branch, the
+      // cursor must be at the end of the line: a mid-line cursor with trailing text would
+      // otherwise produce a malformed line after applying a candidate. The prefix returned is
+      // the text after the command name (`install <query>` etc.), matching the host's
+      // argument-text semantics. `add ` is not Bridge-owned (#124), so a forced Tab there
+      // falls through to the host provider's filesystem completion unchanged.
       if (options.force && cursorCol === line.length && SECOND_LEVEL_ARGUMENT_RE.test(line)) {
         const argumentText = line.slice(EXACT_COMMAND.length + 1, cursorCol);
         const items = completeArguments(argumentText, readOptions);

--- a/extensions/pi/index.ts
+++ b/extensions/pi/index.ts
@@ -18,11 +18,13 @@ import { completeArguments } from '../../src/bridge/completion.js';
 import { createBridgeAutocompleteProvider } from './autocomplete.js';
 
 export default function (pi: ExtensionAPI) {
-  // Root-level autocomplete (#121) + second-level autocomplete (#122–#123): stack a narrow
-  // provider for the exact `/codex-marketplace` editor text and the forced `install ` and
-  // Installation lifecycle (`enable ` / `disable ` / `remove `) argument contexts (Pi
-  // otherwise completes just the command name plus a space, and routes forced argument Tabs
-  // to file completion). session_start supplies the full TUI ui context;
+  // Root-level autocomplete (#121) + second-level autocomplete (#122–#124): stack a narrow
+  // provider for the exact `/codex-marketplace` editor text and the forced `install `,
+  // Installation lifecycle (`enable ` / `disable ` / `remove `), and Marketplace Registration
+  // (`list ` / `forget `) argument contexts (Pi otherwise completes just the command name
+  // plus a space, and routes forced argument Tabs to file completion). `add ` stays free-form
+  // (#124): forced Tabs keep Pi's native filesystem completion and typed Git locators are
+  // never constrained. session_start supplies the full TUI ui context;
   // RPC/JSON/print modes no-op ctx.ui.addAutocompleteProvider, so a terminal-only provider is
   // never registered outside a TUI session and command execution is unchanged.
   pi.on('session_start', (_event, ctx) => {
@@ -45,9 +47,10 @@ export default function (pi: ExtensionAPI) {
 
   pi.registerCommand('codex-marketplace', {
     description: 'codex / claude marketplace 管理（add/list/install/update/disable/enable/remove/forget/help）',
-    // Standard argument completion (#121–#123): typed subcommand and `install <query>` /
-    // lifecycle `<query>` prefixes go through Pi's normal autocomplete; unowned syntax
-    // returns null so Pi falls through to its own behavior.
+    // Standard argument completion (#121–#124): typed subcommand and `install <query>` /
+    // lifecycle `<query>` / Registration (`list` / `forget`) `<query>` prefixes go through
+    // Pi's normal autocomplete; unowned syntax (including `add`'s free-form argument) returns
+    // null so Pi falls through to its own behavior.
     getArgumentCompletions: (argumentPrefix: string) => completeArguments(argumentPrefix),
     handler: async (args: string, ctx: ExtensionCommandContext) => {
       const rawArgs = (args ?? '').trim();

--- a/src/bridge/completion.ts
+++ b/src/bridge/completion.ts
@@ -1,16 +1,17 @@
 /**
- * Bridge completion seam (#121, #122).
+ * Bridge completion seam (#121, #122, #123, #124).
  *
- * Pure autocomplete for `/codex-marketplace`: root-level subcommands (#121) plus
- * state-aware second-level `install` candidates (#122). This module owns no terminal, TUI,
- * rendering, or Pi host types: its input is the complete argument prefix plus replaceable
- * read-only options, and its output is only the insertion value, display label, and optional
- * description that Pi autocomplete needs — or `null` when the argument prefix is not
- * Bridge-owned syntax.
+ * Pure autocomplete for `/codex-marketplace`: root-level subcommands (#121), state-aware
+ * second-level `install` candidates (#122), Installation lifecycle `enable` / `disable` /
+ * `remove` candidates (#123), and Marketplace Registration candidates for `list` / `forget`
+ * (#124). This module owns no terminal, TUI, rendering, or Pi host types: its input is the
+ * complete argument prefix plus replaceable read-only options, and its output is only the
+ * insertion value, display label, and optional description that Pi autocomplete needs — or
+ * `null` when the argument prefix is not Bridge-owned syntax.
  *
- * Not owned: second-level candidates for subcommands other than `install`, arbitrary text,
- * file and path completion. When the module does not own the syntax, callers fall through to
- * Pi's normal behavior unchanged.
+ * Not owned: the `add` argument (arbitrary path or Git locator — free-form by design #124),
+ * arbitrary text, file and path completion. When the module does not own the syntax, callers
+ * fall through to Pi's normal behavior unchanged.
  */
 
 import { queryMarketplacePlugins, type MarketplacePluginInstallationState } from './plugin-query.js';
@@ -109,6 +110,16 @@ const INSTALL_SECOND_LEVEL_RE = /^install\s+(\S*)$/;
  * without a trailing space stays at the root level; a second token is not Bridge-owned.
  */
 const LIFECYCLE_SECOND_LEVEL_RE = /^(enable|disable|remove)\s+(\S*)$/;
+
+/**
+ * The owned Registration second-level syntax (#124): `list` / `forget` followed by
+ * whitespace and a single-token query. Both commands resolve their argument against the same
+ * Registration identity fields (marketplaceName OR alias OR id). Each command without a
+ * trailing space stays at the root level; a second token is not Bridge-owned. `add` is
+ * deliberately absent: its argument is free-form input (path or Git locator) and stays
+ * Pi-native.
+ */
+const REGISTRATION_SECOND_LEVEL_RE = /^(list|forget)\s+(\S*)$/;
 
 export type LifecycleAction = 'enable' | 'disable' | 'remove';
 
@@ -310,6 +321,118 @@ function toLifecycleItem(action: LifecycleAction, candidate: LifecycleCandidate)
   };
 }
 
+interface RegistrationCandidate {
+  /** Registration display name — marketplaceName, else alias, else id (command surface display). */
+  name: string;
+  /** Unique resolvable token the command executes on: the name, else its alias, else its id. */
+  insertion: string;
+  /** Marketplace format ('codex' | 'claude') shown as provenance. */
+  format: string;
+  /** 本地 / git source-kind vocabulary matching the `list` overview surface (#90). */
+  sourceKindLabel: string;
+  /** Raw source (local path or Git URL) shown as provenance. */
+  source: string;
+  /** Case-insensitive fuzzy search target: name + alias + format + source provenance. */
+  searchText: string;
+}
+
+/**
+ * Whether a name-typed `list|forget <token>` invocation would resolve exactly this
+ * Registration: the command matches marketplaceName OR alias OR id over every Registration
+ * (the same predicate as `matchesRegistration` in the command surface), so the token must be
+ * unique across all identity fields and survive the command's whitespace token split.
+ */
+function registrationTokenUsable(registrations: MinimalBridgeState['registrations'], token: string): boolean {
+  if (token.length === 0 || /\s/.test(token)) return false;
+  let matches = 0;
+  for (const reg of registrations) {
+    if (reg.marketplaceName === token || reg.alias === token || reg.id === token) matches += 1;
+  }
+  return matches === 1;
+}
+
+/**
+ * Compose Registration candidates directly from Bridge State (#124). `list` and `forget`
+ * both resolve their argument on Registration records, so a candidate is offered only when
+ * some token uniquely names that record — the readable name first, then its alias, then its
+ * Registration id — mirroring the exact predicate the commands execute with. Ambiguity uses
+ * the full predicate over every Registration identity field; a Registration with no uniquely
+ * resolvable token contributes no candidate, because the typed command could never select it.
+ */
+function composeRegistrationCandidates(state: MinimalBridgeState): RegistrationCandidate[] {
+  const candidates: RegistrationCandidate[] = [];
+  for (const reg of state.registrations) {
+    const name = reg.marketplaceName || reg.alias || reg.id;
+    const insertion =
+      (registrationTokenUsable(state.registrations, name) && name) ||
+      (reg.alias && reg.alias !== name && registrationTokenUsable(state.registrations, reg.alias) && reg.alias) ||
+      (registrationTokenUsable(state.registrations, reg.id) && reg.id);
+    if (!insertion) continue;
+    const format = reg.format ?? 'codex';
+    const sourceKindLabel = reg.sourceKind === 'local' ? '本地' : 'git';
+    candidates.push({
+      name,
+      insertion,
+      format,
+      sourceKindLabel,
+      source: reg.source,
+      searchText: [name, reg.alias, format, sourceKindLabel, reg.source].filter(Boolean).join(' '),
+    });
+  }
+  return candidates;
+}
+
+/**
+ * Compose the candidate label: the readable Registration name; when the insertion is not the
+ * name (ambiguous name, alias, or id), it stays visible so the user sees which token the
+ * candidate inserts.
+ */
+function registrationLabel(candidate: RegistrationCandidate): string {
+  return candidate.insertion === candidate.name
+    ? candidate.name
+    : `${candidate.name} (${candidate.insertion})`;
+}
+
+function toRegistrationItem(action: 'list' | 'forget', candidate: RegistrationCandidate): CompletionItem {
+  return {
+    value: `${action} ${candidate.insertion}`,
+    label: registrationLabel(candidate),
+    description: `[${candidate.format}] ${candidate.sourceKindLabel} ${candidate.source}`,
+  };
+}
+
+/**
+ * Second-level `list` / `forget` candidates for `/codex-marketplace <action> <query>` (#124).
+ *
+ * - Empty query → every Registration with a uniquely resolvable token, in state order.
+ * - A query → case-insensitive fuzzy match over the name, alias, and source/format
+ *   provenance; `[]` when nothing matches.
+ *
+ * The Bridge State read is passive: empty, damaged, unreadable, or incompatible state or
+ * marketplace material contributes no candidates and is never written, reset, or repaired
+ * (#119 stories 22–23). `add` is not owned here by design.
+ */
+function completeRegistrationArguments(
+  action: 'list' | 'forget',
+  query: string,
+  options: CompletionReadOptions,
+): CompletionItem[] {
+  const state = readMinimalBridgeStatePassive({ statePath: options.statePath, agentDir: options.agentDir });
+  const candidates = composeRegistrationCandidates(state);
+  if (query.length === 0) {
+    return candidates.map((candidate) => toRegistrationItem(action, candidate));
+  }
+  const scored: { item: CompletionItem; score: number }[] = [];
+  for (const candidate of candidates) {
+    const score = fuzzyScore(query, candidate.searchText);
+    if (score !== null) {
+      scored.push({ item: toRegistrationItem(action, candidate), score });
+    }
+  }
+  scored.sort((a, b) => a.score - b.score || a.item.label.localeCompare(b.item.label));
+  return scored.map((entry) => entry.item);
+}
+
 /**
  * Second-level `enable` / `disable` / `remove` candidates for `/codex-marketplace <action> <query>`.
  *
@@ -349,13 +472,15 @@ function completeLifecycleArguments(
  * Compose completion candidates for `/codex-marketplace <argumentPrefix>`.
  *
  * - `install ` / `install <query>` → state-aware second-level install candidates (#122).
+ * - `enable|disable|remove <query>` → Installation lifecycle candidates (#123).
+ * - `list|forget <query>` → Registration candidates (#124); `add` is never owned.
  * - Empty prefix → all nine root candidates (Pi's exact-command interception surface).
  * - A single token → case-insensitive fuzzy-filtered subcommands; `[]` when nothing matches.
  * - Any other whitespace-containing prefix (unowned second-level syntax) → `null`, so callers
  *   fall through to Pi's own completion unchanged.
  *
  * The module never writes Bridge State; root candidates are derived without reading it at all,
- * and install candidates read it passively.
+ * and state-aware candidates read it passively.
  */
 export function completeArguments(
   argumentPrefix: string,
@@ -368,6 +493,14 @@ export function completeArguments(
   const lifecycleMatch = LIFECYCLE_SECOND_LEVEL_RE.exec(argumentPrefix);
   if (lifecycleMatch) {
     return completeLifecycleArguments(lifecycleMatch[1] as LifecycleAction, lifecycleMatch[2], options);
+  }
+  const registrationMatch = REGISTRATION_SECOND_LEVEL_RE.exec(argumentPrefix);
+  if (registrationMatch) {
+    return completeRegistrationArguments(
+      registrationMatch[1] as 'list' | 'forget',
+      registrationMatch[2],
+      options,
+    );
   }
   if (/\s/.test(argumentPrefix)) return null;
 

--- a/tests/e2e/extension-autocomplete.test.ts
+++ b/tests/e2e/extension-autocomplete.test.ts
@@ -140,9 +140,10 @@ describe('/codex-marketplace autocomplete thin Pi adapter (#121)', () => {
     const narrowed = command.getArgumentCompletions!('INSTL');
     expect(narrowed!.map((item) => item.label)).toEqual(['install']);
 
-    // Non-install argument text is not Bridge-owned; second-token install text neither.
-    expect(command.getArgumentCompletions!('list ')).toBeNull();
+    // The `add` argument is free-form (path or Git locator) and never Bridge-owned (#124);
+    // second-token install text is not owned either.
     expect(command.getArgumentCompletions!('add some/path')).toBeNull();
+    expect(command.getArgumentCompletions!('add https://github.com/acme/skills')).toBeNull();
     expect(command.getArgumentCompletions!('install foo bar')).toBeNull();
   });
 
@@ -595,6 +596,231 @@ describe('Installation lifecycle autocomplete thin Pi adapter (#123)', () => {
       expect(current.calls).toEqual([]);
       expect(result!.prefix).toBe('disable ');
       expect(result!.items.map((item) => item.label)).toEqual(['demo']);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});
+
+// ---- #124 fixture: two same-named marketplaces plus a unique one, one git-sourced ----
+function makeRegistrationFixture(): { root: string; statePath: string; cleanup(): void } {
+  const root = mkdtempSync(join(tmpdir(), 'bridge-e2e-registration-'));
+  const statePath = join(root, 'state.json');
+  writeFileSync(
+    statePath,
+    JSON.stringify(
+      {
+        schemaVersion: 1,
+        registrations: [
+          { id: 'reg-a', marketplaceName: 'shared-market', format: 'codex', sourceKind: 'local', source: join(root, 'mkt-a') },
+          { id: 'reg-b', marketplaceName: 'shared-market', format: 'claude', sourceKind: 'git', source: 'https://github.com/acme/skills' },
+          { id: 'reg-c', marketplaceName: 'unique-market', format: 'codex', sourceKind: 'local', source: join(root, 'mkt-c') },
+        ],
+        installations: [],
+      },
+      null,
+      2,
+    ),
+  );
+  return { root, statePath, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+describe('Marketplace Registration autocomplete thin Pi adapter (#124)', () => {
+  it('intercepts a forced Tab inside `list ` / `forget ` with Registration candidates and does not consult the current provider', async () => {
+    const fixture = makeRegistrationFixture();
+    try {
+      const current = fakeCurrentProvider();
+      const wrapper = createBridgeAutocompleteProvider(current, { statePath: fixture.statePath });
+
+      const list = await wrapper.getSuggestions(['/codex-marketplace list '], 0, '/codex-marketplace list '.length, {
+        signal: new AbortController().signal,
+        force: true,
+      });
+      expect(current.calls).toEqual([]);
+      expect(list!.prefix).toBe('list ');
+      // `shared-market` is ambiguous in the fixture (reg-a + reg-b), so the ids are inserted;
+      // only unique names keep the readable form.
+      expect(list!.items[0].value).toBe('list reg-a');
+      expect(list!.items[1].value).toBe('list reg-b');
+      expect(list!.items[0].description).toContain('[codex]');
+      expect(list!.items[1].description).toContain('[claude]');
+      expect(list!.items[2].value).toBe('list unique-market');
+
+      const forget = await wrapper.getSuggestions(['/codex-marketplace forget '], 0, '/codex-marketplace forget '.length, {
+        signal: new AbortController().signal,
+        force: true,
+      });
+      expect(current.calls).toEqual([]);
+      expect(forget!.prefix).toBe('forget ');
+      expect(forget!.items.map((item) => item.value)).toEqual(['forget reg-a', 'forget reg-b', 'forget unique-market']);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('filters forced Registration candidates by the typed query and returns the matching argument prefix', async () => {
+    const fixture = makeRegistrationFixture();
+    try {
+      const current = fakeCurrentProvider();
+      const wrapper = createBridgeAutocompleteProvider(current, { statePath: fixture.statePath });
+
+      const line = '/codex-marketplace list uni';
+      const result = await wrapper.getSuggestions([line], 0, line.length, {
+        signal: new AbortController().signal,
+        force: true,
+      });
+
+      expect(current.calls).toEqual([]);
+      expect(result!.prefix).toBe('list uni');
+      expect(result!.items.map((item) => item.label)).toEqual(['unique-market']);
+      expect(result!.items[0].value).toBe('list unique-market');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('keeps a forced Tab inside `add ` under Pi native filesystem completion (#124)', async () => {
+    const fixture = makeRegistrationFixture();
+    try {
+      const current = fakeCurrentProvider({
+        suggestions: { items: [{ value: '/some/root/path', label: '/some/root/path' }], prefix: '' },
+      });
+      const wrapper = createBridgeAutocompleteProvider(current, { statePath: fixture.statePath });
+
+      // `add ` is not Bridge-owned: a forced Tab must consult the host provider exactly like
+      // any other stacked provider (Pi's filesystem completion), never Bridge candidates.
+      const line = '/codex-marketplace add ';
+      const result = await wrapper.getSuggestions([line], 0, line.length, {
+        signal: new AbortController().signal,
+        force: true,
+      });
+
+      expect(current.calls).toEqual(['getSuggestions']);
+      expect(result).toEqual({ items: [{ value: '/some/root/path', label: '/some/root/path' }], prefix: '' });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('never constrains a free-form Git locator typed after `add ` (#124)', async () => {
+    const fixture = makeRegistrationFixture();
+    try {
+      const current = fakeCurrentProvider({
+        suggestions: { items: [], prefix: 'add https://github.com/acme/skills' },
+      });
+      const wrapper = createBridgeAutocompleteProvider(current, { statePath: fixture.statePath });
+
+      const line = '/codex-marketplace add https://github.com/acme/skills';
+      const result = await wrapper.getSuggestions([line], 0, line.length, {
+        signal: new AbortController().signal,
+        force: true,
+      });
+
+      expect(current.calls).toEqual(['getSuggestions']);
+      expect(result!.prefix).toBe('add https://github.com/acme/skills');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('does not intercept a forced Registration request with a mid-line cursor and trailing text', async () => {
+    const fixture = makeRegistrationFixture();
+    try {
+      const current = fakeCurrentProvider({
+        suggestions: { items: [{ value: 'x', label: 'x' }], prefix: 'x' },
+      });
+      const wrapper = createBridgeAutocompleteProvider(current, { statePath: fixture.statePath });
+
+      const line = '/codex-marketplace list uni junk';
+      const result = await wrapper.getSuggestions([line], 0, '/codex-marketplace list uni'.length, {
+        signal: new AbortController().signal,
+        force: true,
+      });
+
+      expect(current.calls).toEqual(['getSuggestions']);
+      expect(result).toEqual({ items: [{ value: 'x', label: 'x' }], prefix: 'x' });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('delegates natural (non-forced) requests inside a Registration argument context to the host provider', async () => {
+    const captured = captureExtension();
+    const current = fakeCurrentProvider({
+      suggestions: { items: [{ value: 'x', label: 'x' }], prefix: 'x' },
+    });
+    const wrapper = installFactory(captured)(current) as AutocompleteProvider;
+
+    const line = '/codex-marketplace list uni';
+    const result = await wrapper.getSuggestions([line], 0, line.length, {
+      signal: new AbortController().signal,
+      force: false,
+    });
+
+    // force=false is the host's natural argument-completion path (getArgumentCompletions
+    // owns it); the wrapper must not double-intercept.
+    expect(current.calls).toEqual(['getSuggestions']);
+    expect(result).toEqual({ items: [{ value: 'x', label: 'x' }], prefix: 'x' });
+  });
+
+  it('applies a Registration candidate through Pi 0.84.2 real combined provider, cursor at the inserted argument end', async () => {
+    const fixture = makeRegistrationFixture();
+    try {
+      const captured = captureExtension();
+      const command = captured.commands.get('codex-marketplace')!;
+      const wrapper = createBridgeAutocompleteProvider(
+        new CombinedAutocompleteProvider(
+          [{ name: 'codex-marketplace', getArgumentCompletions: command.getArgumentCompletions }],
+          '/tmp',
+          null,
+        ),
+        { statePath: fixture.statePath },
+      );
+
+      const line = '/codex-marketplace list ';
+      const suggestions = await wrapper.getSuggestions([line], 0, line.length, {
+        signal: new AbortController().signal,
+        force: true,
+      });
+      const unique = suggestions!.items.find((item) => item.value === 'list unique-market')!;
+      const applied = wrapper.applyCompletion([line], 0, line.length, unique, suggestions!.prefix);
+      expect(applied.lines[0]).toBe('/codex-marketplace list unique-market');
+      expect(applied.cursorCol).toBe('/codex-marketplace list unique-market'.length);
+
+      // The id insertion for the same-named Registration candidate resolves to a working
+      // `forget <id>` command too (the command resolves by id exactly like `forget <名稱>`).
+      const forgetLine = '/codex-marketplace forget ';
+      const forgetSuggestions = await wrapper.getSuggestions([forgetLine], 0, forgetLine.length, {
+        signal: new AbortController().signal,
+        force: true,
+      });
+      const byId = forgetSuggestions!.items.find((item) => item.value === 'forget reg-b')!;
+      const appliedForget = wrapper.applyCompletion([forgetLine], 0, forgetLine.length, byId, forgetSuggestions!.prefix);
+      expect(appliedForget.lines[0]).toBe('/codex-marketplace forget reg-b');
+      expect(appliedForget.cursorCol).toBe('/codex-marketplace forget reg-b'.length);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('does not chain-reopen the root subcommand list after an applied Registration argument (#124)', async () => {
+    const fixture = makeRegistrationFixture();
+    try {
+      const current = fakeCurrentProvider();
+      const wrapper = createBridgeAutocompleteProvider(current, { statePath: fixture.statePath });
+
+      const result = await wrapper.getSuggestions(['/codex-marketplace list '], 0, '/codex-marketplace list '.length, {
+        signal: new AbortController().signal,
+        force: true,
+      });
+
+      expect(current.calls).toEqual([]);
+      expect(result!.prefix).toBe('list ');
+      expect(result!.items.map((item) => item.label)).toEqual([
+        'shared-market (reg-a)',
+        'shared-market (reg-b)',
+        'unique-market',
+      ]);
     } finally {
       fixture.cleanup();
     }

--- a/tests/unit/bridge/completion.test.ts
+++ b/tests/unit/bridge/completion.test.ts
@@ -141,11 +141,12 @@ describe('Bridge completion seam (#121)', () => {
 
   it('returns null when the argument prefix is not Bridge-owned syntax', () => {
     // Non-lifecycle second-level argument text is not Bridge-owned (#121–#123) — the module
-    // must not own it, and callers fall through to Pi's own completion. `forget` stays unowned:
-    // its registration candidates belong to #124, not the Installation lifecycle (#123).
-    expect(completeArguments('list ')).toBeNull();
+    // must not own it, and callers fall through to Pi's own completion. `add` stays unowned
+    // (#124): its argument is free-form input (path or Git locator) and must never be
+    // constrained by Bridge-owned candidates, so Pi's native completion keeps working.
     expect(completeArguments('add some/path')).toBeNull();
-    expect(completeArguments('forget my-market')).toBeNull();
+    expect(completeArguments('add https://github.com/acme/skills')).toBeNull();
+    expect(completeArguments('add owner/repo')).toBeNull();
   });
 
   it('mirrors the command surface description vocabulary without drift', () => {
@@ -756,16 +757,266 @@ describe('state-aware Installation lifecycle completion (#123)', () => {
     }
   });
 
-  it('returns null for a third token and for unowned second-level syntax', () => {
+  it('returns null for a second token after the query (not Bridge-owned)', () => {
     const fixture = makeFixture();
     try {
       lifecycleState(fixture, [], []);
       // A single-token argument query is Bridge-owned; a second token is not.
       expect(completeArguments('remove foo bar', { statePath: fixture.statePath })).toBeNull();
       expect(completeArguments('disable   baz qux', { statePath: fixture.statePath })).toBeNull();
-      // `forget` and `list` second-level arguments are not owned by #123.
-      expect(completeArguments('forget mkt', { statePath: fixture.statePath })).toBeNull();
-      expect(completeArguments('list ', { statePath: fixture.statePath })).toBeNull();
+      // `list`/`forget` own only a single-token query too (#124); `add` stays unowned
+      // entirely, exactly like #123's lifecycle commands.
+      expect(completeArguments('forget mkt extra', { statePath: fixture.statePath })).toBeNull();
+      expect(completeArguments('list a b', { statePath: fixture.statePath })).toBeNull();
+      expect(completeArguments('add some/path extra', { statePath: fixture.statePath })).toBeNull();
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});
+
+describe('state-aware Registration completion (#124)', () => {
+  function reg(
+    id: string,
+    marketplaceName: string,
+    fields: Partial<MinimalBridgeState['registrations'][number]> = {},
+  ): MinimalBridgeState['registrations'][number] {
+    return {
+      id,
+      marketplaceName,
+      format: 'codex',
+      sourceKind: 'local',
+      source: `/tmp/${id}`,
+      ...fields,
+    };
+  }
+
+  function regState(fixture: StateFixture, regs: MinimalBridgeState['registrations']): void {
+    writeState(fixture, { schemaVersion: 1, registrations: regs, installations: [] });
+  }
+
+  it('`list ` and `forget ` list every Registration, resolving unique names to readable insertions with source/format provenance', () => {
+    const fixture = makeFixture();
+    try {
+      regState(fixture, [
+        reg('reg-a', 'alpha-market'),
+        reg('reg-b', 'beta-market', { format: 'claude', sourceKind: 'git', source: 'https://github.com/acme/skills' }),
+      ]);
+
+      const list = completeArguments('list ', { statePath: fixture.statePath })!;
+      expect(list.map((item) => item.label)).toEqual(['alpha-market', 'beta-market']);
+      expect(list.map((item) => item.value)).toEqual(['list alpha-market', 'list beta-market']);
+      expect(list[0].description).toContain('[codex]');
+      expect(list[0].description).toContain('本地');
+      expect(list[0].description).toContain('/tmp/reg-a');
+      expect(list[1].description).toContain('[claude]');
+      expect(list[1].description).toContain('git');
+      expect(list[1].description).toContain('https://github.com/acme/skills');
+
+      const forget = completeArguments('forget ', { statePath: fixture.statePath })!;
+      expect(forget.map((item) => item.value)).toEqual(['forget alpha-market', 'forget beta-market']);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('inserts the Registration ID when the name is not uniquely resolvable, with provenance in the description', () => {
+    const fixture = makeFixture();
+    try {
+      regState(fixture, [
+        reg('reg-a', 'demo-market'),
+        reg('reg-b', 'demo-market', { format: 'claude', sourceKind: 'git', source: 'https://github.com/acme/demo' }),
+      ]);
+
+      const result = completeArguments('list ', { statePath: fixture.statePath })!;
+      // A typed `list demo-market` would match both records and be rejected as ambiguous
+      // (#93 semantics), so the candidates insert their Registration IDs — tokens the
+      // command resolves by id exactly like `list <id>`.
+      expect(result.map((item) => item.value)).toEqual(['list reg-a', 'list reg-b']);
+      expect(result.map((item) => item.label)).toEqual(['demo-market (reg-a)', 'demo-market (reg-b)']);
+      expect(result[0].description).toContain('[codex] 本地');
+      expect(result[1].description).toContain('[claude] git');
+      expect(result[0].description).not.toBe(result[1].description);
+
+      const forget = completeArguments('forget ', { statePath: fixture.statePath })!;
+      expect(forget.map((item) => item.value)).toEqual(['forget reg-a', 'forget reg-b']);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('applies the ambiguity rule across every identity field the command resolves on', () => {
+    const fixture = makeFixture();
+    try {
+      // A resolves by marketplaceName `x`; B carries the same token as its alias. A name-typed
+      // `list x` matches both records (marketplaceName OR alias OR id), so A's name is
+      // ambiguous and its id is inserted; B's own name `x` is ambiguous too, but B has a
+      // unique alias `b-alias` that resolves exactly it.
+      regState(fixture, [
+        reg('reg-a', 'x'),
+        reg('reg-b', 'x', { alias: 'b-alias' }),
+      ]);
+
+      const result = completeArguments('list ', { statePath: fixture.statePath })!;
+      const byValue = new Map(result.map((item) => [item.value, item]));
+      expect(byValue.has('list x')).toBe(false);
+      expect(byValue.get('list reg-a')!.label).toBe('x (reg-a)');
+      // A typed `list b-alias` resolves exactly B, so the unique alias is the insertion.
+      expect(byValue.get('list b-alias')!.label).toBe('x (b-alias)');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('drops a Registration whose id is itself ambiguous (collides with a sibling identity)', () => {
+    const fixture = makeFixture();
+    try {
+      // reg-a's id `collide` equals reg-c's alias, and both register under the same name:
+      // no token uniquely resolves reg-a (name `same` matches both; id `collide` matches
+      // both), so it must not be offered. reg-c stays selectable through its unique id.
+      regState(fixture, [
+        reg('collide', 'same'),
+        reg('reg-c', 'same', { alias: 'collide' }),
+      ]);
+
+      const result = completeArguments('list ', { statePath: fixture.statePath })!;
+      const byValue = new Map(result.map((item) => [item.value, item]));
+      expect(byValue.has('list same')).toBe(false);
+      expect(byValue.has('list collide')).toBe(false);
+      expect(byValue.get('list reg-c')!.label).toBe('same (reg-c)');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('never offers a Registration whose name the whitespace-splitting command cannot resolve', () => {
+    const fixture = makeFixture();
+    try {
+      regState(fixture, [
+        reg('reg-a', 'good-market'),
+        reg('reg-b', 'my market'),
+        reg('reg-c', 'my market', { alias: 'my-market' }),
+      ]);
+
+      const result = completeArguments('list ', { statePath: fixture.statePath })!;
+      const byValue = new Map(result.map((item) => [item.value, item]));
+      // `list my market` splits into two tokens and never resolves a Registration; the
+      // unique alias (when present) or the Registration id (otherwise) is inserted instead.
+      expect(byValue.get('list good-market')!.label).toBe('good-market');
+      expect(byValue.get('list reg-b')!.label).toBe('my market (reg-b)');
+      expect(byValue.get('list my-market')!.label).toBe('my market (my-market)');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('filters by case-insensitive fuzzy match over Registration name and source/format provenance', () => {
+    const fixture = makeFixture();
+    try {
+      regState(fixture, [
+        reg('reg-a', 'alpha-market'),
+        reg('reg-b', 'beta-market', { format: 'claude', sourceKind: 'git', source: 'https://github.com/acme/skills' }),
+      ]);
+
+      // Mixed-case partial over the Registration name.
+      const byName = completeArguments('list Bta', { statePath: fixture.statePath })!;
+      expect(byName.map((item) => item.value)).toEqual(['list beta-market']);
+
+      // Fuzzy partial over the raw git source.
+      const bySource = completeArguments('list gthb', { statePath: fixture.statePath })!;
+      expect(bySource.map((item) => item.value)).toEqual(['list beta-market']);
+
+      // Non-contiguous query a-l-p-…-‘-’ across the combined name＋provenance: only the
+      // alpha name matches (`alp-` needs a trailing `-` after the non-contiguous `alp`,
+      // which beta's provenance lacks).
+      const nonContig = completeArguments('list alp-', { statePath: fixture.statePath })!;
+      expect(nonContig.map((item) => item.value)).toEqual(['list alpha-market']);
+
+      expect(completeArguments('list zzz', { statePath: fixture.statePath })).toEqual([]);
+      expect(completeArguments('forget zzz', { statePath: fixture.statePath })).toEqual([]);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('returns no candidates for an empty Registration set', () => {
+    const fixture = makeFixture();
+    try {
+      regState(fixture, []);
+      expect(completeArguments('list ', { statePath: fixture.statePath })).toEqual([]);
+      expect(completeArguments('list anything', { statePath: fixture.statePath })).toEqual([]);
+      expect(completeArguments('forget ', { statePath: fixture.statePath })).toEqual([]);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('reflects the latest Registrations on every completion request', () => {
+    const fixture = makeFixture();
+    try {
+      regState(fixture, [reg('reg-a', 'alpha-market')]);
+      expect(completeArguments('list ', { statePath: fixture.statePath })!.map((i) => i.value)).toEqual(['list alpha-market']);
+
+      // Simulate the user running `add` (or `forget`) between requests: the next completion
+      // re-reads Bridge State and immediately reflects the current Registration set.
+      regState(fixture, [reg('reg-a', 'alpha-market'), reg('reg-b', 'beta-market')]);
+      expect(completeArguments('list ', { statePath: fixture.statePath })!.map((i) => i.value)).toEqual([
+        'list alpha-market',
+        'list beta-market',
+      ]);
+      expect(completeArguments('forget ', { statePath: fixture.statePath })!.map((i) => i.value)).toEqual([
+        'forget alpha-market',
+        'forget beta-market',
+      ]);
+
+      regState(fixture, [reg('reg-b', 'beta-market')]);
+      expect(completeArguments('forget ', { statePath: fixture.statePath })!.map((i) => i.value)).toEqual(['forget beta-market']);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('is passive for damaged Bridge State: no candidates and the file content is untouched', () => {
+    const fixture = makeFixture();
+    try {
+      const damaged = 'INVALID JSON CONTENT';
+      writeFileSync(fixture.statePath, damaged, 'utf-8');
+
+      for (const prefix of ['list ', 'list some', 'forget ', 'forget some']) {
+        expect(completeArguments(prefix, { statePath: fixture.statePath })).toEqual([]);
+        // Malformed Bridge State must be byte-identical before and after completion (#124).
+        expect(readFileSync(fixture.statePath, 'utf-8')).toBe(damaged);
+      }
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('keeps a bare `list` / `forget` at the root level so the trailing-space candidate can apply first', () => {
+    const fixture = makeFixture();
+    try {
+      regState(fixture, [reg('reg-a', 'alpha-market')]);
+      for (const label of ['list', 'forget']) {
+        const result = completeArguments(label, { statePath: fixture.statePath })!;
+        expect(result.map((item) => item.label)).toEqual([label]);
+        expect(result[0].value).toBe(`${label} `);
+      }
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('returns null for a second token and for `add` (which stays free-form)', () => {
+    const fixture = makeFixture();
+    try {
+      regState(fixture, [reg('reg-a', 'alpha-market')]);
+      expect(completeArguments('list foo bar', { statePath: fixture.statePath })).toBeNull();
+      expect(completeArguments('forget a b', { statePath: fixture.statePath })).toBeNull();
+      // `add ` must never be owned: its second-level argument is a path or Git locator and
+      // belongs to Pi's native completion and the command's own free-form parsing (#124).
+      expect(completeArguments('add ', { statePath: fixture.statePath })).toBeNull();
+      expect(completeArguments('add some/path', { statePath: fixture.statePath })).toBeNull();
+      expect(completeArguments('add owner/repo', { statePath: fixture.statePath })).toBeNull();
     } finally {
       fixture.cleanup();
     }


### PR DESCRIPTION
Closes #124

## 背景

#119 要求 `list` 與 `forget` 可從現有 Marketplace Registrations 選擇參數，同時 `add` 保持 Pi 原生路徑補完與自由 Git locator 輸入。本 PR 把 #121–#123 的第二層 autocomplete seam 延伸至 Registration 語法。

## 變更

- **Bridge completion seam（`src/bridge/completion.ts`）**：`list`／`forget` 第二層候選由 Bridge State 的 Registration 記錄**被動**組合而成（`readMinimalBridgeStatePassive`）——空、損毀、不可讀或格式不符的 state 貢獻零候選，文件永不被寫入、重設或修復（#119 stories 22–23）。
  - 候選只在某個 token 能被既有指令**唯一執行**的前提下提供：可讀名稱（marketplaceName → alias → id）優先，其次 alias，最後 Registration ID；解析述詞與命令 surface 的 `matchesRegistration`（marketplaceName OR alias OR id）完全一致，跨全部註冊計數，同名或多身分欄位碰撞的 token 一律不用（選了必失敗），無唯一可解析 token 的註冊不提供候選。
  - 同名 Registrations 以現有 Registration ID 為 insertion value，label 顯示 `名稱 (id)`，description 顯示 Marketplace source／format provenance（`[codex] 本地 <路徑>`／`[claude] git <URL>`），使選取結果可由既有命令唯一執行。
  - 候選提供不分大小寫的非連續模糊搜尋（名稱＋alias＋format＋source provenance）。
- **薄 Pi adapter（`extensions/pi/autocomplete.ts`＋`index.ts`）**：`list`／`forget` 加入 `SECOND_LEVEL_ARGUMENT_RE`，force（Tab）請求在 Bridge-owned 第二層語法內由 wrapper 攔截（host 在 force=true 會改走 file completion）。**`add` 刻意缺席**：`add ` 後的 Tab 保持 Pi 原生 filesystem suggestions，自由輸入的 HTTPS／SSH／scp-like／owner-repo Git locator 不受候選清單約束。自然輸入（force=false）仍經 `getArgumentCompletions` 到達同一候選邏輯；其餘 slash command、文字、檔案／路徑 completion 與其他 stacked providers 的 suggestion generation、application、file-trigger 判定保持不變。

## 測試

- **unit（`tests/unit/bridge/completion.test.ts`）**：`list `／`forget ` 全量列出（可讀名稱 vs ID insertion 與 provenance）、跨身分欄位歧義規則、id 碰撞候選丟棄、空白名稱委派 alias／id、fuzzy partial（名稱＋provenance）、每次 request 即時反映 add／forget、空集合與 damaged state 被動（byte-identical）、`add ` 及第二 token 回 null。
- **e2e（`tests/e2e/extension-autocomplete.test.ts`）**：force Tab 攔截與查詢前綴、**`add ` 委派 host provider（Pi 原生補完）**、free-form Git locator 不受約束、中線游標不攔截、force=false 委派、真實 `CombinedAutocompleteProvider` 套用候選（`list <名稱>`／`forget <id>` 游標位置正確）。

## 驗證

- `npm run typecheck` ✓
- `npm test` ✓（28 files / 334 tests，含既有 #121–#123 全部回歸）