### PR TITLE
feat: CLI 追蹤子彈：骨架＋overview／help／--version＋ADR 0007 (#133)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,6 +12,10 @@ _Avoid_: Pi plugin, importer, converter
 The runtime portion of the Bridge Package that presents marketplace and plugin capabilities inside Pi.
 _Avoid_: Bridge Package, Codex plugin, Claude plugin
 
+**Bridge CLI**:
+The command-line management entry (`pi-codex-marketplace`) provided by the Bridge Package for headless and CI environments. It executes directly via Node without Pi runtime APIs, operates over the exact same single Global Scope Bridge State as the Bridge Extension, and delivers TUI-parity command semantics under a deterministic stdout/stderr/exit code output contract.
+_Avoid_: Pi CLI, standalone daemon, separate state store
+
 **Bridge State**:
 The Bridge-owned durable desired state stored in a single Global Scope document. It contains a schema version and Registration and Installation records; source-derived catalogs, projection results, effective precedence, and diagnostics are recomputed.
 _Avoid_: Pi settings, runtime snapshot, cache

--- a/bin/pi-codex-marketplace.js
+++ b/bin/pi-codex-marketplace.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+import { register } from "node:module";
+
+try {
+  register("./ts-resolver.mjs", import.meta.url);
+} catch {
+  // Module registration unsupported or already active
+}
+
+const { runCli } = await import("../src/cli/index.js");
+const code = await runCli(process.argv.slice(2), process);
+process.exitCode = code;

--- a/bin/ts-resolver.mjs
+++ b/bin/ts-resolver.mjs
@@ -1,0 +1,15 @@
+export async function resolve(specifier, context, nextResolve) {
+  try {
+    return await nextResolve(specifier, context);
+  } catch (err) {
+    if (specifier.endsWith(".js")) {
+      const tsSpecifier = specifier.slice(0, -3) + ".ts";
+      try {
+        return await nextResolve(tsSpecifier, context);
+      } catch {
+        // Fall back to original error
+      }
+    }
+    throw err;
+  }
+}

--- a/docs/adr/0007-headless-bridge-cli.md
+++ b/docs/adr/0007-headless-bridge-cli.md
@@ -1,0 +1,24 @@
+# Headless Bridge CLI（純 Node 輕量 Shim＋單一 Global Scope＋Parity 輸出契約）
+
+> **Status: 已採納（#132, #133）**
+
+Bridge Package 原僅透過 Pi Extension（`/codex-marketplace` 指令與 `resources_discover`）提供管理與投影功能，必須在 Pi TUI 內或經由 Pi runtime 啟動。但在 CI/CD 流程、自動化腳本及純 Shell 環境下，開發者需要直接管理 Marketplace 註冊與外掛安裝。#132 與 #133 決定：在 Bridge Package 提供純 Node 輕量 CLI shim（`pi-codex-marketplace`），直接調度純粹的 `runCommand` 縫，操作同一份單一 Global Scope（`state.json`），提供無須啟動 Pi runtime、免互動、確定性輸出與退出代碼的 headless 管理表面。
+
+## Decisions
+
+- **Node ≥22.19 原生 Type Stripping 執行**：CLI bin shim（`bin/pi-codex-marketplace.js`）直接執行並以內建 module loader hook 解析 TypeScript，無須額外建置步驟（no build step），與 extension `jiti` 載入哲學一致。
+- **純粹適配層（`runCli(argv, io, opts)`）**：將 `process.argv` 轉發至既有純粹 `runCommand` 派發縫；注入式 `io`（stdout/stderr/exit）使 E2E 測試完全隔離，不觸發真實處理程序退出或污染終端。
+- **輸出與退出代碼契約（Output & Exit Contract）**：
+  - 主要輸出（overview、help、--version、查詢結果、成功訊息）寫入 stdout，退出代碼為 `0`。
+  - 錯誤訊息（未知子命令、缺少或非法參數、註冊/安裝/狀態寫入失敗）寫入 stderr，退出代碼非零（`1`）。
+  - 絕對免提示（Never prompt）：背景與 CI 執行安全。
+  - 狀態變更（`reload: true`）提示語轉換：CLI 無 in-process reload（`ctx.reload`），原「已重新載入生效」改為「已寫入 Bridge State · 下次 pi session／/reload 生效」，明確告知變更將於下次 Pi 啟動或 `/reload` 生效。
+- **單一 Global Scope 一致性**：CLI 與 Extension 共用相同的 `getAgentDir()` 與 Bridge State 儲存位址，完全支援 `PI_CODING_AGENT_DIR` / `PI_AGENT_DIR` 環境變數覆寫，測試不污染本機 `~/.pi/agent`。
+- **語意與參數 Parity**：九個子命令（`add`, `list`, `install`, `update`, `disable`, `enable`, `remove`, `forget`, `help`）及 `--version` 維持與 TUI 相同的語彙與行為。
+
+## Considered Options（拒絕）
+
+- **修改 Pi Core 支援 Extension Top-Level Verbs**：需破壞 Pi 核心架構與擴充契約。拒絕。
+- **僅支援 TUI / 僅在 Pi 進程內操作**：CI 與自動化腳本無法運作。拒絕。
+- **常駐 Background Daemon / In-process Reload 守護進程**：過度設計；Global Scope 檔案寫入本就於下次 Pi session 或 `/reload` 自然生效。拒絕。
+- **首期支援 `--json` 機器可讀輸出**：超出追蹤子彈範疇；首期專注於與 TUI 輸出 Parity 及標準 CLI 退出碼。

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   "engines": {
     "node": ">=22.19.0"
   },
+  "bin": {
+    "pi-codex-marketplace": "./bin/pi-codex-marketplace.js"
+  },
   "pi": {
     "extensions": [
       "./extensions/pi/index.ts"
@@ -56,6 +59,7 @@
     "prepublishOnly": "npm run typecheck && npm test"
   },
   "files": [
+    "bin",
     "extensions",
     "src",
     "README.md",

--- a/src/bridge/command.ts
+++ b/src/bridge/command.ts
@@ -6,8 +6,9 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import { basename, isAbsolute, join, resolve } from 'node:path';
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 import { parseFrontmatter } from '@earendil-works/pi-coding-agent';
 
@@ -59,6 +60,17 @@ export interface CommandResult {
   output: string;
   reload: boolean;
   stateReset?: boolean;
+  ok: boolean;
+}
+
+export function getPackageVersion(): string {
+  try {
+    const pkgPath = resolve(dirname(fileURLToPath(import.meta.url)), '../../package.json');
+    const pkgJson = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    return pkgJson.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
 }
 
 const USAGE_LINE = '用法：/codex-marketplace <add|list|install|update|disable|enable|remove|forget|help>';
@@ -495,7 +507,7 @@ export async function runCommand(
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     const messages = [`錯誤：讀取 Bridge State 失敗：${msg}`];
-    return { messages, lines: messages, output: messages.join('\n\n'), reload: false, stateReset: false };
+    return { messages, lines: messages, output: messages.join('\n\n'), reload: false, stateReset: false, ok: false };
   }
 
   const messages: string[] = [];
@@ -513,6 +525,12 @@ export async function runCommand(
     const subargs = rawArgs.slice(1);
 
     switch (subcmd) {
+      case '--version':
+      case '-v':
+      case 'version': {
+        messages.push(getPackageVersion());
+        break;
+      }
       case 'help':
       case '-h':
       case '--help': {
@@ -1274,11 +1292,26 @@ export async function runCommand(
     }
   }
 
+  const ok = !messages.some(
+    (m) =>
+      m.startsWith('錯誤：') ||
+      m.startsWith('未知子命令') ||
+      m.startsWith('用法：/codex-marketplace add') ||
+      m.startsWith('用法：/codex-marketplace install') ||
+      m.startsWith('用法：/codex-marketplace disable') ||
+      m.startsWith('用法：/codex-marketplace enable') ||
+      m.startsWith('用法：/codex-marketplace remove') ||
+      m.startsWith('用法：/codex-marketplace forget') ||
+      m.startsWith('已註冊過相同來源') ||
+      m.startsWith('找不到 marketplace'),
+  );
+
   return {
     messages,
     lines: messages,
     output: messages.join('\n\n'),
     reload,
     stateReset: wasReset,
+    ok,
   };
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,85 @@
+/**
+ * CLI Adapter — Pure headless command-line entry seam for pi-codex-marketplace (#132, #133)
+ *
+ * Provides:
+ * - runCli(argv, io, opts): Pure adapter driving runCommand with stdout/stderr/exit code contract
+ * - formatCliOutput(result): Formats CommandResult for CLI output, replacing in-process reload notices
+ * - getPackageVersion(): Retrieves package version from package.json
+ */
+
+import { runCommand, getPackageVersion, type CommandOptions, type CommandResult } from "../bridge/command.js";
+
+export { getPackageVersion };
+
+export interface CliIO {
+  stdout?: { write: (chunk: string) => unknown } | ((chunk: string) => unknown);
+  stderr?: { write: (chunk: string) => unknown } | ((chunk: string) => unknown);
+  exit?: (code: number) => unknown;
+}
+
+export const RELOAD_NOTICE = "已寫入 Bridge State · 下次 pi session／/reload 生效";
+export const RELOAD_PLACEHOLDER = "已重新載入生效";
+
+export function formatCliOutput(result: CommandResult): string {
+  let text = result.output;
+  if (result.reload) {
+    if (text.includes(RELOAD_PLACEHOLDER)) {
+      text = text.replaceAll(RELOAD_PLACEHOLDER, RELOAD_NOTICE);
+    } else {
+      text = text.length > 0 ? `${text}\n\n${RELOAD_NOTICE}` : RELOAD_NOTICE;
+    }
+  }
+  return text;
+}
+
+function writeStream(
+  target: { write: (chunk: string) => unknown } | ((chunk: string) => unknown) | undefined,
+  message: string,
+): void {
+  if (!target) return;
+  const chunk = message.endsWith("\n") ? message : `${message}\n`;
+  if (typeof target === "function") {
+    target(chunk);
+  } else if (typeof target.write === "function") {
+    target.write(chunk);
+  }
+}
+
+export async function runCli(
+  argv: string[],
+  io: CliIO = process,
+  opts: CommandOptions = {},
+): Promise<number> {
+  const exitWith = (code: number): number => {
+    if (typeof io.exit === "function") {
+      io.exit(code);
+    }
+    return code;
+  };
+
+  try {
+    if (argv.length === 1 && (argv[0] === "--version" || argv[0] === "-v" || argv[0] === "version")) {
+      writeStream(io.stdout, getPackageVersion());
+      return exitWith(0);
+    }
+
+    const result = await runCommand(argv, opts);
+    const output = formatCliOutput(result);
+
+    if (result.ok) {
+      if (output) {
+        writeStream(io.stdout, output);
+      }
+      return exitWith(0);
+    } else {
+      if (output) {
+        writeStream(io.stderr, output);
+      }
+      return exitWith(1);
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    writeStream(io.stderr, `錯誤：${msg}`);
+    return exitWith(1);
+  }
+}

--- a/tests/acceptance/matrix.test.ts
+++ b/tests/acceptance/matrix.test.ts
@@ -48,8 +48,11 @@ describe('Acceptance matrix — per-row gates (smoke that each layer is covered)
     expect(createEmptyMinimalState().schemaVersion).toBe(1);
   });
 
-  it('E2E row — synthetic: /codex-marketplace thin adapter highest seam is exposed', async () => {
-    const mod = await import('../../extensions/pi/index.js');
-    expect(mod.default).toBeDefined();
+  it('E2E row — synthetic: /codex-marketplace thin adapter and Bridge CLI seam are exposed', async () => {
+    const extensionMod = await import('../../extensions/pi/index.js');
+    expect(extensionMod.default).toBeDefined();
+
+    const cliMod = await import('../../src/cli/index.js');
+    expect(cliMod.runCli).toBeDefined();
   });
 });

--- a/tests/e2e/cli-adapter.test.ts
+++ b/tests/e2e/cli-adapter.test.ts
@@ -1,0 +1,268 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runCli, type CliIO, RELOAD_NOTICE } from "../../src/cli/index.js";
+import { readMinimalBridgeState } from "../../src/bridge/state.js";
+
+function createMockIo(): { io: CliIO; stdout: string[]; stderr: string[]; exitCodes: number[] } {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const exitCodes: number[] = [];
+
+  const io: CliIO = {
+    stdout: {
+      write(chunk: string) {
+        stdout.push(chunk);
+      },
+    },
+    stderr: {
+      write(chunk: string) {
+        stderr.push(chunk);
+      },
+    },
+    exit(code: number) {
+      exitCodes.push(code);
+    },
+  };
+
+  return { io, stdout, stderr, exitCodes };
+}
+
+function makeSyntheticMarketplace(root: string, name: string, plugins: { name: string; path: string; skills?: string[] }[]) {
+  mkdirSync(join(root, ".agents", "plugins"), { recursive: true });
+  writeFileSync(
+    join(root, ".agents", "plugins", "marketplace.json"),
+    JSON.stringify({
+      name,
+      plugins: plugins.map((p) => ({ name: p.name, source: { source: "local", path: p.path } })),
+    }),
+  );
+  for (const p of plugins) {
+    const abs = join(root, p.path.replace(/^\.\//, ""));
+    mkdirSync(abs, { recursive: true });
+    mkdirSync(join(abs, ".codex-plugin"), { recursive: true });
+    writeFileSync(join(abs, ".codex-plugin", "plugin.json"), JSON.stringify({ name: p.name }));
+    writeFileSync(join(abs, "plugin.json"), JSON.stringify({ name: p.name }));
+    if (p.skills) {
+      for (const skill of p.skills) {
+        const sdir = join(abs, "skills", skill);
+        mkdirSync(sdir, { recursive: true });
+        writeFileSync(join(sdir, "SKILL.md"), `---\nname: ${skill}\ndescription: Desc for ${skill}\n---\n\nBody for ${skill}\n`);
+      }
+    }
+  }
+}
+
+describe("Bridge CLI adapter seam (#132, #133)", () => {
+  let cwd: string;
+  let agentDir: string;
+  let statePath: string;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), "cli-adapter-cwd-"));
+    agentDir = mkdtempSync(join(tmpdir(), "cli-adapter-agent-"));
+    statePath = join(agentDir, "codex-marketplace", "state.json");
+    mkdirSync(join(agentDir, "codex-marketplace"), { recursive: true });
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    process.env.PI_AGENT_DIR = agentDir;
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(agentDir, { recursive: true, force: true });
+    delete process.env.PI_CODING_AGENT_DIR;
+    delete process.env.PI_AGENT_DIR;
+  });
+
+  it("prints overview to stdout and exits 0 on no arguments", async () => {
+    const mock = createMockIo();
+    const code = await runCli([], mock.io, { cwd, agentDir });
+
+    expect(code).toBe(0);
+    expect(mock.exitCodes).toEqual([0]);
+    expect(mock.stderr).toHaveLength(0);
+    expect(mock.stdout.length).toBeGreaterThan(0);
+    const combinedStdout = mock.stdout.join("");
+    expect(combinedStdout).toContain("Marketplaces");
+    expect(combinedStdout).toContain("Installed");
+    expect(combinedStdout).toContain("用法：/codex-marketplace");
+  });
+
+  it("prints help to stdout and exits 0 on help argument", async () => {
+    const mock = createMockIo();
+    const code = await runCli(["help"], mock.io, { cwd, agentDir });
+
+    expect(code).toBe(0);
+    expect(mock.exitCodes).toEqual([0]);
+    expect(mock.stderr).toHaveLength(0);
+    const combinedStdout = mock.stdout.join("");
+    expect(combinedStdout).toContain("add");
+    expect(combinedStdout).toContain("list");
+    expect(combinedStdout).toContain("install");
+    expect(combinedStdout).toContain("update");
+    expect(combinedStdout).toContain("disable");
+    expect(combinedStdout).toContain("enable");
+    expect(combinedStdout).toContain("remove");
+    expect(combinedStdout).toContain("forget");
+    expect(combinedStdout).toContain("help");
+  });
+
+  it("prints version to stdout and exits 0 on --version / -v", async () => {
+    const mockVersion = createMockIo();
+    const codeVersion = await runCli(["--version"], mockVersion.io, { cwd, agentDir });
+    expect(codeVersion).toBe(0);
+    expect(mockVersion.exitCodes).toEqual([0]);
+    expect(mockVersion.stderr).toHaveLength(0);
+    expect(mockVersion.stdout.join("").trim()).toMatch(/^\d+\.\d+\.\d+/);
+
+    const mockShort = createMockIo();
+    const codeShort = await runCli(["-v"], mockShort.io, { cwd, agentDir });
+    expect(codeShort).toBe(0);
+    expect(mockShort.exitCodes).toEqual([0]);
+    expect(mockShort.stderr).toHaveLength(0);
+    expect(mockShort.stdout.join("").trim()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it("prints error to stderr and exits non-zero on unknown subcommand without prompt", async () => {
+    const mock = createMockIo();
+    const code = await runCli(["unknown-subcommand"], mock.io, { cwd, agentDir });
+
+    expect(code).toBe(1);
+    expect(mock.exitCodes).toEqual([1]);
+    expect(mock.stdout).toHaveLength(0);
+    expect(mock.stderr.length).toBeGreaterThan(0);
+    const combinedStderr = mock.stderr.join("");
+    expect(combinedStderr).toContain("未知子命令 \"unknown-subcommand\"");
+    expect(combinedStderr).toContain("用法：/codex-marketplace");
+  });
+
+  it("prints error to stderr and exits non-zero on missing or invalid subcommand arguments", async () => {
+    // 1. add with no args
+    const mockAdd = createMockIo();
+    const codeAdd = await runCli(["add"], mockAdd.io, { cwd, agentDir });
+    expect(codeAdd).toBe(1);
+    expect(mockAdd.stdout).toHaveLength(0);
+    expect(mockAdd.stderr.join("")).toContain("用法：/codex-marketplace add");
+
+    // 2. install with no args
+    const mockInstall = createMockIo();
+    const codeInstall = await runCli(["install"], mockInstall.io, { cwd, agentDir });
+    expect(codeInstall).toBe(1);
+    expect(mockInstall.stdout).toHaveLength(0);
+    expect(mockInstall.stderr.join("")).toContain("用法：/codex-marketplace install");
+
+    // 3. disable with no args
+    const mockDisable = createMockIo();
+    const codeDisable = await runCli(["disable"], mockDisable.io, { cwd, agentDir });
+    expect(codeDisable).toBe(1);
+    expect(mockDisable.stdout).toHaveLength(0);
+    expect(mockDisable.stderr.join("")).toContain("用法：/codex-marketplace disable");
+
+    // 4. enable with no args
+    const mockEnable = createMockIo();
+    const codeEnable = await runCli(["enable"], mockEnable.io, { cwd, agentDir });
+    expect(codeEnable).toBe(1);
+    expect(mockEnable.stdout).toHaveLength(0);
+    expect(mockEnable.stderr.join("")).toContain("用法：/codex-marketplace enable");
+
+    // 5. remove with no args
+    const mockRemove = createMockIo();
+    const codeRemove = await runCli(["remove"], mockRemove.io, { cwd, agentDir });
+    expect(codeRemove).toBe(1);
+    expect(mockRemove.stdout).toHaveLength(0);
+    expect(mockRemove.stderr.join("")).toContain("用法：/codex-marketplace remove");
+
+    // 6. forget with no args
+    const mockForget = createMockIo();
+    const codeForget = await runCli(["forget"], mockForget.io, { cwd, agentDir });
+    expect(codeForget).toBe(1);
+    expect(mockForget.stdout).toHaveLength(0);
+    expect(mockForget.stderr.join("")).toContain("用法：/codex-marketplace forget");
+  });
+
+  it("handles corrupted state file gracefully with warning notice and overview", async () => {
+    writeFileSync(statePath, "MALFORMED STATE JSON", "utf-8");
+
+    const mock = createMockIo();
+    const code = await runCli([], mock.io, { cwd, agentDir });
+
+    expect(code).toBe(0);
+    expect(mock.stderr).toHaveLength(0);
+    const combinedStdout = mock.stdout.join("");
+    expect(combinedStdout).toMatch(/損壞|重置/);
+    expect(combinedStdout).toContain("Marketplaces");
+  });
+
+  it("replaces reload notice with CLI-specific notice on state-affecting operations", async () => {
+    const mktRoot = mkdtempSync(join(tmpdir(), "cli-mkt-"));
+    makeSyntheticMarketplace(mktRoot, "test-mkt", [
+      { name: "test-plugin", path: "./plugins/test-plugin", skills: ["test-skill"] },
+    ]);
+
+    try {
+      // 1. add
+      const mockAdd = createMockIo();
+      const codeAdd = await runCli(["add", mktRoot], mockAdd.io, { cwd, agentDir });
+      expect(codeAdd).toBe(0);
+      expect(mockAdd.stdout.join("")).toContain("已註冊 \"test-mkt\"");
+
+      // 2. install (state-affecting reload)
+      const mockInstall = createMockIo();
+      const codeInstall = await runCli(["install", "1"], mockInstall.io, { cwd, agentDir });
+      expect(codeInstall).toBe(0);
+      const installOut = mockInstall.stdout.join("");
+      expect(installOut).toContain("安裝 \"test-plugin\"");
+      expect(installOut).toContain(RELOAD_NOTICE);
+      expect(installOut).not.toContain("已重新載入生效");
+
+      // 3. disable
+      const mockDisable = createMockIo();
+      const codeDisable = await runCli(["disable", "test-plugin"], mockDisable.io, { cwd, agentDir });
+      expect(codeDisable).toBe(0);
+      expect(mockDisable.stdout.join("")).toContain("已停用 \"test-plugin\"");
+
+      // 4. enable (state-affecting reload)
+      const mockEnable = createMockIo();
+      const codeEnable = await runCli(["enable", "test-plugin"], mockEnable.io, { cwd, agentDir });
+      expect(codeEnable).toBe(0);
+      const enableOut = mockEnable.stdout.join("");
+      expect(enableOut).toContain("已啟用 \"test-plugin\"");
+      expect(enableOut).toContain(RELOAD_NOTICE);
+      expect(enableOut).not.toContain("已重新載入生效");
+
+      // 5. state inspection to confirm persistence in isolated agentDir
+      const state = readMinimalBridgeState({ agentDir });
+      expect(state.state.registrations).toHaveLength(1);
+      expect(state.state.installations).toHaveLength(1);
+    } finally {
+      rmSync(mktRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("honors environment overrides and isolates state completely in temp agentDir", async () => {
+    const mock = createMockIo();
+    await runCli([], mock.io);
+
+    const state = readMinimalBridgeState({ agentDir });
+    expect(state.state.registrations).toHaveLength(0);
+    expect(state.state.installations).toHaveLength(0);
+  });
+
+  it("runs the actual bin/pi-codex-marketplace.js binary via Node child process", () => {
+    const binPath = join(process.cwd(), "bin", "pi-codex-marketplace.js");
+    const output = execFileSync(process.execPath, [binPath, "--version"], {
+      encoding: "utf-8",
+      env: { ...process.env, PI_CODING_AGENT_DIR: agentDir, PI_AGENT_DIR: agentDir },
+    });
+    expect(output.trim()).toMatch(/^\d+\.\d+\.\d+/);
+
+    const helpOutput = execFileSync(process.execPath, [binPath, "help"], {
+      encoding: "utf-8",
+      env: { ...process.env, PI_CODING_AGENT_DIR: agentDir, PI_AGENT_DIR: agentDir },
+    });
+    expect(helpOutput).toContain("用法：/codex-marketplace");
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,6 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true
   },
-  "include": ["extensions/**/*", "src/**/*", "tests/**/*"],
+  "include": ["bin/**/*", "extensions/**/*", "src/**/*", "tests/**/*"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Closes #133
Parent #132

## 背景

在 CI/CD 流程、自動化腳本及無 Pi TUI 的環境下，需要能直接從 shell 管理 Codex 與 Claude Marketplace。本 PR 作為 Headless Bridge CLI 的追蹤子彈（Tracer Bullet），建立薄 Node CLI shim 與適配層，端到端貫穿 argv → adapter → command → Global Scope state → stdout，並確立輸出與退出代碼契約及記錄 ADR 0007。

## 變更

- **CLI shim（`bin/pi-codex-marketplace.js` & `bin/ts-resolver.mjs`）**：
  - 透過 Node ≥22.19 原生 type stripping 與內建 module loader hook 執行 TypeScript，免建置步驟（no build step）。
  - `package.json` 宣告 `bin: { "pi-codex-marketplace": "./bin/pi-codex-marketplace.js" }`，並加入 `files` 發布清單。
- **純粹 CLI 適配層（`src/cli/index.ts`）**：
  - 提供純粹 `runCli(argv, io, opts)` 轉發至既有 `runCommand` 派發縫，支援注入式 `io`（stdout/stderr/exit）完全隔離測試。
  - 支援 `--version` / `-v` 輸出套件版本。
  - 實作狀態變更（`reload: true`）提示語轉換：原「已重新載入生效」轉換為「已寫入 Bridge State · 下次 pi session／/reload 生效」（CLI 無 in-process `ctx.reload`）。
- **輸出契約與退出代碼**：
  - 主要輸出（overview、help、--version、查詢結果、成功訊息）寫入 stdout，exit 0。
  - 錯誤訊息（未知子命令、缺少/非法參數、失敗）寫入 stderr，exit 1，絕對不彈窗提示（never prompt）。
  - 單一 Global Scope 隔離：完全支援 `PI_CODING_AGENT_DIR` / `PI_AGENT_DIR` 環境變數。
- **文件與 ADR**：
  - `CONTEXT.md` 增加詞彙 **Bridge CLI**。
  - 新增 `docs/adr/0007-headless-bridge-cli.md` 記錄表面決策。

## 測試

- **E2E 測試（`tests/e2e/cli-adapter.test.ts`）**：
  - 無參數 overview 輸出至 stdout 並 exit 0。
  - `help` 列出九個子命令並 exit 0。
  - `--version` / `-v` 輸出版本並 exit 0。
  - 未知子命令及非法參數輸出至 stderr 並 exit 1。
  - 狀態變更指令提示語轉換為 `已寫入 Bridge State · 下次 pi session／/reload 生效`。
  - 損壞 state.json 重置提示與 overview。
  - 環境變數 `PI_CODING_AGENT_DIR` 隔離驗證。
  - 真實 `bin/pi-codex-marketplace.js` 經 Node child process 執行驗證。
- **驗收矩陣（`tests/acceptance/matrix.test.ts`）**：
  - E2E row 加入 Bridge CLI seam 檢查。

## 驗證

- `npm run typecheck` ✓
- `npm test` ✓（29 test files / 343 tests passed）
- `npm run test:acceptance` ✓