### PR TITLE
chore: prepare v1.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `pi-codex-marketplace` are documented here. Format follows Keep a Changelog and SemVer (starting at `0.1.0`; Git tags `v*` mirror npm versions).
 
+## [1.0.1] - 2026-09-02
+
+### Fixed
+- **npm Bridge CLI 啟動（#143、#144）**：修正 npm-packed Bridge Package 位於 `node_modules` 時，Node 因不支援該路徑的原生 TypeScript type stripping 而拋出 `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`；Bridge CLI loader 現在會明確載入與轉換 TypeScript，維持 ADR 0007 的 no-build-step 設計及既有 stdout／stderr 契約。新增真實 npm pack 套件邊界 E2E，涵蓋 `--version` 與隔離 Bridge State 的 `update`，CI 矩陣擴至 Node 24 並保留最低 Node 22.19.0 gate。
+
 ## [1.0.0] - 2026-08-31
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-codex-marketplace",
-  "version": "0.8.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-codex-marketplace",
-      "version": "0.8.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "yaml": "2.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-codex-marketplace",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Bridge Package for Codex and Claude Marketplace compatibility in Pi — 極簡 /codex-marketplace 純文字指令與 Headless CLI（add/list/install/update/disable/enable/remove/forget）、單一 Global Bridge State、當下最新安裝與即時投影",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Summary

- bump the Bridge Package to the next patch version, `1.0.1`
- document the npm-installed Bridge CLI startup fix and Node 24 coverage
- align the root lockfile version metadata with the package version

## Verification

- `npm run typecheck`
- `npm test` — 30 files / 367 tests
- `npm run test:acceptance` — 6 tests
- `npm pack --dry-run` — package reports version `1.0.1`

## Release follow-up

After merge, tag `v1.0.1` to trigger the provenance-backed npm publish and GitHub Release, then verify the registry-backed npx path. This PR intentionally does not close the release ticket before those checks complete.

Refs #145
