### PR TITLE
docs: 文件化 autocomplete 並完成相容性回歸驗證 (#125)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,7 @@ jobs:
       - run: npm run typecheck
       - run: npm test
       - name: acceptance matrix fixture checks (synthetic / pinned @98e78ca / adversarial)
-        run: |
-          npm run test -- tests/unit/bridge/command.test.ts tests/unit/registration/git-selector.test.ts tests/unit/projection/collision.test.ts 2>&1 | tail -20
-          npm run test -- tests/integration/ 2>&1 | tail -20
+        run: npm run test:acceptance
 
   provenance-smoke:
     name: provenance smoke (no publish)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to `pi-codex-marketplace` are documented here. Format follow
 ### Added
 - **分層、狀態感知 autocomplete（#121–#124，文件 #125）**：`/codex-marketplace` 以 Pi 原生 autocomplete 提供兩層候選——純文字指令表面與輸出語意不變，autocomplete 只是 discoverability 與輸入效率層：
   - **根層九個候選**（#121）：輸入完整 `/codex-marketplace` 後按 Tab，顯示 `add`／`list`／`install`／`update`／`disable`／`enable`／`remove`／`forget`／`help` 與說明，不分大小寫模糊搜尋；需參數的子命令套用後補尾隨空格，`update`／`help` 不加。
-  - **第二層狀態感知候選**（#122–#124）：再按一次 Tab 依 Bridge State 只列當下可執行選項——`install` 只給可安裝／可重裝 plugin（不含 Unavailable Entry，同名含 unavailable sibling 改插 enumeration 編號）；`enable` 只列已停用、`disable` 只列已啟用、`remove` 列全部已安裝 Installation；`list`／`forget` 列 Marketplace Registrations（名稱無法唯一解析改插 Registration id）——描述顯示 marketplace／格式／狀態來源。
+  - **第二層狀態感知候選**（#122–#124）：再按一次 Tab 依 Bridge State 只列當下可執行選項——`install` 只給可安裝／可重裝 plugin（不含 Unavailable Entry，同名含 unavailable sibling 改插 enumeration 編號）；`enable` 只列已停用、`disable` 只列已啟用、`remove` 列全部已安裝 Installation；`list`／`forget` 列 Marketplace Registrations（名稱無法唯一解析依序改插唯一可解析的 alias、其次 Registration id）——描述顯示 marketplace／格式／狀態來源。
   - **`add` 保持 Pi 原生**（#124）：不提供 Bridge 候選，Tab 委派 Pi 原生路徑 completion，Git locator 維持自由輸入。
   - **terminal-only 且被動**：provider 只在 TUI session 註冊（RPC／JSON／print 模式不受影響）；候選被動讀取 Bridge State，不重置／重寫損壞文件；未屬 Bridge 的輸入原樣委派 Pi 既有 provider（其他 slash 指令、文字、檔案補完）。
   - **文件與回歸驗證**（#125）：README 新增 Autocomplete 章節（兩層 Tab 流程、狀態篩選與歧義處理、`add` 委派、明示無 custom TUI／自動二層 selector、純文字輸入保留）；Pi adapter 測試涵蓋 command completion registration、exact-command interception、第二次 Tab、completion application 與 previous-provider delegation；全部 typecheck／unit／integration／E2E／acceptance 全綠。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to `pi-codex-marketplace` are documented here. Format follows Keep a Changelog and SemVer (starting at `0.1.0`; Git tags `v*` mirror npm versions).
 
+## [Unreleased]
+
+### Added
+- **分層、狀態感知 autocomplete（#121–#124，文件 #125）**：`/codex-marketplace` 以 Pi 原生 autocomplete 提供兩層候選——純文字指令表面與輸出語意不變，autocomplete 只是 discoverability 與輸入效率層：
+  - **根層九個候選**（#121）：輸入完整 `/codex-marketplace` 後按 Tab，顯示 `add`／`list`／`install`／`update`／`disable`／`enable`／`remove`／`forget`／`help` 與說明，不分大小寫模糊搜尋；需參數的子命令套用後補尾隨空格，`update`／`help` 不加。
+  - **第二層狀態感知候選**（#122–#124）：再按一次 Tab 依 Bridge State 只列當下可執行選項——`install` 只給可安裝／可重裝 plugin（不含 Unavailable Entry，同名含 unavailable sibling 改插 enumeration 編號）；`enable` 只列已停用、`disable` 只列已啟用、`remove` 列全部已安裝 Installation；`list`／`forget` 列 Marketplace Registrations（名稱無法唯一解析改插 Registration id）——描述顯示 marketplace／格式／狀態來源。
+  - **`add` 保持 Pi 原生**（#124）：不提供 Bridge 候選，Tab 委派 Pi 原生路徑 completion，Git locator 維持自由輸入。
+  - **terminal-only 且被動**：provider 只在 TUI session 註冊（RPC／JSON／print 模式不受影響）；候選被動讀取 Bridge State，不重置／重寫損壞文件；未屬 Bridge 的輸入原樣委派 Pi 既有 provider（其他 slash 指令、文字、檔案補完）。
+  - **文件與回歸驗證**（#125）：README 新增 Autocomplete 章節（兩層 Tab 流程、狀態篩選與歧義處理、`add` 委派、明示無 custom TUI／自動二層 selector、純文字輸入保留）；Pi adapter 測試涵蓋 command completion registration、exact-command interception、第二次 Tab、completion application 與 previous-provider delegation；全部 typecheck／unit／integration／E2E／acceptance 全綠。
+
+### Fixed
+- **CI acceptance gate 失效修復**：acceptance step 改跑 `test:acceptance` matrix runner——原 step 引用已退休的 `tests/unit/registration/git-selector.test.ts` 且以 pipe 遮罩失敗，實際未擋任何列。
+
 ## [0.6.2] - 2026-08-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -53,6 +53,28 @@ Nine subcommands, no arguments = 總覽：
 - 安裝成功後由指令層主動要求 reload；reload 失敗不影響已記錄狀態，下次 session start 或 `/reload` 仍生效。
 - `--no-skills` 啟動 Pi 不影響 Bridge 投影。
 
+### Autocomplete（Pi 原生，TUI 限定）
+
+互動（TUI）模式下，`/codex-marketplace` 以 **Pi 原生 autocomplete** 提供兩層、狀態感知的候選。**純文字指令表面維持權威不變**：九個子命令、指令參數、輸出與語意完全不受 autocomplete 影響；RPC／JSON／print 模式根本不註冊 terminal-only provider。
+
+**第一層——九個根層子命令。** 輸入完整的 `/codex-marketplace` 後按 Tab，候選清單顯示全部九個子命令（`add`／`list`／`install`／`update`／`disable`／`enable`／`remove`／`forget`／`help`）與各自說明，支援不分大小寫的模糊搜尋。選取需要參數的子命令（`add`／`list`／`install`／`disable`／`enable`／`remove`／`forget`）會自動補上一個尾隨空格，可直接繼續輸入；`update` 與 `help` 不加。
+
+**第二層——再按一次 Tab 開啟狀態感知候選。** 需要參數的子命令套用後，**再按一次 Tab** 依當下 Bridge State 只列出當下可執行的選項（空集合不給假候選）；**不承諾自動重開 selector**（Pi 0.84.2 在套用候選後不會自動再開一層補完選單，鍵盤流程固定是「輸入 command → Tab 選子命令 → 需要參數時再按一次 Tab」）：
+
+| 子命令 | 候選範圍 | 歧義處理 |
+|--------|----------|----------|
+| `install` | 可安裝／可重裝的 plugin（**不含 Unavailable Entry**） | 名稱在完整 enumeration 唯一＝插入名稱；同名（含 unavailable sibling）＝插入 enumeration 編號（`#N`），描述顯示 `[marketplace]` 與狀態 |
+| `enable` | 僅**已停用**的 Installation | 名稱無法唯一解析的記錄不給候選 |
+| `disable` | 僅**已啟用**的 Installation | 同上 |
+| `remove` | 全部已安裝 plugin（不分啟用／停用） | 同上 |
+| `list` | Marketplace Registrations | 名稱無法唯一解析＝插入 Registration id |
+| `forget` | Marketplace Registrations | 同上 |
+| `add` | **不提供 Bridge 候選**：Tab 委派 Pi 原生路徑 completion，Git locator 維持自由輸入 | — |
+
+補完只提議當下可執行的動作，候選反映最新 Bridge State，且**被動讀取**——按 Tab 絕不會重置或重寫損壞的 state 文件。其餘輸入（其他 slash 指令、一般文字、檔案／路徑補完）一律原樣委派 Pi 既有 provider；安裝本套件不影響任何其他指令的 autocomplete。
+
+> 沒有 custom TUI、沒有自動第二層 selector：所有操作也都可以照舊以純文字輸入完成，autocomplete 只是 discoverability 與輸入效率層。
+
 ### 私有 Git repo：Credentialed Acquisition（核准式取得）
 
 對私有 HTTPS repo，`add`／`update` **開箱即用**：預設會自動偵測本機已存在的憑證來源並逐次核准（**固定白名單**，不讀本機 gitconfig 的任意 helper；偵測結果只限該次呼叫、永不持久化）：

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Nine subcommands, no arguments = 總覽：
 | `enable` | 僅**已停用**的 Installation | 名稱無法唯一解析的記錄不給候選 |
 | `disable` | 僅**已啟用**的 Installation | 同上 |
 | `remove` | 全部已安裝 plugin（不分啟用／停用） | 同上 |
-| `list` | Marketplace Registrations | 名稱無法唯一解析＝插入 Registration id |
+| `list` | Marketplace Registrations | 名稱無法唯一解析＝依序改插唯一可解析的 alias、其次 Registration id |
 | `forget` | Marketplace Registrations | 同上 |
 | `add` | **不提供 Bridge 候選**：Tab 委派 Pi 原生路徑 completion，Git locator 維持自由輸入 | — |
 


### PR DESCRIPTION
Closes #125

## 背景

#119 的四個實作子任務（#121–#124）已全部合併：`/codex-marketplace` 具備兩層、狀態感知的 Pi 原生 autocomplete，但使用文件與 changelog 尚未記錄，且 CI 的 acceptance gate step 引用已退休的測試檔而被 pipe 遮罩成靜默失效。本 PR 完成 #125 的文件化與相容性回歸驗證。

## 變更

- **README 新增 Autocomplete 章節**（TUI 限定）：九個純文字子命令皆支援根層 autocomplete（不分大小寫模糊搜尋；需參數子命令套用後自動補尾隨空格，`update`／`help` 不加）；「輸入 `/codex-marketplace` → Tab 選子命令 → 需參數時再按一次 Tab」的兩層流程，**不承諾自動重開 selector**；`install`／`enable`／`disable`／`remove`／`list`／`forget` 的狀態篩選與歧義處理（install 不含 Unavailable Entry、同名插 enumeration 編號；enable 僅已停用、disable 僅已啟用、remove 全部已安裝；list／forget 列 Registrations、名稱無法唯一解析插 Registration id）；`add` 不提供 Bridge 候選、Tab 委派 Pi 原生路徑 completion、Git locator 自由輸入；明示**無 custom TUI、純文字輸入保留**、被動讀取 state、未屬 Bridge 的輸入原樣委派 Pi 既有 provider。
- **CHANGELOG [Unreleased]**：記錄分層、狀態感知 autocomplete（#121–#124）的 root 九候選、第二層狀態感知候選、`add` provider delegation 與 terminal-only／被動語意，並記錄 #125 文件與回歸驗證。
- **CI acceptance gate 修復**：acceptance step 改跑 `npm run test:acceptance`（matrix runner）——原 step 引用已退休的 `tests/unit/registration/git-selector.test.ts` 且以 `| tail` 遮罩失敗碼，實際未擋任何列。

## 測試

- 既有 Pi adapter tests（`tests/e2e/extension-autocomplete.test.ts`）涵蓋 acceptance criteria 要求的 command completion registration、exact-command interception、第二次 Tab、completion application 與 previous-provider delegation——本次回歸確認全部通過；RPC／JSON／print 模式僅 TUI 註冊 provider 的 no-op ui 測試亦通過。

## 驗證

- `npm run typecheck` ✓
- `npm test` ✓（28 files / 334 tests，含既有 `/codex-marketplace` 指令輸出、reload、Bridge State persistence、Runtime Skill Exposure 與 command execution 全數回歸）
- `npm run test:acceptance` ✓（6 tests）