### PR TITLE
fix: make packaged Bridge CLI executable via npx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node: ["22.19.0", "22.x"]
+        node: ["22.19.0", "22.x", "24.x"]
         # Pi host is pinned to 0.84.2 per spec; devDeps uses ^0.84.2 range for expected compatibility
         # The TUI E2E seam runs against the installed pi-coding-agent at that version.
     steps:

--- a/bin/ts-resolver.mjs
+++ b/bin/ts-resolver.mjs
@@ -1,3 +1,23 @@
+import { readFile } from "node:fs/promises";
+import { stripTypeScriptTypes } from "node:module";
+
+const STRIP_TYPES_WARNING = "stripTypeScriptTypes is an experimental feature and might change at any time";
+
+function stripTypes(source) {
+  const emitWarning = process.emitWarning;
+  process.emitWarning = (warning, ...args) => {
+    const message = warning instanceof Error ? warning.message : String(warning);
+    if (message === STRIP_TYPES_WARNING) return;
+    emitWarning.call(process, warning, ...args);
+  };
+
+  try {
+    return stripTypeScriptTypes(source, { mode: "strip" });
+  } finally {
+    process.emitWarning = emitWarning;
+  }
+}
+
 export async function resolve(specifier, context, nextResolve) {
   try {
     return await nextResolve(specifier, context);
@@ -12,4 +32,17 @@ export async function resolve(specifier, context, nextResolve) {
     }
     throw err;
   }
+}
+
+export async function load(url, context, nextLoad) {
+  if (!url.endsWith(".ts")) {
+    return nextLoad(url, context);
+  }
+
+  const source = await readFile(new URL(url), "utf8");
+  return {
+    format: "module",
+    shortCircuit: true,
+    source: stripTypes(source),
+  };
 }

--- a/tests/e2e/cli-package-boundary.test.ts
+++ b/tests/e2e/cli-package-boundary.test.ts
@@ -1,0 +1,77 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { execFile } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+interface ProcessResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+function run(executable: string, args: string[], options: { cwd?: string; env?: NodeJS.ProcessEnv } = {}): Promise<ProcessResult> {
+  return new Promise((resolvePromise) => {
+    execFile(executable, args, { encoding: "utf8", ...options }, (error, stdout, stderr) => {
+      resolvePromise({
+        exitCode: typeof error?.code === "number" ? error.code : error ? 1 : 0,
+        stdout,
+        stderr,
+      });
+    });
+  });
+}
+
+describe("npm-packed Bridge CLI package boundary", () => {
+  let sandbox: string;
+  let binPath: string;
+  let agentDir: string;
+
+  beforeAll(async () => {
+    sandbox = mkdtempSync(join(resolve("node_modules"), ".cli-package-boundary-"));
+    const packed = await run("npm", ["pack", "--silent", "--pack-destination", sandbox], { cwd: process.cwd() });
+    expect(packed.exitCode, packed.stderr).toBe(0);
+
+    const tarballName = packed.stdout.trim().split(/\r?\n/).at(-1);
+    expect(tarballName).toBeTruthy();
+
+    const packageDir = join(sandbox, "node_modules", "pi-codex-marketplace");
+    mkdirSync(packageDir, { recursive: true });
+    const extracted = await run("tar", ["-xzf", join(sandbox, tarballName!), "-C", packageDir, "--strip-components=1"]);
+    expect(extracted.exitCode, extracted.stderr).toBe(0);
+
+    binPath = join(packageDir, "bin", "pi-codex-marketplace.js");
+    agentDir = join(sandbox, "agent");
+  });
+
+  afterAll(() => {
+    rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  it("runs the published CLI bin from node_modules", async () => {
+    const result = await run(process.execPath, [binPath, "--version"], {
+      env: {
+        ...process.env,
+        PI_CODING_AGENT_DIR: agentDir,
+        PI_AGENT_DIR: agentDir,
+      },
+    });
+
+    expect(result.exitCode, result.stderr).toBe(0);
+    expect(result.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+    expect(result.stderr).toBe("");
+  });
+
+  it("dispatches update from the published package without touching user state", async () => {
+    const result = await run(process.execPath, [binPath, "update"], {
+      env: {
+        ...process.env,
+        PI_CODING_AGENT_DIR: agentDir,
+        PI_AGENT_DIR: agentDir,
+      },
+    });
+
+    expect(result.exitCode, result.stderr).toBe(0);
+    expect(result.stdout).toContain("尚無已註冊的 marketplace。");
+    expect(result.stderr).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

- load packaged TypeScript through the registered Node loader instead of falling through to unsupported `node_modules` type stripping
- preserve clean CLI stderr on Node 22 while keeping the ADR-0007 no-build-step design
- add an npm-pack black-box regression that runs `--version` and isolated `update` from a real `node_modules` boundary
- extend CI coverage to Node 24 while retaining the Node 22.19.0 minimum-runtime gate

## Verification

- `npm run typecheck`
- `npm test` — 30 files / 367 tests
- `npm run test:acceptance` — 6 tests
- packaged-artifact E2E on Node 22.23.2 and Node 24.19.0

Fixes #144
Refs #143
